### PR TITLE
1.1.1

### DIFF
--- a/dist/powercalculator.css
+++ b/dist/powercalculator.css
@@ -243,6 +243,12 @@
 
 
 
+
+
+
+
+
+
 /* application styles */
 
 /* colors */
@@ -719,6 +725,24 @@
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /* graph radio styles */
 .pc-graph-controls {
     display: flex;
@@ -730,7 +754,7 @@
 
 .pc-graph-radio-label {
     position: relative;
-    font-size: 14px;
+    font-size: 13px;
     color: var(--blue);
     margin-right: 20px;
 }
@@ -763,6 +787,9 @@
     width: 100%;
     box-sizing: border-box;
 }
+
+
+
 
 
 
@@ -1391,6 +1418,40 @@
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 .pc-inputs[data-v-297fe272] {
     grid-template-areas:
         "pc-input-left pc-input-right"
@@ -1422,9 +1483,36 @@
     background: var(--white);
 }
 
-.pc-value-field--lockable:not(.pc-value-field--unlocked) .pc-value-field-wrapper[data-v-297fe272] {
+.pc-value-field--lockable.pc-value-field--locked .pc-value-field-wrapper[data-v-297fe272] {
     background: linear-gradient(0deg, var(--light-gray) 0%, var(--white) 100%);
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -1634,6 +1722,13 @@
     z-index: 1;
 }
 
+.pc-block-to-calculate  .pc-value-field--locked .pc-value-formatting:before,
+.pc-block-to-calculate  .pc-value-field--locked .pc-value-formatting:after,
+.pc-value-field--locked .pc-value-formatting:before,
+.pc-value-field--locked .pc-value-formatting:after,
+.pc-value-field--locked .pc-value-field-wrapper {
+    color: var(--dark-gray);
+}
 
 
 
@@ -2528,9 +2623,8 @@
 
 .tooltip-wrapper {
     position: absolute;
-    left: 50%;
+    left: 0;
     top: calc(100% + 10px);
-    transform: translate(-50%, 0);
     background: var(--tooltip-background-color);
     color: var(--light-gray);
     padding: 5px;
@@ -2538,6 +2632,7 @@
     z-index: 10;
     width: 400px;
     white-space: normal;
+    pointer-events: none;
 }
 
 .tooltip-wrapper:after {
@@ -2545,7 +2640,7 @@
 
     content: '';
     position: absolute;
-    left: 50%;
+    left: 50px;
     bottom: calc(100% - var(--size));
     transform: translate(-50%, 0) rotateZ(45deg);
 

--- a/dist/powercalculator.css
+++ b/dist/powercalculator.css
@@ -1,282 +1,24 @@
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* powercalculator.vue */
 
 /* application styles */
-
 /* colors */
-
 .power-calculator {
-
     --white: #FFF;
     --black: #000;
-
     --gray: #B5B5B5;
     --light-gray: #F0F0F0;
     --dark-gray: #525252;
-
     --light-blue: #C1CFD8;
     --pale-blue: #7898AE;
     --blue: #155EAB;
     --dark-blue: #3d78df;
-
     --light-yellow: #FEF1CB;
     --dark-yellow: #E2B634;
     --fade-black: rgba(0, 0, 0, 0.3);
-
     --red: #F00;
-
 }
-
 /* layout */
-
 .pc-main-header {
     display: grid;
     grid-template-columns: min-content auto min-content min-content;
@@ -284,46 +26,37 @@
     grid-template-areas:
         "test-type title false-positive power";
     align-items: center;
-
     margin: 25px 0 25px 10px;
 }
-
 .pc-title {
     grid-area: title;
     font-size: 30px;
     text-align: center;
 }
-
 .pc-test-type,
 .pc-false-positive,
 .pc-power {
     font-size: 0.8em;
 }
-
 .pc-test-type {
     grid-area: test-type;
 }
-
 .pc-test-type-tooltip-wrapper {
     display: inline-block;
 }
-
 .pc-test-type-labels {
     margin: 0 20px;
     white-space: nowrap;
 }
-
 .pc-false-positive {
     grid-area: false-positive;
     white-space: nowrap;
 }
-
 .pc-power {
     grid-area: power;
     margin-left: 10px;
     white-space: nowrap;
 }
-
 .pc-blocks-wrapper {
     grid-area: pc-blocks-wrapper;
     display: grid;
@@ -337,30 +70,22 @@
     grid-column-gap: 8px;
     grid-row-gap: 8px;
 }
-
 .pc-block--base {
     grid-area: block-base;
 }
-
 .pc-block--sample {
     grid-area: block-sample;
 }
-
 .pc-block--impact {
     grid-area: block-impact;
 }
-
 .pc-block--graph {
     grid-area: block-graph;
 }
-
-
 /* blocks */
-
 .pc-block {
     background: var(--light-gray);
 }
-
 .pc-header {
     color: var(--white);
     text-align: center;
@@ -371,377 +96,26 @@
     background: var(--pale-blue);
     margin-bottom: 25px;
 }
-
 .pc-calculate {
     display: inline-block;
     margin-bottom: 25px;
     font-weight: bold;
     font-size: 0.8em;
 }
-
 .pc-value {
     display: block;
     margin-bottom: 25px;
 }
-
 /* block to calculate override rules*/
-
 .pc-block-to-calculate {
     background: var(--light-yellow);
 }
-
 .pc-block-to-calculate .pc-header {
     background: var(--dark-yellow);
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/svg-graph.vue */
 
 /* graph radio styles */
 .pc-graph-controls {
@@ -751,25 +125,21 @@
     margin-bottom: 5px;
     border-bottom: 1px solid var(--blue);
 }
-
 .pc-graph-radio-label {
     position: relative;
     font-size: 13px;
     color: var(--blue);
     margin-right: 20px;
 }
-
 .pc-graph-radio-input {
     position: absolute;
     visibility: hidden;
 }
-
 .pc-graph-radio-text {
     display: block;
     padding: 0 5px 15px;
     position: relative;
 }
-
 .pc-graph-radio-input:checked + .pc-graph-radio-text::after {
     content: '';
     position: absolute;
@@ -779,9 +149,7 @@
     height: 4px;
     background: var(--blue);
 }
-
 /* graph layout */
-
 .pc-graph {
     padding: 10px;
     width: 100%;
@@ -789,343 +157,10 @@
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/pc-block-field.vue */
 
 .pc-value-field-wrapper {
     --base-padding: 5px;
-
     display: block;
     position: relative;
     box-sizing: border-box;
@@ -1134,14 +169,11 @@
     border-radius: 5px;
     background: var(--white);
     padding: var(--base-padding);
-
     overflow: hidden;
 }
-
 .pc-field--focused {
     box-shadow: inset 0 0 0 1px var(--dark-blue);
 }
-
 .pc-value--formatted {
     position: absolute;
     left: 50%;
@@ -1150,7 +182,6 @@
     pointer-events: none;
     width: 100%;
 }
-
 .pc-value-display {
     box-sizing: border-box;
     font-size: 1em;
@@ -1159,11 +190,9 @@
     min-height: 1em;
     display: inline-block;
 }
-
 .pc-value-display:focus {
     outline: 0;
 }
-
 .pc-power-input,
 .pc-false-positive-input {
     display: inline-block;
@@ -1175,282 +204,33 @@
     border-radius: 8px;
     font-size: inherit;
 }
-
 .pc-top-fields-error {
     color: var(--red);
 }
-
 /* prefixes and suffixes */
-
 .pc-value-formatting:before {
     color: var(--gray);
     content: attr(data-prefix);
 }
-
 .pc-value-formatting:after {
     color: var(--gray);
     content: attr(data-suffix);
 }
-
 /* block to calculate override rules*/
-
 .pc-block-to-calculate .pc-value-field-wrapper:not(.pc-value-display) {
     background: var(--light-yellow);
     outline: 2px solid var(--dark-yellow);
 }
-
 .pc-block-to-calculate .pc-value .pc-value-formatting:before {
     content: "=" attr(data-prefix);
     color: var(--black);
 }
-
 .pc-block-to-calculate .pc-value-formatting:after {
     color: var(--black);
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/sample-comp.vue */
 
 .pc-inputs[data-v-297fe272] {
     grid-template-areas:
@@ -1458,253 +238,31 @@
         "pc-input-left-swap pc-input-right-swap"
     ;
 }
-
 .pc-input-right-swap[data-v-297fe272],
 .pc-input-right[data-v-297fe272] {
     position: relative;
 }
-
 .pc-input-right-swap[data-v-297fe272] {
     grid-area: pc-input-right-swap;
     margin-top: -10px;
     filter: drop-shadow(0 4px 2px rgba(0,0,0,0.1)) drop-shadow(0 -4px 2px rgba(0,0,0,0.1));
 }
-
 .pc-input-right-swap .pc-value-field-wrapper[data-v-297fe272] {
     filter: none;
 }
-
 .pc-value-formatting[data-v-297fe272]:after {
     font-size: 14px;
 }
-
 .pc-block-to-calculate .pc-field-visitorsPerDay[data-v-297fe272],
 .pc-block-to-calculate .pc-field-days[data-v-297fe272] {
     background: var(--white);
 }
-
 .pc-value-field--lockable.pc-value-field--locked .pc-value-field-wrapper[data-v-297fe272] {
     background: linear-gradient(0deg, var(--light-gray) 0%, var(--white) 100%);
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/sample-comp.vue */
 
 .pc-swap-button {
     -webkit-appearance: none;
@@ -1717,11 +275,9 @@
     left: 5px;
     z-index: 5;
 }
-
 .pc-value-field--unlocked .pc-value-field-wrapper {
     z-index: 1;
 }
-
 .pc-block-to-calculate  .pc-value-field--locked .pc-value-formatting:before,
 .pc-block-to-calculate  .pc-value-field--locked .pc-value-formatting:after,
 .pc-value-field--locked .pc-value-formatting:before,
@@ -1731,52 +287,16 @@
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/pc-block.vue */
 
 .pc-block {
     position: relative;
     padding-bottom: 25px;
     border-bottom: 3px solid var(--pale-blue);
 }
-
 .pc-block-to-calculate {
     border-bottom-color: var(--dark-yellow);
 }
-
 .pc-calc-radio {
     position: absolute;
     top: 0;
@@ -1786,22 +306,18 @@
     border-radius: 25% / 100%;
     padding: 7px 15px;
 }
-
 .pc-calc-radio--active {
     background: var(--white);
 }
-
 .pc-inputs {
     display: block;
     list-style-type: none;
     margin: 0;
     padding: 0;
-
     --row-gap: 10px;
     --padding: 25px;
     --columns-gap: 70px;
     --grid-column-width: calc(50% - (var(--columns-gap) / 2));
-
     display: grid;
     grid-template-columns: var(--grid-column-width) var(--grid-column-width);
     grid-template-rows: auto;
@@ -1811,19 +327,15 @@
     align-items: start;
     grid-gap: var(--row-gap) var(--columns-gap);
     padding: 0 var(--padding);
-
 }
-
 .pc-input-item {
     text-align: center;
 }
-
 .pc-input-title {
     position: relative;
     display: block;
     margin-bottom: 25px;
 }
-
 .pc-input-sub-title {
     position: absolute;
     top: 100%;
@@ -1832,27 +344,21 @@
     text-align: center;
     font-size: 9px;
 }
-
 .pc-input-left {
     grid-area: pc-input-left;
-
 }
-
 .pc-input-right {
     grid-area: pc-input-right;
 }
-
 .pc-input-details {
     font-size: 10px;
     color: var(--dark-gray);
 }
-
 .pc-field-not-editable {
     position: relative;
     padding: 5px;
     display: block;
 }
-
 .pc-input-left .pc-field-not-editable,
 .pc-input-right .pc-field-not-editable {
     background: var(--light-gray);
@@ -1860,64 +366,7 @@
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/pc-svg-chain.vue */
 
 .pc-svg-chain-icon {
     position: absolute;
@@ -1927,274 +376,7 @@
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/impact-comp.vue */
 
 .pc-inputs {
     grid-template-areas:
@@ -2203,195 +385,7 @@
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/base-comp.vue */
 
 .pc-input-left[data-v-0d0bef2b] {
     position: relative;
@@ -2399,180 +393,7 @@
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/base-comp.vue */
 
 .pc-input-sd-rate {
     margin-top: -10px;
@@ -2580,47 +401,18 @@
     position: relative;
     text-align: center;
 }
-
 .pc-field-sdRate {
     width: 90%;
     display: inline-block;
 }
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+/* components/pc-tooltip.vue */
 
 .pc-tooltip {
     --tooltip-background-color: var(--black);
     position: relative;
 }
-
 .tooltip-wrapper {
     position: absolute;
     left: 0;
@@ -2634,16 +426,13 @@
     white-space: normal;
     pointer-events: none;
 }
-
 .tooltip-wrapper:after {
     --size: 5px;
-
     content: '';
     position: absolute;
     left: 50px;
     bottom: calc(100% - var(--size));
     transform: translate(-50%, 0) rotateZ(45deg);
-
     border: var(--size) solid var(--tooltip-background-color);
     border-right-color: transparent;
     border-bottom-color: transparent;

--- a/dist/powercalculator.js
+++ b/dist/powercalculator.js
@@ -4848,6 +4848,7 @@ var valueTransformationMixin = {
                 tTest: {type: 'float'}
             },
             impact: {type: 'percentage'},
+            runtime: {type: 'int'},
             power: {type: 'percentage'},
             falsePosRate: {type: 'percentage'},
             impactByMetricValue: {type: 'percentage'},
@@ -5016,6 +5017,84 @@ var _incrementalTrials = {
     }
 };
 
+var _incrementalTrialsPerDay = {
+    getGraphYTicks () {
+        let impact = this.impact,
+            arr = [impact/4, impact/2, impact, impact*2, impact*4];
+
+        return arr
+    },
+    getGraphYTicksFormatted (y) {
+        let sample = this.sample,
+            base = this.base,
+
+            result = statFormulas.getAbsoluteImpactInVisitors({
+                total_sample_size: this.extractValue('sample', sample / this.runtime),
+                base_rate: this.extractValue('base', base),
+                effect_size: this.extractValue('impact', y)
+            });
+
+        return this.displayValue('impactByVisitors', result);
+    },
+    updateClonedValues (clonedObj, value) {
+        clonedObj.effect_size = this.extractValue('impact', value);
+
+        return clonedObj;
+    },
+    getCurrentYValue () {
+        return this.impact
+    },
+    getGraphXTicksFormatted (x) {
+        let { displayValue } = this,
+            result = x;
+
+        result = result;
+        result += '%';
+
+        return result
+    },
+    getGraphXTicksFormatted (x) {
+        let { displayValue } = this,
+            result = x / this.runtime;
+
+        result = displayValue('impactByVisitors', result);
+        if (result >= 1000) {
+            result = window.parseInt(result / 1000) + 'k';
+        }
+
+        return result
+    },
+    getGraphXValueForClonedValues (clonedValues) {
+        let {total_sample_size, base_rate, effect_size} = clonedValues,
+
+            impactByVisitor = statFormulas.getAbsoluteImpactInVisitors({
+                total_sample_size,
+                base_rate,
+                effect_size,
+            });
+
+        return this.displayValue('impactByVisitors', impactByVisitor);
+    }
+};
+
+var _days = {
+    getGraphXTicksFormatted (x) {
+        let { displayValue } = this,
+            samplePerDay = this.sample / this.runtime,
+            result = x / samplePerDay;
+        result = displayValue('sample', result);
+        if (result >= 1000) {
+            result = window.parseInt(result / 1000) + 'k';
+        }
+
+        return result
+    },
+    getGraphXValueForClonedValues (clonedValues) {
+        let graphX = 'sample';
+        return this.displayValue(graphX, (this.math[graphX](clonedValues)));
+    }
+};
+
 var _sample = {
     getGraphXTicksFormatted (x) {
         let { displayValue } = this,
@@ -5085,17 +5164,16 @@ var defaultConfig = {
             ratio = (lastTick - firstTick) / amount,
             result = Array.from(new Array(amount));
 
-        result[0] = firstTick;
-
-        result = result.map((cur, i) => {
-            return cur ? cur : ratio * i
+        result = result.map((cur, i, arr) => {
+            let value = firstTick + ratio * i;
+            return value
         });
 
         // add the current value in case it isn't there
         result.push(curYValue);
 
         // sort current value
-        result.sort((a,b) => { return a > b});
+        result.sort((a,b) => { return a - b});
 
         // remove duplicates
         result = [...new Set(result)];
@@ -5127,11 +5205,13 @@ var graphDataMixin = {
         // this is done to agregate different pieces of configuration that need to work in harmony
         // for the svg graph
         Object.assign(this, {
-            _sample:            Object.assign({}, defaultConfig, _sample),
-            _samplePerDay:      Object.assign({}, defaultConfig, _samplePerDay),
-            _impact:            Object.assign({}, defaultConfig, _impact),
-            _incrementalTrials: Object.assign({}, defaultConfig, _incrementalTrials),
-            _power:             Object.assign({}, defaultConfig, _power),
+            _sample:                    Object.assign({}, defaultConfig, _sample),
+            _samplePerDay:              Object.assign({}, defaultConfig, _samplePerDay),
+            _impact:                    Object.assign({}, defaultConfig, _impact),
+            _incrementalTrials:         Object.assign({}, defaultConfig, _incrementalTrials),
+            _power:                     Object.assign({}, defaultConfig, _power),
+            _incrementalTrialsPerDay:   Object.assign({}, defaultConfig, _incrementalTrialsPerDay),
+            _days:                      Object.assign({}, defaultConfig, _days),
         });
     },
     methods: {
@@ -5203,7 +5283,7 @@ document.querySelector('head').appendChild(style);
 
 
 
-var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--graph"},[_c('div',{staticClass:"pc-graph-controls"},[_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"sample-power"},domProps:{"checked":_vm._q(_vm.graphType,"sample-power")},on:{"change":function($event){_vm.graphType="sample-power";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'sample-power'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('power'))+" / "+_vm._s(_vm.getMetricDisplayName('sample')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"impact-power"},domProps:{"checked":_vm._q(_vm.graphType,"impact-power")},on:{"change":function($event){_vm.graphType="impact-power";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'impact-power'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('power'))+" / "+_vm._s(_vm.getMetricDisplayName('impact')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"sample-impact"},domProps:{"checked":_vm._q(_vm.graphType,"sample-impact")},on:{"change":function($event){_vm.graphType="sample-impact";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'sample-impact'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('impact'))+" / "+_vm._s(_vm.getMetricDisplayName('sample')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"samplePerDay-power"},domProps:{"checked":_vm._q(_vm.graphType,"samplePerDay-power")},on:{"change":function($event){_vm.graphType="samplePerDay-power";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'samplePerDay-power'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('power'))+" / "+_vm._s(_vm.getMetricDisplayName('samplePerDay')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"samplePerDay-incrementalTrials"},domProps:{"checked":_vm._q(_vm.graphType,"samplePerDay-incrementalTrials")},on:{"change":function($event){_vm.graphType="samplePerDay-incrementalTrials";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'samplePerDay-incrementalTrials'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('incrementalTrials'))+" / "+_vm._s(_vm.getMetricDisplayName('samplePerDay')))])])]),_vm._v(" "),_c('div',{ref:"pc-graph-size",staticClass:"pc-graph"},[_c('div',{ref:"pc-graph-wrapper",style:(_vm.style)},[_c('div',{ref:"pc-graph"})])])])},staticRenderFns: [],
+var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--graph"},[_c('div',{staticClass:"pc-graph-controls"},[_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"sample-power"},domProps:{"checked":_vm._q(_vm.graphType,"sample-power")},on:{"change":function($event){_vm.graphType="sample-power";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'sample-power'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('power'))+" / "+_vm._s(_vm.getMetricDisplayName('sample')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"impact-power"},domProps:{"checked":_vm._q(_vm.graphType,"impact-power")},on:{"change":function($event){_vm.graphType="impact-power";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'impact-power'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('power'))+" / "+_vm._s(_vm.getMetricDisplayName('impact')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"sample-impact"},domProps:{"checked":_vm._q(_vm.graphType,"sample-impact")},on:{"change":function($event){_vm.graphType="sample-impact";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'sample-impact'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('impact'))+" / "+_vm._s(_vm.getMetricDisplayName('sample')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"samplePerDay-power"},domProps:{"checked":_vm._q(_vm.graphType,"samplePerDay-power")},on:{"change":function($event){_vm.graphType="samplePerDay-power";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'samplePerDay-power'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('power'))+" / "+_vm._s(_vm.getMetricDisplayName('samplePerDay')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"samplePerDay-incrementalTrials"},domProps:{"checked":_vm._q(_vm.graphType,"samplePerDay-incrementalTrials")},on:{"change":function($event){_vm.graphType="samplePerDay-incrementalTrials";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'samplePerDay-incrementalTrials'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('incrementalTrials'))+" / "+_vm._s(_vm.getMetricDisplayName('samplePerDay')))])]),_vm._v(" "),_c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphType),expression:"graphType"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph-x","value":"days-incrementalTrialsPerDay"},domProps:{"checked":_vm._q(_vm.graphType,"days-incrementalTrialsPerDay")},on:{"change":function($event){_vm.graphType="days-incrementalTrialsPerDay";}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:{'pc-graph-radio-selected': _vm.graphType == 'days-incrementalTrialsPerDay'}},[_vm._v(_vm._s(_vm.getMetricDisplayName('incrementalTrialsPerDay'))+" / "+_vm._s(_vm.getMetricDisplayName('days')))])])]),_vm._v(" "),_c('div',{ref:"pc-graph-size",staticClass:"pc-graph"},[_c('div',{ref:"pc-graph-wrapper",style:(_vm.style)},[_c('div',{ref:"pc-graph"})])])])},staticRenderFns: [],
     mixins: [valueTransformationMixin, graphDataMixin],
     template: '#svg-graph',
     props: ['testtype', 'sample', 'impact', 'power', 'base', 'falseposrate', 'sdrate', 'runtime'],
@@ -5298,7 +5378,7 @@ var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c
 
                 clonedValues = this.updateClonedValues(clonedValues, yValue);
 
-                let xValues = this.getGraphXValueForClonedValues(clonedValues);
+                let xValues = this.getGraphXValueForClonedValues(clonedValues, yValue);
 
                  newData[0][i + 1] = xValues; // x
                  newData[1][i + 1] = yValue; // line
@@ -5378,6 +5458,9 @@ var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c
 
                 samplePerDay: 'Daily Visitors',
                 incrementalTrials: 'Incremental Trials',
+
+                days: '# of days',
+                incrementalTrialsPerDay: 'Inc. Trials per day',
             }[metric] || ''
         }
     },
@@ -5395,6 +5478,9 @@ var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c
             this.updateGraphData();
         },
         graphX () {
+            this.updateGraphData();
+        },
+        runtime () {
             this.updateGraphData();
         }
     },
@@ -5418,6 +5504,14 @@ var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c
                 x: 'x',
                 columns: this.dataDefault,
                 type: 'line'
+            },
+            grid: {
+                x: {
+                    show: true
+                },
+                y: {
+                    show: true
+                }
             },
             axis: {
                 x: {
@@ -5479,6 +5573,12 @@ let validateFunctions = {
                     return value >= 0 && value <= 100
                 },
                 defaultVal: 80
+            },
+            days: {
+                fn (value) {
+                    return value > 0
+                },
+                defaultVal: 14
             }
         },
         gTest: {
@@ -5592,10 +5692,7 @@ var pcBlockField = {render: function(){var _vm=this;var _h=_vm.$createElement;va
             // try to extract numbers from it
             newValue = parseFloat(newValue);
 
-            // in case of NaN
-            if (isNaN(newValue)) {
-                newValue = 0;
-            }
+            newValue = this.validateField(newValue);
 
             return newValue
 
@@ -5824,20 +5921,19 @@ var pcBlock = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=
     }
 };
 
-var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--sample",class:{'pc-block-focused': _vm.isblockfocused == 'sample', 'pc-block-to-calculate': _vm.calculateprop == 'sample'}},[_c('pc-svg-chain',{attrs:{"calculateprop":_vm.calculateprop,"fieldfromblock":_vm.fieldfromblock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--sample",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Sample Size ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_vm._m(0,false,false),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldprop":"totalSample","fieldvalue":_vm.totalSample,"testtype":_vm.testtype,"isreadonly":_vm.calculateprop == 'sample',"enableedit":_vm.enableedit},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right pc-value-field--lockable",class:{'pc-value-field--unlocked': _vm.lockedField == 'days'}},[_c('label',[_vm._m(1,false,false),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldprop":"visitorsPerDay","fieldvalue":_vm.visitorsPerDay,"testtype":_vm.testtype,"isreadonly":_vm.lockedField == 'visitorsPerDay',"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit,"lockedfield":_vm.lockedField,"lock":_vm.lockedField},on:{"update:lock":function($event){_vm.lockedField=$event;},"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1),_vm._v(" "),_c('button',{staticClass:"pc-swap-button",attrs:{"type":"button"},on:{"click":_vm.switchLockedField}},[_c('svg',{attrs:{"width":"20px","height":"20px","viewBox":"0 0 20 20","version":"1.1","xmlns":"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink"}},[_c('desc',[_vm._v("Lock "+_vm._s(_vm.lockedField == 'days' ? 'number of days' : 'visitors per day'))]),_vm._v(" "),_c('defs',[_c('circle',{attrs:{"id":"path-1","cx":"13","cy":"13","r":"10"}}),_vm._v(" "),_c('filter',{attrs:{"x":"-5.0%","y":"-5.0%","width":"110.0%","height":"110.0%","filterUnits":"objectBoundingBox","id":"filter-2"}},[_c('feGaussianBlur',{attrs:{"stdDeviation":"0.5","in":"SourceAlpha","result":"shadowBlurInner1"}}),_vm._v(" "),_c('feOffset',{attrs:{"dx":"0","dy":"1","in":"shadowBlurInner1","result":"shadowOffsetInner1"}}),_vm._v(" "),_c('feComposite',{attrs:{"in":"shadowOffsetInner1","in2":"SourceAlpha","operator":"arithmetic","k2":"-1","k3":"1","result":"shadowInnerInner1"}}),_vm._v(" "),_c('feColorMatrix',{attrs:{"values":"0 0 0 0 0.489716199   0 0 0 0 0.489716199   0 0 0 0 0.489716199  0 0 0 0.5 0","type":"matrix","in":"shadowInnerInner1"}})],1)]),_vm._v(" "),_c('g',{attrs:{"id":"Page-1","stroke":"none","stroke-width":"1","fill":"none","fill-rule":"evenodd"}},[_c('g',{attrs:{"id":"Power-Calculator","transform":"translate(-550.000000, -522.000000)"}},[_c('g',{attrs:{"id":"Switcher","transform":"translate(547.000000, 519.000000)"}},[_c('g',{attrs:{"id":"Oval-3"}},[_c('use',{attrs:{"fill":"#EFEFEF","fill-rule":"evenodd","xlink:href":"#path-1"}}),_vm._v(" "),_c('use',{attrs:{"fill":"black","fill-opacity":"1","filter":"url(#filter-2)","xlink:href":"#path-1"}})]),_vm._v(" "),_c('g',{attrs:{"id":"Group","stroke-width":"1","fill-rule":"evenodd","transform":"translate(7.000000, 7.000000)","fill":"#155EAB"}},[_c('path',{attrs:{"d":"M4.5,4.20404051 L4.5,9.9127641 L2.5,9.9127641 L2.5,4.20404051 L0.5,4.20404051 L3.5,0.70872359 L6.5,4.20404051 L4.5,4.20404051 Z","id":"Combined-Shape"}}),_vm._v(" "),_c('path',{attrs:{"d":"M9.5,5.49531692 L9.5,11.2040405 L7.5,11.2040405 L7.5,5.49531692 L5.5,5.49531692 L8.5,2 L11.5,5.49531692 L9.5,5.49531692 Z","id":"Combined-Shape","transform":"translate(8.500000, 6.602020) scale(1, -1) translate(-8.500000, -6.602020) "}})])])])])])])]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right-swap pc-value-field--lockable",class:{'pc-value-field--unlocked': _vm.lockedField != 'days'}},[_c('label',[_c('pc-block-field',{attrs:{"fieldprop":"days","prefix":"","suffix":" days","fieldvalue":_vm.days,"testtype":_vm.testtype,"isreadonly":_vm.lockedField == 'days',"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit,"lockedfield":_vm.lockedField,"lock":_vm.lockedField,"aria-label":"Days"},on:{"update:lock":function($event){_vm.lockedField=$event;},"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1)])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Total # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of visitors")])])},function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Daily # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of visitors")])])}],_scopeId: 'data-v-297fe272',
-    props: ['runtime', 'testtype', 'calculateprop', 'enableedit', 'isblockfocused', 'sample', 'calculateprop', 'fieldfromblock'],
+var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--sample",class:{'pc-block-focused': _vm.isblockfocused == 'sample', 'pc-block-to-calculate': _vm.calculateprop == 'sample'}},[_c('pc-svg-chain',{attrs:{"calculateprop":_vm.calculateprop,"fieldfromblock":_vm.fieldfromblock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--sample",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Sample Size ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_vm._m(0,false,false),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldprop":"totalSample","fieldvalue":_vm.totalSample,"testtype":_vm.testtype,"isreadonly":_vm.calculateprop == 'sample',"enableedit":_vm.enableedit},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right pc-value-field--lockable",class:_vm.getLockedStateClass('visitorsPerDay')},[_c('label',[_vm._m(1,false,false),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldprop":"visitorsPerDay","fieldvalue":_vm.visitorsPerDay,"testtype":_vm.testtype,"isreadonly":_vm.lockedField == 'visitorsPerDay',"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit,"lockedfield":_vm.lockedField,"lock":_vm.lockedField},on:{"update:lock":function($event){_vm.lockedField=$event;},"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1),_vm._v(" "),_c('button',{staticClass:"pc-swap-button",attrs:{"type":"button"},on:{"click":_vm.switchLockedField}},[_c('svg',{attrs:{"width":"20px","height":"20px","viewBox":"0 0 20 20","version":"1.1","xmlns":"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink"}},[_c('desc',[_vm._v("Lock "+_vm._s(_vm.lockedField == 'days' ? 'number of days' : 'visitors per day'))]),_vm._v(" "),_c('defs',[_c('circle',{attrs:{"id":"path-1","cx":"13","cy":"13","r":"10"}}),_vm._v(" "),_c('filter',{attrs:{"x":"-5.0%","y":"-5.0%","width":"110.0%","height":"110.0%","filterUnits":"objectBoundingBox","id":"filter-2"}},[_c('feGaussianBlur',{attrs:{"stdDeviation":"0.5","in":"SourceAlpha","result":"shadowBlurInner1"}}),_vm._v(" "),_c('feOffset',{attrs:{"dx":"0","dy":"1","in":"shadowBlurInner1","result":"shadowOffsetInner1"}}),_vm._v(" "),_c('feComposite',{attrs:{"in":"shadowOffsetInner1","in2":"SourceAlpha","operator":"arithmetic","k2":"-1","k3":"1","result":"shadowInnerInner1"}}),_vm._v(" "),_c('feColorMatrix',{attrs:{"values":"0 0 0 0 0.489716199   0 0 0 0 0.489716199   0 0 0 0 0.489716199  0 0 0 0.5 0","type":"matrix","in":"shadowInnerInner1"}})],1)]),_vm._v(" "),_c('g',{attrs:{"id":"Page-1","stroke":"none","stroke-width":"1","fill":"none","fill-rule":"evenodd"}},[_c('g',{attrs:{"id":"Power-Calculator","transform":"translate(-550.000000, -522.000000)"}},[_c('g',{attrs:{"id":"Switcher","transform":"translate(547.000000, 519.000000)"}},[_c('g',{attrs:{"id":"Oval-3"}},[_c('use',{attrs:{"fill":"#EFEFEF","fill-rule":"evenodd","xlink:href":"#path-1"}}),_vm._v(" "),_c('use',{attrs:{"fill":"black","fill-opacity":"1","filter":"url(#filter-2)","xlink:href":"#path-1"}})]),_vm._v(" "),_c('g',{attrs:{"id":"Group","stroke-width":"1","fill-rule":"evenodd","transform":"translate(7.000000, 7.000000)","fill":"#155EAB"}},[_c('path',{attrs:{"d":"M4.5,4.20404051 L4.5,9.9127641 L2.5,9.9127641 L2.5,4.20404051 L0.5,4.20404051 L3.5,0.70872359 L6.5,4.20404051 L4.5,4.20404051 Z","id":"Combined-Shape"}}),_vm._v(" "),_c('path',{attrs:{"d":"M9.5,5.49531692 L9.5,11.2040405 L7.5,11.2040405 L7.5,5.49531692 L5.5,5.49531692 L8.5,2 L11.5,5.49531692 L9.5,5.49531692 Z","id":"Combined-Shape","transform":"translate(8.500000, 6.602020) scale(1, -1) translate(-8.500000, -6.602020) "}})])])])])])])]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right-swap pc-value-field--lockable",class:_vm.getLockedStateClass('days')},[_c('label',[_c('pc-block-field',{attrs:{"fieldprop":"days","prefix":"","suffix":" days","fieldvalue":_vm.days,"testtype":_vm.testtype,"isreadonly":_vm.lockedField == 'days',"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit,"lockedfield":_vm.lockedField,"lock":_vm.lockedField,"aria-label":"Days"},on:{"update:lock":function($event){_vm.lockedField=$event;},"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1)])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Total # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of visitors")])])},function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Daily # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of visitors")])])}],_scopeId: 'data-v-297fe272',
+    props: ['runtime', 'testtype', 'lockedfield', 'calculateprop', 'enableedit', 'isblockfocused', 'sample', 'calculateprop', 'fieldfromblock'],
     template: '#sample-comp',
     extends: pcBlock,
     data () {
-        let initialDaysValue = 14;
         return {
-            days: initialDaysValue,
-            visitorsPerDay: this.calculateVisitorsPerDay(this.sample, initialDaysValue),
+            days: this.runtime,
+            visitorsPerDay: this.calculateVisitorsPerDay(this.sample, this.runtime),
             variants: 2,
             totalSample: this.sample,
             enableEdit: false,
             focusedBlock: '',
-            lockedField: 'days'
+            lockedField: this.lockedfield
         }
     },
     methods: {
@@ -5845,14 +5941,33 @@ var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var 
             let result =  Math.floor(window.parseInt(sample) / days);
             return isNaN(result) ? '-' : result;
         },
-        calculateDays(sample, newValue) {
-            let result =  Math.ceil(window.parseInt(sample) / newValue);
+        calculateDays(sample, visitorsPerDay) {
+            let result =  Math.ceil(window.parseInt(sample) / visitorsPerDay);
             return isNaN(result) ? '-' : result;
         },
         enableInput () {
             this.$emit('edit:update', {prop: 'sample'});
         },
         updateFields ({prop, value}) {
+
+            if (prop == 'days') {
+                this.days = value;
+            } else if (prop == 'visitorsPerDay') {
+                this.visitorsPerDay = value;
+            }
+
+            if (this.calculateprop == 'sample') {
+                if (prop == 'visitorsPerDay') {
+                    this.days = this.calculateDays(this.totalSample, this.visitorsPerDay);
+                } else if (prop == 'days') {
+                    this.visitorsPerDay = this.calculateVisitorsPerDay(this.totalSample, this.days);
+                }
+            } else {
+                this.updateTotalSampleField({prop, value});
+            }
+
+        },
+        updateTotalSampleField ({prop, value}) {
             let totalSample = 0;
 
             if (prop == 'totalSample') {
@@ -5886,6 +6001,9 @@ var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var 
         },
         switchLockedField () {
             this.lockedField = this.lockedField == 'days' ? 'visitorsPerDay' : 'days';
+        },
+        getLockedStateClass (param) {
+            return this.lockedField == param ? 'pc-value-field--locked' : 'pc-value-field--unlocked'
         }
     },
     watch: {
@@ -5894,17 +6012,23 @@ var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var 
         },
         totalSample (newValue) {
             if (this.lockedField == 'days') {
-                this.visitorsPerDay = this.calculateVisitorsPerDay(newValue, this.days);
-            } else {
                 this.days = this.calculateDays(newValue, this.visitorsPerDay);
+            } else {
+                this.visitorsPerDay = this.calculateVisitorsPerDay(newValue, this.days);
             }
 
             this.updateSampleMainField();
+        },
+        days (newValue) {
+            this.$emit('update:runtime', newValue);
+        },
+        lockedField (newValue) {
+            this.$emit('update:lockedfield', newValue);
         }
     }
 };
 
-var impactComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--impact",class:{'pc-block-focused': _vm.isblockfocused, 'pc-block-to-calculate': _vm.calculateprop == 'impact'}},[_c('pc-svg-chain',{attrs:{"calculateprop":_vm.calculateprop,"fieldfromblock":_vm.fieldfromblock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--impact",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Impact ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Relative")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"prefix":"±","suffix":"%","fieldprop":"relativeImpact","fieldvalue":_vm.relativeImpact,"testtype":_vm.testType,"isreadonly":_vm.calculateprop == 'impact',"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Absolute")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldprop":"impactByMetricValue","fieldvalue":_vm.impactByMetricDisplay,"testtype":_vm.testtype,"isreadonly":_vm.isReadOnly,"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit,"aria-label":"visitors with goals"},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" going from "+_vm._s(_vm.impactByMetricMinDisplay)+" to "+_vm._s(_vm.impactByMetricMaxDisplay)+"% ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-left"},[_c('label',[_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldprop":"impactByVisitors","fieldvalue":_vm.impactByVisitorsDisplay,"testtype":_vm.testtype,"isreadonly":_vm.isReadOnly,"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit && _vm.calculateprop != 'sample'},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testtype == 'gTest' ? ' Incremental trials': ' Incremental change in the metric')+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-right"},[_c('label',[_c('pc-block-field',{attrs:{"fieldprop":"impactByVisitorsPerDay","fieldvalue":_vm.impactByVisitorsPerDayDisplay,"testtype":_vm.testtype,"isreadonly":_vm.isReadOnly,"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit && _vm.calculateprop != 'sample'},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testtype == 'gTest' ? ' Incremental trials per day': ' Incremental change in the metric per day')+" ")])],1)])])],1)},staticRenderFns: [],
+var impactComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--impact",class:{'pc-block-focused': _vm.isblockfocused, 'pc-block-to-calculate': _vm.calculateprop == 'impact'}},[_c('pc-svg-chain',{attrs:{"calculateprop":_vm.calculateprop,"fieldfromblock":_vm.fieldfromblock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--impact",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Impact ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Relative")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"prefix":"±","suffix":"%","fieldprop":"relativeImpact","fieldvalue":_vm.relativeImpact,"testtype":_vm.testType,"isreadonly":_vm.calculateprop == 'impact',"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Absolute")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldprop":"impactByMetricValue","fieldvalue":_vm.impactByMetricDisplay,"testtype":_vm.testtype,"isreadonly":_vm.isReadOnly,"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit,"aria-label":"visitors with goals"},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" going from "+_vm._s(_vm.base)+" to either "+_vm._s(_vm.impactByMetricMinDisplay)+" or "+_vm._s(_vm.impactByMetricMaxDisplay)+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-left"},[_c('label',[_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldprop":"impactByVisitors","fieldvalue":_vm.impactByVisitorsDisplay,"testtype":_vm.testtype,"isreadonly":_vm.isReadOnly,"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit && _vm.calculateprop != 'sample'},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testtype == 'gTest' ? ' Incremental trials': ' Incremental change in the metric')+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-right"},[_c('label',[_c('pc-block-field',{attrs:{"fieldprop":"impactByVisitorsPerDay","fieldvalue":_vm.impactByVisitorsPerDayDisplay,"testtype":_vm.testtype,"isreadonly":_vm.isReadOnly,"isblockfocused":_vm.isblockfocused,"enableedit":_vm.enableedit && _vm.calculateprop != 'sample'},on:{"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testtype == 'gTest' ? ' Incremental trials per day': ' Incremental change in the metric per day')+" ")])],1)])])],1)},staticRenderFns: [],
     extends: pcBlock,
     template: '#impact-comp',
     props: ['view', 'testtype', 'enableedit', 'calculateprop', 'fieldfromblock', 'isblockfocused', 'testtype'],
@@ -6004,7 +6128,7 @@ var impactComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var 
             })
         },
         getImpactByVisitorsPerDay () {
-            return this.getImpactByVisitor() / this.view.runtime
+            return Math.floor(this.getImpactByVisitor() / this.view.runtime);
         },
         updateData () {
             this.impactByMetricValue = this.getImpactByMetric();
@@ -6180,7 +6304,7 @@ var pcTooltip = {render: function(){var _vm=this;var _h=_vm.$createElement;var _
 
 };
 
-var powerCalculator$1 = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"power-calculator"},[_c('form',{staticClass:"pc-form",attrs:{"action":"."}},[_c('div',{staticClass:"pc-main-header"},[_c('div',{staticClass:"pc-test-type"},[_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"gTest","checked":"checked"},domProps:{"checked":_vm._q(_vm.testType,"gTest")},on:{"change":function($event){_vm.testType="gTest";}}}),_vm._v(" Binary Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A binary metric is one that can be only two values like 0 or 1, yes or no, converted or not converted ")])]),_vm._v(" "),_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"tTest"},domProps:{"checked":_vm._q(_vm.testType,"tTest")},on:{"change":function($event){_vm.testType="tTest";}}}),_vm._v(" Continuous Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A continuous metric is one that can be any number like time on site or the number of rooms sold ")])])],1),_vm._v(" "),_vm._m(0,false,false),_vm._v(" "),_c('label',{staticClass:"pc-false-positive"},[_c('pc-block-field',{staticClass:"pc-false-positive-input",class:{ 'pc-top-fields-error': _vm.view.falsePosRate > 10 },attrs:{"suffix":"%","fieldprop":"falsePosRate","fieldvalue":_vm.view.falsePosRate,"testtype":_vm.testType,"enableedit":true},on:{"field:change":_vm.updateFields}}),_vm._v(" false positive rate ")],1),_vm._v(" "),_c('label',{staticClass:"pc-power"},[_c('pc-block-field',{staticClass:"pc-power-input",class:{ 'pc-top-fields-error': _vm.view.power < 80 },attrs:{"suffix":"%","fieldprop":"power","fieldvalue":_vm.view.power,"testtype":_vm.testType,"enableedit":true},on:{"field:change":_vm.updateFields}}),_vm._v(" power ")],1)]),_vm._v(" "),_c('div',{staticClass:"pc-blocks-wrapper",class:{'pc-blocks-wrapper-ttest': _vm.testType == 'tTest'}},[_c('base-comp',{attrs:{"fieldfromblock":"base","view":_vm.view,"calculateprop":_vm.calculateProp,"isblockfocused":_vm.focusedBlock == 'base',"testtype":_vm.testType,"enableedit":_vm.enabledMainInputs.base},on:{"update:focus":_vm.updateFocus,"field:change":_vm.updateFields}}),_vm._v(" "),_c('sample-comp',{attrs:{"fieldfromblock":"sample","sample":_vm.view.sample,"runtime":_vm.view.runtime,"calculateprop":_vm.calculateProp,"enableedit":_vm.enabledMainInputs.sample,"isblockfocused":_vm.focusedBlock == 'sample'},on:{"update:runtime":function($event){_vm.$set(_vm.view, "runtime", $event);},"update:calculateprop":_vm.updateCalculateProp,"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('impact-comp',{attrs:{"fieldfromblock":"impact","view":_vm.view,"isblockfocused":_vm.focusedBlock == 'impact',"testtype":_vm.testType,"enableedit":_vm.enabledMainInputs.impact,"calculateprop":_vm.calculateProp},on:{"update:calculateprop":_vm.updateCalculateProp,"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('svg-graph',{attrs:{"power":_vm.view.power,"impact":_vm.view.impact,"base":_vm.view.base,"sample":_vm.view.sample,"sdrate":_vm.view.sdRate,"falseposrate":_vm.view.falsePosRate,"runtime":_vm.view.runtime,"testtype":_vm.testType}})],1)])])},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-title"},[_vm._v("Power Calculator "),_c('sup',{staticStyle:{"color":"#F00","font-size":"11px"}},[_vm._v("BETA")])])}],
+var powerCalculator$1 = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"power-calculator"},[_c('form',{staticClass:"pc-form",attrs:{"action":"."}},[_c('div',{staticClass:"pc-main-header"},[_c('div',{staticClass:"pc-test-type"},[_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"gTest","checked":"checked"},domProps:{"checked":_vm._q(_vm.testType,"gTest")},on:{"change":function($event){_vm.testType="gTest";}}}),_vm._v(" Binary Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A binary metric is one that can be only two values like 0 or 1, yes or no, converted or not converted ")])]),_vm._v(" "),_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"tTest"},domProps:{"checked":_vm._q(_vm.testType,"tTest")},on:{"change":function($event){_vm.testType="tTest";}}}),_vm._v(" Continuous Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A continuous metric is one that can be any number like time on site or the number of rooms sold ")])])],1),_vm._v(" "),_vm._m(0,false,false),_vm._v(" "),_c('label',{staticClass:"pc-false-positive"},[_c('pc-block-field',{staticClass:"pc-false-positive-input",class:{ 'pc-top-fields-error': _vm.view.falsePosRate > 10 },attrs:{"suffix":"%","fieldprop":"falsePosRate","fieldvalue":_vm.view.falsePosRate,"testtype":_vm.testType,"enableedit":true},on:{"field:change":_vm.updateFields}}),_vm._v(" false positive rate ")],1),_vm._v(" "),_c('label',{staticClass:"pc-power"},[_c('pc-block-field',{staticClass:"pc-power-input",class:{ 'pc-top-fields-error': _vm.view.power < 80 },attrs:{"suffix":"%","fieldprop":"power","fieldvalue":_vm.view.power,"testtype":_vm.testType,"enableedit":true},on:{"field:change":_vm.updateFields}}),_vm._v(" power ")],1)]),_vm._v(" "),_c('div',{staticClass:"pc-blocks-wrapper",class:{'pc-blocks-wrapper-ttest': _vm.testType == 'tTest'}},[_c('base-comp',{attrs:{"fieldfromblock":"base","view":_vm.view,"calculateprop":_vm.calculateProp,"isblockfocused":_vm.focusedBlock == 'base',"testtype":_vm.testType,"enableedit":_vm.enabledMainInputs.base},on:{"update:focus":_vm.updateFocus,"field:change":_vm.updateFields}}),_vm._v(" "),_c('sample-comp',{attrs:{"fieldfromblock":"sample","testtype":_vm.testType,"sample":_vm.view.sample,"runtime":_vm.view.runtime,"lockedfield":_vm.lockedField,"calculateprop":_vm.calculateProp,"enableedit":_vm.enabledMainInputs.sample,"isblockfocused":_vm.focusedBlock == 'sample'},on:{"update:runtime":function($event){_vm.$set(_vm.view, "runtime", $event);},"update:lockedfield":function($event){_vm.lockedField=$event;},"update:calculateprop":_vm.updateCalculateProp,"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('impact-comp',{attrs:{"fieldfromblock":"impact","view":_vm.view,"isblockfocused":_vm.focusedBlock == 'impact',"testtype":_vm.testType,"enableedit":_vm.enabledMainInputs.impact,"calculateprop":_vm.calculateProp},on:{"update:calculateprop":_vm.updateCalculateProp,"field:change":_vm.updateFields,"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('svg-graph',{attrs:{"power":_vm.view.power,"impact":_vm.view.impact,"base":_vm.view.base,"sample":_vm.view.sample,"sdrate":_vm.view.sdRate,"falseposrate":_vm.view.falsePosRate,"runtime":_vm.view.runtime,"testtype":_vm.testType}})],1)])])},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-title"},[_vm._v("Power Calculator "),_c('sup',{staticStyle:{"color":"#F00","font-size":"11px"}},[_vm._v("BETA")])])}],
     mixins: [valueTransformationMixin],
     props: ['parentmetricdata'],
     data () {
@@ -6201,6 +6325,9 @@ var powerCalculator$1 = {render: function(){var _vm=this;var _h=_vm.$createEleme
 
                 runtime: 14 //days
             },
+
+            // this is used for sample size but we also want to make it shareable
+            lockedField: 'days',
 
             // false means the editable ones are the secondary mode (metric totals, days&daily trials and absolute impact)
             enabledMainInputs: {
@@ -6230,6 +6357,7 @@ var powerCalculator$1 = {render: function(){var _vm=this;var _h=_vm.$createEleme
                     testType: this.testType,
                     calculateProp: this.calculateProp,
                     view: this.view,
+                    lockedField: this.lockedField,
                 };
             return JSON.parse(JSON.stringify(result))
         }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import replace from 'rollup-plugin-replace';
 import vue from 'rollup-plugin-vue';
 import resolve from 'rollup-plugin-node-resolve';
@@ -19,7 +20,20 @@ export default {
     commonjs({
       include: ['node_modules/**'],
     }),
-    vue({ css: 'dist/powercalculator.css' }),
+    vue({
+      css (style, styles, compiler) {
+          fs.writeFileSync('dist/powercalculator.css', styles.reduce((str, styleData) => {
+            let { id, $compiled } = styleData,
+              { code } = $compiled,
+              relativeVuePath = id.replace(__dirname + '/src/', ''),
+              codeTrimLineBreaks = code.replace(/[\n]+/g, '\n');
+
+            str += `\n/* ${relativeVuePath} */\n${codeTrimLineBreaks}\n`;
+
+            return str
+          }, ''));
+      }
+    })
   ],
   output: {
     name: 'powercalculator',

--- a/src/components/impact-comp.vue
+++ b/src/components/impact-comp.vue
@@ -51,7 +51,7 @@
                         v-on:update:focus="updateFocus"
                         aria-label="visitors with goals"></pc-block-field>
                         <span class="pc-input-details">
-                            going from {{impactByMetricMinDisplay}} to {{impactByMetricMaxDisplay}}%
+                            going from {{base}} to either {{impactByMetricMinDisplay}} or {{impactByMetricMaxDisplay}}
                         </span>
                 </label>
             </li>
@@ -201,7 +201,7 @@ export default {
             })
         },
         getImpactByVisitorsPerDay () {
-            return this.getImpactByVisitor() / this.view.runtime
+            return Math.floor(this.getImpactByVisitor() / this.view.runtime);
         },
         updateData () {
             this.impactByMetricValue = this.getImpactByMetric();

--- a/src/components/pc-block-field.vue
+++ b/src/components/pc-block-field.vue
@@ -49,6 +49,12 @@ let validateFunctions = {
                     return value >= 0 && value <= 100
                 },
                 defaultVal: 80
+            },
+            days: {
+                fn (value) {
+                    return value > 0
+                },
+                defaultVal: 14
             }
         },
         gTest: {
@@ -162,10 +168,7 @@ export default {
             // try to extract numbers from it
             newValue = parseFloat(newValue);
 
-            // in case of NaN
-            if (isNaN(newValue)) {
-                newValue = 0;
-            }
+            newValue = this.validateField(newValue);
 
             return newValue
 

--- a/src/components/pc-tooltip.vue
+++ b/src/components/pc-tooltip.vue
@@ -35,9 +35,8 @@ export default {
 
 .tooltip-wrapper {
     position: absolute;
-    left: 50%;
+    left: 0;
     top: calc(100% + 10px);
-    transform: translate(-50%, 0);
     background: var(--tooltip-background-color);
     color: var(--light-gray);
     padding: 5px;
@@ -45,6 +44,7 @@ export default {
     z-index: 10;
     width: 400px;
     white-space: normal;
+    pointer-events: none;
 }
 
 .tooltip-wrapper:after {
@@ -52,7 +52,7 @@ export default {
 
     content: '';
     position: absolute;
-    left: 50%;
+    left: 50px;
     bottom: calc(100% - var(--size));
     transform: translate(-50%, 0) rotateZ(45deg);
 

--- a/src/components/svg-graph.vue
+++ b/src/components/svg-graph.vue
@@ -22,6 +22,10 @@
                 <input type="radio" class="pc-graph-radio-input" name="graph-x" value="samplePerDay-incrementalTrials" v-model="graphType">
                 <span class="pc-graph-radio-text" :class="{'pc-graph-radio-selected': graphType == 'samplePerDay-incrementalTrials'}">{{getMetricDisplayName('incrementalTrials')}} / {{getMetricDisplayName('samplePerDay')}}</span>
             </label>
+            <label class="pc-graph-radio-label">
+                <input type="radio" class="pc-graph-radio-input" name="graph-x" value="days-incrementalTrialsPerDay" v-model="graphType">
+                <span class="pc-graph-radio-text" :class="{'pc-graph-radio-selected': graphType == 'days-incrementalTrialsPerDay'}">{{getMetricDisplayName('incrementalTrialsPerDay')}} / {{getMetricDisplayName('days')}}</span>
+            </label>
         </div>
         <div class="pc-graph" ref="pc-graph-size">
             <div v-bind:style="style" ref="pc-graph-wrapper">
@@ -159,7 +163,7 @@ export default {
 
                 clonedValues = this.updateClonedValues(clonedValues, yValue);
 
-                let xValues = this.getGraphXValueForClonedValues(clonedValues);
+                let xValues = this.getGraphXValueForClonedValues(clonedValues, yValue);
 
                  newData[0][i + 1] = xValues; // x
                  newData[1][i + 1] = yValue; // line
@@ -239,6 +243,9 @@ export default {
 
                 samplePerDay: 'Daily Visitors',
                 incrementalTrials: 'Incremental Trials',
+
+                days: '# of days',
+                incrementalTrialsPerDay: 'Inc. Trials per day',
             }[metric] || ''
         }
     },
@@ -256,6 +263,9 @@ export default {
             this.updateGraphData();
         },
         graphX () {
+            this.updateGraphData();
+        },
+        runtime () {
             this.updateGraphData();
         }
     },
@@ -279,6 +289,14 @@ export default {
                 x: 'x',
                 columns: this.dataDefault,
                 type: 'line'
+            },
+            grid: {
+                x: {
+                    show: true
+                },
+                y: {
+                    show: true
+                }
             },
             axis: {
                 x: {
@@ -340,7 +358,7 @@ export default {
 
 .pc-graph-radio-label {
     position: relative;
-    font-size: 14px;
+    font-size: 13px;
     color: var(--blue);
     margin-right: 20px;
 }

--- a/src/js/graph-data-days.js
+++ b/src/js/graph-data-days.js
@@ -1,0 +1,17 @@
+export default {
+    getGraphXTicksFormatted (x) {
+        let { displayValue } = this,
+            samplePerDay = this.sample / this.runtime,
+            result = x / samplePerDay;
+        result = displayValue('sample', result)
+        if (result >= 1000) {
+            result = window.parseInt(result / 1000) + 'k'
+        }
+
+        return result
+    },
+    getGraphXValueForClonedValues (clonedValues) {
+        let graphX = 'sample';
+        return this.displayValue(graphX, (this.math[graphX](clonedValues)));
+    }
+};

--- a/src/js/graph-data-incremental-trials-per-day.js
+++ b/src/js/graph-data-incremental-trials-per-day.js
@@ -1,0 +1,61 @@
+import statFormulas from '../js/math.js'
+
+export default {
+    getGraphYTicks () {
+        let impact = this.impact,
+            arr = [impact/4, impact/2, impact, impact*2, impact*4];
+
+        return arr
+    },
+    getGraphYTicksFormatted (y) {
+        let sample = this.sample,
+            base = this.base,
+
+            result = statFormulas.getAbsoluteImpactInVisitors({
+                total_sample_size: this.extractValue('sample', sample / this.runtime),
+                base_rate: this.extractValue('base', base),
+                effect_size: this.extractValue('impact', y)
+            });
+
+        return this.displayValue('impactByVisitors', result);
+    },
+    updateClonedValues (clonedObj, value) {
+        clonedObj.effect_size = this.extractValue('impact', value);;
+
+        return clonedObj;
+    },
+    getCurrentYValue () {
+        return this.impact
+    },
+    getGraphXTicksFormatted (x) {
+        let { displayValue } = this,
+            result = x;
+
+        result = result
+        result += '%';
+
+        return result
+    },
+    getGraphXTicksFormatted (x) {
+        let { displayValue } = this,
+            result = x / this.runtime;
+
+        result = displayValue('impactByVisitors', result)
+        if (result >= 1000) {
+            result = window.parseInt(result / 1000) + 'k'
+        }
+
+        return result
+    },
+    getGraphXValueForClonedValues (clonedValues) {
+        let {total_sample_size, base_rate, effect_size} = clonedValues,
+
+            impactByVisitor = statFormulas.getAbsoluteImpactInVisitors({
+                total_sample_size,
+                base_rate,
+                effect_size,
+            });
+
+        return this.displayValue('impactByVisitors', impactByVisitor);
+    }
+};

--- a/src/js/graph-data-mixin.js
+++ b/src/js/graph-data-mixin.js
@@ -2,9 +2,12 @@
 
 import _impact from './graph-data-impact.js'
 import _incrementalTrials from './graph-data-incremental-trials.js'
+import _incrementalTrialsPerDay from './graph-data-incremental-trials-per-day.js'
+import _days from './graph-data-days.js'
 import _sample from './graph-data-sample.js'
 import _samplePerDay from './graph-data-sample-per-day.js'
 import _power from './graph-data-power.js'
+
 
 var defaultConfig = {
     getGraphYTicks () {
@@ -21,17 +24,16 @@ var defaultConfig = {
             ratio = (lastTick - firstTick) / amount,
             result = Array.from(new Array(amount));
 
-        result[0] = firstTick;
-
-        result = result.map((cur, i) => {
-            return cur ? cur : ratio * i
+        result = result.map((cur, i, arr) => {
+            let value = firstTick + ratio * i;
+            return value
         })
 
         // add the current value in case it isn't there
         result.push(curYValue);
 
         // sort current value
-        result.sort((a,b) => { return a > b});
+        result.sort((a,b) => { return a - b});
 
         // remove duplicates
         result = [...new Set(result)]
@@ -63,11 +65,13 @@ export default {
         // this is done to agregate different pieces of configuration that need to work in harmony
         // for the svg graph
         Object.assign(this, {
-            _sample:            Object.assign({}, defaultConfig, _sample),
-            _samplePerDay:      Object.assign({}, defaultConfig, _samplePerDay),
-            _impact:            Object.assign({}, defaultConfig, _impact),
-            _incrementalTrials: Object.assign({}, defaultConfig, _incrementalTrials),
-            _power:             Object.assign({}, defaultConfig, _power),
+            _sample:                    Object.assign({}, defaultConfig, _sample),
+            _samplePerDay:              Object.assign({}, defaultConfig, _samplePerDay),
+            _impact:                    Object.assign({}, defaultConfig, _impact),
+            _incrementalTrials:         Object.assign({}, defaultConfig, _incrementalTrials),
+            _power:                     Object.assign({}, defaultConfig, _power),
+            _incrementalTrialsPerDay:   Object.assign({}, defaultConfig, _incrementalTrialsPerDay),
+            _days:                      Object.assign({}, defaultConfig, _days),
         })
     },
     methods: {

--- a/src/js/value-transformation-mixin.js
+++ b/src/js/value-transformation-mixin.js
@@ -7,6 +7,7 @@ export default {
                 tTest: {type: 'float'}
             },
             impact: {type: 'percentage'},
+            runtime: {type: 'int'},
             power: {type: 'percentage'},
             falsePosRate: {type: 'percentage'},
             impactByMetricValue: {type: 'percentage'},

--- a/src/powercalculator.vue
+++ b/src/powercalculator.vue
@@ -72,8 +72,10 @@
 
                 <sample-comp
                     fieldfromblock="sample"
+                    v-bind:testtype="testType"
                     v-bind:sample="view.sample"
                     v-bind:runtime.sync="view.runtime"
+                    v-bind:lockedfield.sync="lockedField"
                     v-bind:calculateprop="calculateProp"
                     v-bind:enableedit="enabledMainInputs.sample"
                     v-bind:isblockfocused="focusedBlock == 'sample'"
@@ -147,6 +149,9 @@ export default {
                 runtime: 14 //days
             },
 
+            // this is used for sample size but we also want to make it shareable
+            lockedField: 'days',
+
             // false means the editable ones are the secondary mode (metric totals, days&daily trials and absolute impact)
             enabledMainInputs: {
                 base: true,
@@ -175,6 +180,7 @@ export default {
                     testType: this.testType,
                     calculateProp: this.calculateProp,
                     view: this.view,
+                    lockedField: this.lockedField,
                 };
             return JSON.parse(JSON.stringify(result))
         }


### PR DESCRIPTION
New version of power calculator and change in rollup vue-loader config to remove the multiple line breaks from css and add the name of the .vue file where the style below is.

Power Calculator 1.1.1:
    Improvements:
    - Daily visitors or number of days when calculating sample will not change total anymore, will change one or the other only.
    - Making lockField available in root. this way we can emit this data along with other metric to application
    - Disable day or disabled daily visitors field more visible
    - Adding base to absolute impact small copy.
    - User feedback shows people want to type daily visitors and then change other values to find out what are the number of days the experiment needs to run
    
    Bugfixes:
    - Runtime was set in 2 different places where the parent component should also define the value of the child component in creation
    - Fix a problem where the change of days was not updating the application data runtime. this was causing incremental trials per day to be wrong
    - Fixing logic to create data sets
    - Graph inc trials per day fixed
    - Fixed behavior of sample component when both calculated or not calculated
    - Adjusting test type tooltips


