### PR TITLE
Exposing non inferiority data to external application

### DIFF
--- a/dist/powercalculator.js
+++ b/dist/powercalculator.js
@@ -5518,7 +5518,7 @@ var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c
     },
     methods: {
         getDefaultGraphOption () {
-            if (this.isNonInferiorityEnabled) {
+            if (this.nonInferiority.enabled) {
                 return 'sample-power'
             } else {
                 return 'days-incrementalTrialsPerDay'
@@ -6803,6 +6803,7 @@ var powerCalculator$1 = {render: function(){var _vm=this;var _h=_vm.$createEleme
                     calculateProp: this.calculateProp,
                     view: this.view,
                     lockedField: this.lockedField,
+                    nonInferiority: this.nonInferiority
                 };
             return JSON.parse(JSON.stringify(result))
         },

--- a/src/components/svg-graph.vue
+++ b/src/components/svg-graph.vue
@@ -103,7 +103,7 @@ export default {
     },
     methods: {
         getDefaultGraphOption () {
-            if (this.isNonInferiorityEnabled) {
+            if (this.nonInferiority.enabled) {
                 return 'sample-power'
             } else {
                 return 'days-incrementalTrialsPerDay'

--- a/src/powercalculator.vue
+++ b/src/powercalculator.vue
@@ -214,6 +214,7 @@ export default {
                     calculateProp: this.calculateProp,
                     view: this.view,
                     lockedField: this.lockedField,
+                    nonInferiority: this.nonInferiority
                 };
             return JSON.parse(JSON.stringify(result))
         },


### PR DESCRIPTION
Exposing non inferiority data to external application along with the other elements.

bugfix:

When the wrapper application set the data to non inferiority the first graph wasn't being selected properly