### PR TITLE
We are replacing impact block with non inferiority when that's the case.

### DIFF
--- a/dist/powercalculator.css
+++ b/dist/powercalculator.css
@@ -328,6 +328,7 @@
     grid-template-rows: auto;
     grid-template-areas:
         "pc-input-left pc-input-right"
+        "pc-input-left-bottom pc-input-right-bottom"
     ;
     align-items: start;
     grid-gap: var(--row-gap) var(--columns-gap);
@@ -354,6 +355,12 @@
 }
 .pc-input-right {
     grid-area: pc-input-right;
+}
+.pc-input-left-bottom {
+    grid-area: pc-input-left-bottom;
+}
+.pc-input-right-bottom {
+    grid-area: pc-input-right-bottom;
 }
 .pc-input-details {
     font-size: 10px;
@@ -383,12 +390,7 @@
 
 /* components/impact-comp.vue */
 
-.pc-inputs {
-    grid-template-areas:
-        "pc-input-left pc-input-right"
-    ;
-}
-
+/*# sourceMappingURL=impact-comp.vue.map */
 
 /* components/base-comp.vue */
 
@@ -455,5 +457,48 @@
 }
 .pc-non-inf-treshold-input {
     margin-left: 5px;
+}
+
+
+/* components/non-inferiority-comp.vue */
+
+.pc-non-inf-select {
+    --base-padding: 5px;
+    font-size: inherit;
+    line-height: 28px;
+    border: none;
+    display: block;
+    position: relative;
+    box-sizing: border-box;
+    width: 100%;
+    filter: drop-shadow(0 4px 2px rgba(0,0,0,0.1));
+    border-radius: 5px;
+    background: var(--white);
+    padding: var(--base-padding);
+    overflow: hidden;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+.pc-non-inf-select:focus {
+    outline: 0;
+    box-shadow: inset 0 0 0 1px var(--dark-blue);
+}
+.pc-non-inf-select-wrapper {
+    position: relative;
+}
+.pc-non-inf-select-wrapper:after {
+    --border-size: 7px;
+    content: '';
+    position: absolute;
+    right: 5px;
+    bottom: 0;
+    pointer-events: none;
+    border: var(--border-size) solid transparent;
+    border-top: var(--border-size) solid var(--gray);
+    transform: translateY(calc(-50% - var(--border-size)/2));
+}
+.no-sub-title {
+    margin: 15px 0 10px 0;
 }
 

--- a/dist/powercalculator.js
+++ b/dist/powercalculator.js
@@ -4713,7 +4713,6 @@ jStat.models = (function(){
 });
 });
 
-// SOLVING FOR POWER
 function solveforpower_Gtest ({total_sample_size, base_rate, effect_size, alpha, alternative, mu}) {
     var sample_size = total_sample_size/2;
 
@@ -6217,20 +6216,10 @@ var pcTooltip = {render: function(){var _vm=this;var _h=_vm.$createElement;var _
 
 };
 
-var nonInferiority = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-non-inferiority"},[_c('label',{staticClass:"pc-non-inf-label"},[_vm._v(" Use non inferiority test "),_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.enabled),expression:"enabled"}],attrs:{"type":"checkbox"},domProps:{"checked":Array.isArray(_vm.enabled)?_vm._i(_vm.enabled,null)>-1:(_vm.enabled)},on:{"change":function($event){var $$a=_vm.enabled,$$el=$event.target,$$c=$$el.checked?(true):(false);if(Array.isArray($$a)){var $$v=null,$$i=_vm._i($$a,$$v);if($$el.checked){$$i<0&&(_vm.enabled=$$a.concat([$$v]));}else{$$i>-1&&(_vm.enabled=$$a.slice(0,$$i).concat($$a.slice($$i+1)));}}else{_vm.enabled=$$c;}}}})]),_vm._v(" "),(_vm.enabled)?_c('div',{staticClass:"pc-non-inf-treshold"},[_c('select',{directives:[{name:"model",rawName:"v-model",value:(_vm.selected),expression:"selected"}],staticClass:"pc-non-inf-select",on:{"change":function($event){var $$selectedVal = Array.prototype.filter.call($event.target.options,function(o){return o.selected}).map(function(o){var val = "_value" in o ? o._value : o.value;return val}); _vm.selected=$event.target.multiple ? $$selectedVal : $$selectedVal[0];}}},_vm._l((_vm.options),function(option,index){return _c('option',{key:index,domProps:{"value":option.value}},[_vm._v(" "+_vm._s(option.text)+" ")])})),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-non-inf-treshold-input",attrs:{"fieldProp":"threshold","suffix":_vm.isRelative ? '%' : '',"fieldValue":_vm.nonInfThreshold,"enableEdit":true}})],1):_vm._e()])},staticRenderFns: [],
-    props: [ 'lockedField', 'readOnlyVisitorsPerDay' ],
+var nonInferiority = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-non-inferiority"},[_c('label',{staticClass:"pc-non-inf-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.enabled),expression:"enabled"}],attrs:{"type":"checkbox"},domProps:{"checked":Array.isArray(_vm.enabled)?_vm._i(_vm.enabled,null)>-1:(_vm.enabled)},on:{"change":function($event){var $$a=_vm.enabled,$$el=$event.target,$$c=$$el.checked?(true):(false);if(Array.isArray($$a)){var $$v=null,$$i=_vm._i($$a,$$v);if($$el.checked){$$i<0&&(_vm.enabled=$$a.concat([$$v]));}else{$$i>-1&&(_vm.enabled=$$a.slice(0,$$i).concat($$a.slice($$i+1)));}}else{_vm.enabled=$$c;}}}}),_vm._v(" Use non inferiority test ")])])},staticRenderFns: [],
+    props: [ 'lockedField' ],
     data () {
         return {
-            options: [
-                {
-                    text: 'relative difference of',
-                    value: 'relative'
-                },
-                {
-                    text: 'absolute impact per day of',
-                    value: 'absolutePerDay'
-                }
-            ]
         }
     },
     computed: {
@@ -6245,6 +6234,44 @@ var nonInferiority = {render: function(){var _vm=this;var _h=_vm.$createElement;
                 });
             }
         },
+        isRelative () {
+            return this.$store.state.nonInferiority.selected == 'relative'
+        }
+    }
+};
+
+var nonInferiorityComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--noninferiority",class:{'pc-block-focused': _vm.focusedblock == 'noninferiority'}},[_c('pc-svg-chain',{attrs:{"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Non Inferiority ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Acceptable Cost "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v(" "+_vm._s(_vm.isRelative ? 'relative difference of' : 'absolute impact per day of')+" ")])]),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"threshold","suffix":_vm.isRelative ? '%' : '',"fieldValue":_vm.threshold,"fieldFromBlock":_vm.fieldFromBlock,"isBlockFocused":_vm.isBlockFocused,"isReadOnly":_vm.isReadOnly,"enableEdit":true},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v(" Type "+_vm._s(_vm.isRelative ? '' : '(per day)')+" "),_c('small',{staticClass:"pc-input-sub-title"})]),_vm._v(" "),_c('div',{staticClass:"pc-non-inf-select-wrapper"},[_c('select',{directives:[{name:"model",rawName:"v-model",value:(_vm.selected),expression:"selected"}],staticClass:"pc-non-inf-select",on:{"change":function($event){var $$selectedVal = Array.prototype.filter.call($event.target.options,function(o){return o.selected}).map(function(o){var val = "_value" in o ? o._value : o.value;return val}); _vm.selected=$event.target.multiple ? $$selectedVal : $$selectedVal[0];}}},_vm._l((_vm.options),function(option,index){return _c('option',{key:index,domProps:{"value":option.value}},[_vm._v(" "+_vm._s(option.text)+" ")])}))])])]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-left-bottom"},[_c('label',[_vm._m(0),_vm._v(" "),_c('div',{staticClass:"pc-non-inf-select-wrapper"},[_c('select',{directives:[{name:"model",rawName:"v-model",value:(_vm.expectedChange),expression:"expectedChange"}],staticClass:"pc-non-inf-select",on:{"change":function($event){var $$selectedVal = Array.prototype.filter.call($event.target.options,function(o){return o.selected}).map(function(o){var val = "_value" in o ? o._value : o.value;return val}); _vm.expectedChange=$event.target.multiple ? $$selectedVal : $$selectedVal[0];}}},[_c('option',{attrs:{"value":"nochange"}},[_vm._v(" No Change ")]),_vm._v(" "),_c('option',{attrs:{"value":"degradation"}},[_vm._v(" Degradation ")]),_vm._v(" "),_c('option',{attrs:{"value":"improvement"}},[_vm._v(" Improvement ")])])])])])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title no-sub-title"},[_vm._v(" Expected Change "),_c('small',{staticClass:"pc-input-sub-title"})])}],
+    props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused'],
+    extends: pcBlock,
+    template: '#base-comp',
+    data () {
+        return {
+            focusedBlock: '',
+            options: [
+                {
+                    text: 'relative',
+                    value: 'relative'
+                },
+                {
+                    text: 'absolute',
+                    value: 'absolutePerDay'
+                }
+            ]
+        }
+    },
+    computed: {
+        isReadOnly () {
+            return this.calculateProp == 'base'
+        },
+        enabled () {
+            return this.$store.state.nonInferiority.enabled
+        },
+        threshold () {
+            return this.$store.state.nonInferiority.threshold
+        },
+        isRelative () {
+            return this.$store.state.nonInferiority.selected == 'relative'
+        },
         selected: {
             get () {
                 return this.$store.state.nonInferiority.selected
@@ -6256,20 +6283,39 @@ var nonInferiority = {render: function(){var _vm=this;var _h=_vm.$createElement;
                 });
             }
         },
-
-        isRelative () {
-            return this.$store.state.nonInferiority.selected == 'relative'
+        expectedChange: {
+            get () {
+                return this.$store.state.nonInferiority.expectedChange
+            },
+            set (newValue) {
+                this.$store.dispatch('field:change', {
+                    prop: 'expectedChange',
+                    value: newValue
+                });
+            }
         },
-        nonInfThreshold () {
-            return this.$store.state.nonInferiority.threshold
-        }
     },
-    components: {
-        'pc-block-field': pcBlockField,
+    methods: {
+        enableInput () {
+            this.$emit('edit:update', {prop: 'base'});
+        },
+        updateFocus ({fieldProp, value}) {
+            if (this.focusedBlock == fieldProp && value === false) {
+                this.focusedBlock = '';
+            } else if (value === true) {
+                this.focusedBlock = fieldProp;
+            }
+
+            this.$emit('update:focus', {
+                fieldProp: this.fieldFromBlock,
+                value: value
+            });
+        }
+
     }
 };
 
-var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"power-calculator"},[_c('form',{staticClass:"pc-form",attrs:{"action":"."}},[_c('div',{staticClass:"pc-main-header"},[_c('div',{staticClass:"pc-test-type"},[_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"gTest","checked":"checked"},domProps:{"checked":_vm._q(_vm.testType,"gTest")},on:{"change":function($event){_vm.testType="gTest";}}}),_vm._v(" Binary Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A binary metric is one that can be only two values like 0 or 1, yes or no, converted or not converted ")])]),_vm._v(" "),_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"tTest"},domProps:{"checked":_vm._q(_vm.testType,"tTest")},on:{"change":function($event){_vm.testType="tTest";}}}),_vm._v(" Continuous Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A continuous metric is one that can be any number like time on site or the number of rooms sold ")])])],1),_vm._v(" "),_c('non-inferiority',{attrs:{"readOnlyVisitorsPerDay":_vm.readOnlyVisitorsPerDay,"view":_vm.view,"extractValue":_vm.extractValue}}),_vm._v(" "),_vm._m(0),_vm._v(" "),_c('label',{staticClass:"pc-false-positive"},[_c('pc-block-field',{staticClass:"pc-false-positive-input",class:{ 'pc-top-fields-error': _vm.falsePosRate > 10 },attrs:{"suffix":"%","fieldProp":"falsePosRate","fieldValue":_vm.falsePosRate,"enableEdit":true}}),_vm._v(" false positive rate ")],1),_vm._v(" "),_c('label',{staticClass:"pc-power"},[_c('pc-block-field',{staticClass:"pc-power-input",class:{ 'pc-top-fields-error': _vm.power < 80 },attrs:{"suffix":"%","fieldProp":"power","fieldValue":_vm.power,"enableEdit":true}}),_vm._v(" power ")],1)],1),_vm._v(" "),_c('div',{staticClass:"pc-blocks-wrapper",class:{'pc-blocks-wrapper-ttest': _vm.testType == 'tTest'}},[_c('base-comp',{attrs:{"fieldFromBlock":"base","isBlockFocused":_vm.focusedBlock == 'base',"enableEdit":_vm.enabledMainInputs.base},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('sample-comp',{attrs:{"fieldFromBlock":"sample","enableEdit":_vm.enabledMainInputs.sample,"isBlockFocused":_vm.focusedBlock == 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('impact-comp',{attrs:{"fieldFromBlock":"impact","enableEdit":_vm.enabledMainInputs.impact,"isBlockFocused":_vm.focusedBlock == 'impact'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('svg-graph')],1)])])},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-title"},[_vm._v("Power Calculator "),_c('sup',{staticStyle:{"color":"#F00","font-size":"11px"}},[_vm._v("BETA")])])}],
+var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"power-calculator"},[_c('form',{staticClass:"pc-form",attrs:{"action":"."}},[_c('div',{staticClass:"pc-main-header"},[_c('div',{staticClass:"pc-test-type"},[_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"gTest","checked":"checked"},domProps:{"checked":_vm._q(_vm.testType,"gTest")},on:{"change":function($event){_vm.testType="gTest";}}}),_vm._v(" Binary Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A binary metric is one that can be only two values like 0 or 1, yes or no, converted or not converted ")])]),_vm._v(" "),_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"tTest"},domProps:{"checked":_vm._q(_vm.testType,"tTest")},on:{"change":function($event){_vm.testType="tTest";}}}),_vm._v(" Continuous Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A continuous metric is one that can be any number like time on site or the number of rooms sold ")])])],1),_vm._v(" "),_c('non-inferiority'),_vm._v(" "),_vm._m(0),_vm._v(" "),_c('label',{staticClass:"pc-false-positive"},[_c('pc-block-field',{staticClass:"pc-false-positive-input",class:{ 'pc-top-fields-error': _vm.falsePosRate > 10 },attrs:{"suffix":"%","fieldProp":"falsePosRate","fieldValue":_vm.falsePosRate,"enableEdit":true}}),_vm._v(" false positive rate ")],1),_vm._v(" "),_c('label',{staticClass:"pc-power"},[_c('pc-block-field',{staticClass:"pc-power-input",class:{ 'pc-top-fields-error': _vm.power < 80 },attrs:{"suffix":"%","fieldProp":"power","fieldValue":_vm.power,"enableEdit":true}}),_vm._v(" power ")],1)],1),_vm._v(" "),_c('div',{staticClass:"pc-blocks-wrapper",class:{'pc-blocks-wrapper-ttest': _vm.testType == 'tTest'}},[_c('base-comp',{attrs:{"fieldFromBlock":"base","isBlockFocused":_vm.focusedBlock == 'base',"enableEdit":_vm.enabledMainInputs.base},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('sample-comp',{attrs:{"fieldFromBlock":"sample","enableEdit":_vm.enabledMainInputs.sample,"isBlockFocused":_vm.focusedBlock == 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),(!_vm.nonInferiorityEnabled)?_c('impact-comp',{attrs:{"fieldFromBlock":"impact","enableEdit":_vm.enabledMainInputs.impact,"isBlockFocused":_vm.focusedBlock == 'impact'},on:{"update:focus":_vm.updateFocus}}):_vm._e(),_vm._v(" "),(_vm.nonInferiorityEnabled)?_c('non-inferiority-comp',{attrs:{"fieldFromBlock":"non-inferiority","enableEdit":_vm.enabledMainInputs['non-inferiority'],"isBlockFocused":_vm.focusedBlock == 'non-inferiority'},on:{"update:focus":_vm.updateFocus}}):_vm._e(),_vm._v(" "),_c('svg-graph')],1)])])},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-title"},[_vm._v("Power Calculator "),_c('sup',{staticStyle:{"color":"#F00","font-size":"11px"}},[_vm._v("BETA")])])}],
     mounted () {
         // start of application
         this.$store.dispatch('init:calculator');
@@ -6287,9 +6333,9 @@ var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement
                 base: true,
                 sample: true,
                 impact: true,
-                power: true
-            },
-            readOnlyVisitorsPerDay: 0
+                power: true,
+                'non-inferiority': true
+            }
         };
 
         // mergeComponentData has no array support for now
@@ -6316,11 +6362,11 @@ var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement
         },
 
         nonInferiorityEnabled () {
-            return this.nonInferiority.enabled;
+            return this.$store.state.nonInferiority.enabled
         },
 
         nonInferioritySelected () {
-            return this.nonInferiority.selected;
+            return this.$store.state.nonInferiority.selected
         },
 
         falsePosRate () {
@@ -6384,7 +6430,8 @@ var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement
         'sample-comp': sampleComp,
         'impact-comp' : impactComp,
         'base-comp': baseComp,
-        'non-inferiority': nonInferiority
+        'non-inferiority': nonInferiority,
+        'non-inferiority-comp': nonInferiorityComp
 
     }
 };
@@ -6396,6 +6443,15 @@ var actions = {
         switch (prop) {
 
             // these 3 cases will call the same extra action
+            case 'base':
+                context.commit('field:change', { prop, value });
+                if (context.state.nonInferiority.enabled === true && context.state.nonInferiority.selected == 'absolutePerDay') {
+                    context.dispatch('change:noninferiorityimpact');
+                }
+
+                context.dispatch('update:proptocalculate', context.getters.calculatedValues);
+            break;
+
             case 'sample':
             case 'runtime':
             case 'visitorsPerDay':
@@ -6405,10 +6461,16 @@ var actions = {
 
             case 'threshold':
                 context.dispatch('threshold:sideeffect', {prop, value});
+                context.dispatch('change:noninferiorityimpact');
             break;
 
             case 'impactByMetricValue':
                 context.dispatch('convert:absoluteimpact', {prop, value});
+            break;
+
+            case 'expectedChange':
+                context.commit('field:change', { prop, value });
+                context.dispatch('change:noninferiorityimpact');
             break;
 
             case 'visitorsWithGoals':
@@ -6426,17 +6488,23 @@ var actions = {
     'change:noninferiority' (context, { prop, value }) {
         // add validations necessary here
         context.commit('change:noninferiority', { prop, value });
+        context.dispatch('change:noninferiorityimpact');
 
         if (prop == 'enabled') {
 
-            context.dispatch('change:noninferiorityimpact');
+            if (value === true) {
+                context.dispatch('field:change', {
+                    prop: 'lockedField',
+                    value: 'days'
+                });
+            }
         } else {
             // update values based on nonInferiority.selected
             context.dispatch('update:proptocalculate', context.getters.calculatedValues);
         }
     },
     'change:noninferiorityimpact' (context) {
-        let impactValue = 0;
+        let impactValue = context.getters.nonInferiorityImpact;
 
         if (context.state.nonInferiority.enabled === true) {
             this.__impactBackup = context.state.attributes.impact;
@@ -6451,6 +6519,11 @@ var actions = {
     },
     'switch:lockedfield' (context) {
         let newLockedField = context.state.attributes.lockedField == 'days' ? 'visitorsPerDay' : 'days';
+
+        if (context.state.nonInferiority.enabled === true) {
+            newLockedField = 'days';
+        }
+
         context.commit('switch:lockedfield', {
             value: newLockedField
         });
@@ -6706,7 +6779,8 @@ var nonInferiority$1 = {
     state:{
         threshold: 0,
         selected: 'relative', // relative, absolutePerDay
-        enabled: false
+        enabled: false,
+        expectedChange: 'nochange' // nochange, degradation, improvement
     },
     mutations: {
         'field:change' (state, { prop, value }) {
@@ -6727,6 +6801,32 @@ var nonInferiority$1 = {
         }
     },
     getters: {
+        nonInferiorityImpact (state, getters, rootState) {
+            let { expectedChange, threshold, selected } = state,
+                newImpact = 0,
+                visitorsPerDay = rootState.attributes.visitorsPerDay,
+                base = getters.extractValue('base', rootState.attributes.base);
+
+            if (selected == 'absolutePerDay') {
+                threshold = threshold/(base*visitorsPerDay)*100;
+            }
+            switch (expectedChange) {
+                case 'nochange':
+                default:
+                    // zero
+                break;
+
+                case 'degradation':
+                    newImpact = -threshold/2;
+                break;
+
+                case 'improvement':
+                    newImpact = threshold;
+                break;
+            }
+
+            return newImpact
+        },
         mu (state, getters) {
             let mu = 0;
 

--- a/src/components/impact-comp.vue
+++ b/src/components/impact-comp.vue
@@ -176,10 +176,5 @@ export default {
 </script>
 
 <style>
-.pc-inputs {
-    grid-template-areas:
-        "pc-input-left pc-input-right"
-    ;
-}
 
 </style>

--- a/src/components/non-inferiority-comp.vue
+++ b/src/components/non-inferiority-comp.vue
@@ -1,0 +1,209 @@
+<template id="noninferiority-comp">
+    <div class="pc-block pc-block--noninferiority" :class="{'pc-block-focused': focusedblock == 'noninferiority'}">
+
+        <pc-svg-chain v-bind:fieldFromBlock="fieldFromBlock"></pc-svg-chain>
+
+        <div class="pc-header">
+            Non Inferiority
+        </div>
+
+        <ul class="pc-inputs">
+            <li class="pc-input-item pc-input-left">
+                <label>
+                    <span class="pc-input-title">Acceptable Cost
+                        <small class="pc-input-sub-title">
+                            {{isRelative ?
+                                'relative difference of' :
+                                'absolute impact per day of'
+                            }}
+                        </small>
+                    </span>
+
+                    <pc-block-field
+                        fieldProp="threshold"
+                        :suffix="isRelative ? '%' : ''"
+
+                        v-bind:fieldValue="threshold"
+                        v-bind:fieldFromBlock="fieldFromBlock"
+                        v-bind:isBlockFocused="isBlockFocused"
+                        v-bind:isReadOnly="isReadOnly"
+                        v-bind:enableEdit="true"
+
+                        v-on:update:focus="updateFocus"></pc-block-field>
+                </label>
+            </li>
+
+            <li class="pc-input-item pc-input-right">
+                <label>
+                    <span class="pc-input-title">
+                        Type {{ isRelative ?
+                                '' :
+                                '(per day)'
+                            }}
+                        <small class="pc-input-sub-title">
+                        </small>
+                    </span>
+
+                    <div class="pc-non-inf-select-wrapper">
+                        <select v-model="selected" class="pc-non-inf-select">
+                            <option v-for="(option, index) in options" v-bind:key="index" v-bind:value="option.value">
+                                {{option.text}}
+                            </option>
+                        </select>
+                    </div>
+                </label>
+            </li>
+
+            <li class="pc-input-item pc-input-left-bottom">
+                <label>
+                    <span class="pc-input-title no-sub-title">
+                            Expected Change
+                        <small class="pc-input-sub-title">
+
+                        </small>
+                    </span>
+
+                    <div class="pc-non-inf-select-wrapper">
+                        <select v-model="expectedChange" class="pc-non-inf-select">
+                            <option value="nochange">
+                                No Change
+                            </option>
+                            <option value="degradation">
+                                Degradation
+                            </option>
+                            <option value="improvement">
+                                Improvement
+                            </option>
+                        </select>
+                    </div>
+                </label>
+            </li>
+        </ul>
+    </div>
+</template>
+
+<script>
+import pcBlock from './pc-block.vue'
+
+export default {
+    props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused'],
+    extends: pcBlock,
+    template: '#base-comp',
+    data () {
+        return {
+            focusedBlock: '',
+            options: [
+                {
+                    text: 'relative',
+                    value: 'relative'
+                },
+                {
+                    text: 'absolute',
+                    value: 'absolutePerDay'
+                }
+            ]
+        }
+    },
+    computed: {
+        isReadOnly () {
+            return this.calculateProp == 'base'
+        },
+        enabled () {
+            return this.$store.state.nonInferiority.enabled
+        },
+        threshold () {
+            return this.$store.state.nonInferiority.threshold
+        },
+        isRelative () {
+            return this.$store.state.nonInferiority.selected == 'relative'
+        },
+        selected: {
+            get () {
+                return this.$store.state.nonInferiority.selected
+            },
+            set (newValue) {
+                this.$store.dispatch('change:noninferiority', {
+                    prop: 'selected',
+                    value: newValue
+                })
+            }
+        },
+        expectedChange: {
+            get () {
+                return this.$store.state.nonInferiority.expectedChange
+            },
+            set (newValue) {
+                this.$store.dispatch('field:change', {
+                    prop: 'expectedChange',
+                    value: newValue
+                })
+            }
+        },
+    },
+    methods: {
+        enableInput () {
+            this.$emit('edit:update', {prop: 'base'})
+        },
+        updateFocus ({fieldProp, value}) {
+            if (this.focusedBlock == fieldProp && value === false) {
+                this.focusedBlock = ''
+            } else if (value === true) {
+                this.focusedBlock = fieldProp
+            }
+
+            this.$emit('update:focus', {
+                fieldProp: this.fieldFromBlock,
+                value: value
+            })
+        }
+
+    }
+}
+</script>
+
+<style>
+.pc-non-inf-select {
+    --base-padding: 5px;
+    font-size: inherit;
+    line-height: 28px;
+    border: none;
+    display: block;
+    position: relative;
+    box-sizing: border-box;
+    width: 100%;
+    filter: drop-shadow(0 4px 2px rgba(0,0,0,0.1));
+    border-radius: 5px;
+    background: var(--white);
+    padding: var(--base-padding);
+
+    overflow: hidden;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+}
+
+.pc-non-inf-select:focus {
+    outline: 0;
+    box-shadow: inset 0 0 0 1px var(--dark-blue);
+}
+
+.pc-non-inf-select-wrapper {
+    position: relative;
+}
+
+.pc-non-inf-select-wrapper:after {
+    --border-size: 7px;
+    content: '';
+    position: absolute;
+    right: 5px;
+    bottom: 0;
+    pointer-events: none;
+    border: var(--border-size) solid transparent;
+    border-top: var(--border-size) solid var(--gray);
+    transform: translateY(calc(-50% - var(--border-size)/2));
+}
+
+.no-sub-title {
+    margin: 15px 0 10px 0;
+}
+</style>

--- a/src/components/non-inferiority.vue
+++ b/src/components/non-inferiority.vue
@@ -1,43 +1,17 @@
 <template>
     <div class="pc-non-inferiority">
         <label class="pc-non-inf-label">
-            Use non inferiority test
             <input type="checkbox" v-model="enabled">
+            Use non inferiority test
         </label>
-        <div v-if="enabled" class="pc-non-inf-treshold">
-            <select v-model="selected" class="pc-non-inf-select">
-                <option v-for="(option, index) in options" v-bind:key="index" v-bind:value="option.value">
-                    {{option.text}}
-                </option>
-            </select>
-
-            <pc-block-field
-                class="pc-non-inf-treshold-input"
-                fieldProp="threshold"
-                :suffix="isRelative ? '%' : ''"
-                v-bind:fieldValue="nonInfThreshold"
-                v-bind:enableEdit="true"></pc-block-field>
-        </div>
     </div>
 </template>
 
 <script>
-import pcBlockField from './pc-block-field.vue'
-
 export default {
-    props: [ 'lockedField', 'readOnlyVisitorsPerDay' ],
+    props: [ 'lockedField' ],
     data () {
         return {
-            options: [
-                {
-                    text: 'relative difference of',
-                    value: 'relative'
-                },
-                {
-                    text: 'absolute impact per day of',
-                    value: 'absolutePerDay'
-                }
-            ]
         }
     },
     computed: {
@@ -52,27 +26,9 @@ export default {
                 })
             }
         },
-        selected: {
-            get () {
-                return this.$store.state.nonInferiority.selected
-            },
-            set (newValue) {
-                this.$store.dispatch('change:noninferiority', {
-                    prop: 'selected',
-                    value: newValue
-                })
-            }
-        },
-
         isRelative () {
             return this.$store.state.nonInferiority.selected == 'relative'
-        },
-        nonInfThreshold () {
-            return this.$store.state.nonInferiority.threshold
         }
-    },
-    components: {
-        'pc-block-field': pcBlockField,
     }
 }
 

--- a/src/components/pc-block.vue
+++ b/src/components/pc-block.vue
@@ -80,6 +80,7 @@ export default {
     grid-template-rows: auto;
     grid-template-areas:
         "pc-input-left pc-input-right"
+        "pc-input-left-bottom pc-input-right-bottom"
     ;
     align-items: start;
     grid-gap: var(--row-gap) var(--columns-gap);
@@ -113,6 +114,14 @@ export default {
 
 .pc-input-right {
     grid-area: pc-input-right;
+}
+
+.pc-input-left-bottom {
+    grid-area: pc-input-left-bottom;
+}
+
+.pc-input-right-bottom {
+    grid-area: pc-input-right-bottom;
 }
 
 .pc-input-details {

--- a/src/powercalculator.vue
+++ b/src/powercalculator.vue
@@ -27,12 +27,7 @@
 
                 </div>
 
-                <non-inferiority
-                    v-bind:readOnlyVisitorsPerDay="readOnlyVisitorsPerDay"
-
-                    v-bind:view="view"
-                    v-bind:extractValue="extractValue">
-                </non-inferiority>
+                <non-inferiority></non-inferiority>
 
 
                 <div class="pc-title">Power Calculator <sup style="color: #F00; font-size: 11px;">BETA</sup> </div>
@@ -81,12 +76,22 @@
                 </sample-comp>
 
                 <impact-comp
+                    v-if="!nonInferiorityEnabled"
                     fieldFromBlock="impact"
 
                     v-bind:enableEdit="enabledMainInputs.impact"
                     v-bind:isBlockFocused="focusedBlock == 'impact'"
                     v-on:update:focus="updateFocus">
                 </impact-comp>
+
+                <non-inferiority-comp
+                    v-if="nonInferiorityEnabled"
+                    fieldFromBlock="non-inferiority"
+
+                    v-bind:enableEdit="enabledMainInputs['non-inferiority']"
+                    v-bind:isBlockFocused="focusedBlock == 'non-inferiority'"
+                    v-on:update:focus="updateFocus">
+                </non-inferiority-comp>
 
                 <svg-graph></svg-graph>
 
@@ -103,6 +108,7 @@ import impactComp from './components/impact-comp.vue'
 import baseComp from './components/base-comp.vue'
 import pcTooltip from './components/pc-tooltip.vue'
 import nonInferiority from './components/non-inferiority.vue'
+import nonInferiorityComp from './components/non-inferiority-comp.vue'
 
 export default {
     mounted () {
@@ -122,9 +128,9 @@ export default {
                 base: true,
                 sample: true,
                 impact: true,
-                power: true
-            },
-            readOnlyVisitorsPerDay: 0
+                power: true,
+                'non-inferiority': true
+            }
         };
 
         // mergeComponentData has no array support for now
@@ -151,11 +157,11 @@ export default {
         },
 
         nonInferiorityEnabled () {
-            return this.nonInferiority.enabled;
+            return this.$store.state.nonInferiority.enabled
         },
 
         nonInferioritySelected () {
-            return this.nonInferiority.selected;
+            return this.$store.state.nonInferiority.selected
         },
 
         falsePosRate () {
@@ -219,7 +225,8 @@ export default {
         'sample-comp': sampleComp,
         'impact-comp' : impactComp,
         'base-comp': baseComp,
-        'non-inferiority': nonInferiority
+        'non-inferiority': nonInferiority,
+        'non-inferiority-comp': nonInferiorityComp
 
     }
 }

--- a/src/store/modules/non-inferiority.js
+++ b/src/store/modules/non-inferiority.js
@@ -4,7 +4,8 @@ export default {
     state:{
         threshold: 0,
         selected: 'relative', // relative, absolutePerDay
-        enabled: false
+        enabled: false,
+        expectedChange: 'nochange' // nochange, degradation, improvement
     },
     mutations: {
         'field:change' (state, { prop, value }) {
@@ -25,6 +26,32 @@ export default {
         }
     },
     getters: {
+        nonInferiorityImpact (state, getters, rootState) {
+            let { expectedChange, threshold, selected } = state,
+                newImpact = 0,
+                visitorsPerDay = rootState.attributes.visitorsPerDay,
+                base = getters.extractValue('base', rootState.attributes.base);
+
+            if (selected == 'absolutePerDay') {
+                threshold = threshold/(base*visitorsPerDay)*100
+            }
+            switch (expectedChange) {
+                case 'nochange':
+                default:
+                    // zero
+                break;
+
+                case 'degradation':
+                    newImpact = -threshold/2;
+                break;
+
+                case 'improvement':
+                    newImpact = threshold;
+                break;
+            }
+
+            return newImpact
+        },
         mu (state, getters) {
             let mu = 0;
 

--- a/tests/store/non-inferiority-gTest-sample.js
+++ b/tests/store/non-inferiority-gTest-sample.js
@@ -28,7 +28,8 @@ function resetStore(obj = {}) {
         // non inferiority
         threshold: 0,
         selected: 'relative',
-        enabled: true
+        enabled: true,
+        expectedChange: 'nochange'
     }, obj);
 
     store.dispatch('test:reset', resetObj)
@@ -123,6 +124,17 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10);
         expect(store.getters.impactByVisitorsDisplay).toBe(0);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(0);
+
+
+        store.dispatch('change:noninferiority', {prop: 'selected', value: 'relative'});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'improvement'});
+        store.dispatch('change:noninferiority', {prop: 'selected', value: 'absolutePerDay'});
+
+        // extra tests to be sure this is updating impact correcly
+
+        // sample
+        expect(store.state.attributes.sample).toBe(65954);
+
     });
 
     test('Expected changes (none) for Relative Threshold when Runtime changes', () => {
@@ -143,8 +155,8 @@ function init () {
 
         // sample
         expect(store.state.attributes.sample).toBe(16230);
-        expect(store.state.attributes.visitorsPerDay).toBe(1082);
-        expect(store.state.attributes.runtime).toBe(15);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(1);
 
         // impact block
         expect(store.state.attributes.impact).toBe(0);
@@ -153,6 +165,66 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10);
         expect(store.getters.impactByVisitorsDisplay).toBe(0);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(0);
+    });
+
+    test('Expected changes for Relative Threshold when Expected Change degradation', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 10});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'degradation'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(10);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('relative');
+        expect(store.state.nonInferiority.expectedChange).toBe('degradation');
+        expect(store.getters.thresholdCorrectedValue).toBe(0.10);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(6346);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(63462);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(2);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(-5);
+        expect(store.getters.impactByMetricDisplay).toBe(-0.5);
+        expect(store.getters.impactByMetricMinDisplay).toBe(10.5);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(9.5);
+        expect(store.getters.impactByVisitorsDisplay).toBe(-317);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(-159);
+    });
+
+    test('Expected changes for Relative Threshold when Expected Change improvement', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 10});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'improvement'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(10);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('relative');
+        expect(store.state.nonInferiority.expectedChange).toBe('improvement');
+        expect(store.getters.thresholdCorrectedValue).toBe(0.10);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(423);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(4236);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(1);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(10);
+        expect(store.getters.impactByMetricDisplay).toBe(1);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(11);
+        expect(store.getters.impactByVisitorsDisplay).toBe(42);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(42);
     });
 
     test('Expected changes (sample) for Absolute Threshold per Day when Runtime changes', () => {
@@ -170,12 +242,12 @@ function init () {
         expect(store.getters.thresholdCorrectedValue).toBe(100);
 
         // base block
-        expect(store.getters.visitorsWithGoals).toBe(138646);
+        expect(store.getters.visitorsWithGoals).toBe(26092);
 
         // sample
-        expect(store.state.attributes.sample).toBe(1386468);
-        expect(store.state.attributes.visitorsPerDay).toBe(92431);
-        expect(store.state.attributes.runtime).toBe(15);
+        expect(store.state.attributes.sample).toBe(260928);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7);
 
         // impact block
         expect(store.state.attributes.impact).toBe(0);
@@ -205,12 +277,12 @@ function init () {
         expect(store.getters.thresholdCorrectedValue).toBe(100);
 
         // base block
-        expect(store.getters.visitorsWithGoals).toBe(138646);
+        expect(store.getters.visitorsWithGoals).toBe(26092);
 
         // sample
-        expect(store.state.attributes.sample).toBe(1386468);
-        expect(store.state.attributes.visitorsPerDay).toBe(92431);
-        expect(store.state.attributes.runtime).toBe(15);
+        expect(store.state.attributes.sample).toBe(260928);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7);
 
         // impact block
         expect(store.state.attributes.impact).toBe(0);
@@ -219,6 +291,66 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10);
         expect(store.getters.impactByVisitorsDisplay).toBe(0);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(0);
+    });
+
+    test('Expected changes (sample) for Absolute Threshold per Day when Expected Change degradation', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 100});
+        store.dispatch('change:noninferiority', {prop: 'selected', value: 'absolutePerDay'});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'degradation'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(100);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('absolutePerDay');
+        expect(store.getters.thresholdCorrectedValue).toBe(100);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(103791);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(1037914);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(26);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(-1.2469449847872711);
+        expect(store.getters.impactByMetricDisplay).toBe(-0.12);
+        expect(store.getters.impactByMetricMinDisplay).toBe(10.12);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(9.88);
+        expect(store.getters.impactByVisitorsDisplay).toBe(-1294);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(-50);
+    });
+
+    test('Expected changes (sample) for Absolute Threshold per Day when Expected Change improvement', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 100});
+        store.dispatch('change:noninferiority', {prop: 'selected', value: 'absolutePerDay'});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'improvement'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(100);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('absolutePerDay');
+        expect(store.getters.thresholdCorrectedValue).toBe(100);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(6595);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(65954);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(2);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(2.4938899695745422);
+        expect(store.getters.impactByMetricDisplay).toBe(0.25);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.75);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.25);
+        expect(store.getters.impactByVisitorsDisplay).toBe(164);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(82);
     });
 }
 

--- a/tests/store/non-inferiority-tTest-sample.js
+++ b/tests/store/non-inferiority-tTest-sample.js
@@ -28,7 +28,8 @@ function resetStore(obj = {}) {
         // non inferiority
         threshold: 0,
         selected: 'relative',
-        enabled: true
+        enabled: true,
+        expectedChange: 'nochange'
     }, obj);
 
     store.dispatch('test:reset', resetObj)
@@ -143,8 +144,8 @@ function init () {
 
         // sample
         expect(store.state.attributes.sample).toBe(1804);
-        expect(store.state.attributes.visitorsPerDay).toBe(120);
-        expect(store.state.attributes.runtime).toBe(15);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(1);
 
         // impact block
         expect(store.state.attributes.impact).toBe(0);
@@ -153,6 +154,66 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10);
         expect(store.getters.impactByVisitorsDisplay).toBe(0);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(0);
+    });
+
+    test('Expected changes for Relative Threshold when Expected Change degradation', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 10});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'degradation'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(10);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('relative');
+        expect(store.state.nonInferiority.expectedChange).toBe('degradation');
+        expect(store.getters.thresholdCorrectedValue).toBe(0.10);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(72140);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(7214);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(1);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(-5);
+        expect(store.getters.impactByMetricDisplay).toBe(-0.5);
+        expect(store.getters.impactByMetricMinDisplay).toBe(10.5);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(9.5);
+        expect(store.getters.impactByVisitorsDisplay).toBe(-3607);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(-3607);
+    });
+
+    test('Expected changes for Relative Threshold when Expected Change improvement', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 10});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'improvement'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(10);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('relative');
+        expect(store.state.nonInferiority.expectedChange).toBe('improvement');
+        expect(store.getters.thresholdCorrectedValue).toBe(0.10);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(4520);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(452);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(1);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(10);
+        expect(store.getters.impactByMetricDisplay).toBe(1);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(11);
+        expect(store.getters.impactByVisitorsDisplay).toBe(452);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(452);
     });
 
     test('Expected changes (sample) for Absolute Threshold per Day when Runtime changes', () => {
@@ -170,12 +231,12 @@ function init () {
         expect(store.getters.thresholdCorrectedValue).toBe(100);
 
         // base block
-        expect(store.getters.visitorsWithGoals).toBe(12480);
+        expect(store.getters.visitorsWithGoals).toBe(2899186140);
 
         // sample
-        expect(store.state.attributes.sample).toBe(1248);
-        expect(store.state.attributes.visitorsPerDay).toBe(83);
-        expect(store.state.attributes.runtime).toBe(15);
+        expect(store.state.attributes.sample).toBe(289918614);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7231);
 
         // impact block
         expect(store.state.attributes.impact).toBe(0);
@@ -205,12 +266,12 @@ function init () {
         expect(store.getters.thresholdCorrectedValue).toBe(100);
 
         // base block
-        expect(store.getters.visitorsWithGoals).toBe(12480);
+        expect(store.getters.visitorsWithGoals).toBe(2899186140);
 
         // sample
-        expect(store.state.attributes.sample).toBe(1248);
-        expect(store.state.attributes.visitorsPerDay).toBe(83);
-        expect(store.state.attributes.runtime).toBe(15);
+        expect(store.state.attributes.sample).toBe(289918614);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7231);
 
         // impact block
         expect(store.state.attributes.impact).toBe(0);
@@ -219,6 +280,66 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10);
         expect(store.getters.impactByVisitorsDisplay).toBe(0);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(0);
+    });
+
+    test('Expected changes (sample) for Absolute Threshold per Day when Expected Change degradation', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 100});
+        store.dispatch('change:noninferiority', {prop: 'selected', value: 'absolutePerDay'});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'degradation'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(100);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('absolutePerDay');
+        expect(store.getters.thresholdCorrectedValue).toBe(100);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(11596744520);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(1159674452);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(28922);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(-0.01246944984787271);
+        expect(store.getters.impactByMetricDisplay).toBe(-0.001246944984787271);
+        expect(store.getters.impactByMetricMinDisplay).toBe(10.001246944984787);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(9.998753055015213);
+        expect(store.getters.impactByVisitorsDisplay).toBe(-1446050);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(-50);
+    });
+
+    test('Expected changes (sample) for Absolute Threshold per Day when Expected Change improvement', () => {
+        resetStore();
+
+        store.dispatch('field:change', {prop: 'threshold', value: 100});
+        store.dispatch('change:noninferiority', {prop: 'selected', value: 'absolutePerDay'});
+        store.dispatch('field:change', {prop: 'expectedChange', value: 'improvement'});
+
+        // non inferiority
+        expect(store.state.nonInferiority.threshold).toBe(100);
+        expect(store.state.nonInferiority.enabled).toBe(true);
+        expect(store.state.nonInferiority.selected).toBe('absolutePerDay');
+        expect(store.getters.thresholdCorrectedValue).toBe(100);
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(724796540);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(72479654);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(1808);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(0.02493889969574542);
+        expect(store.getters.impactByMetricDisplay).toBe(0.002493889969574542);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.997506110030425);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.002493889969575);
+        expect(store.getters.impactByVisitorsDisplay).toBe(180756);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(99);
     });
 }
 


### PR DESCRIPTION
- Changing base change noninferiority impact only when it is absolute per day
- New tests for non inferiority new field (Expected Change) and bugfixes

Simplify selection of the effect size under the alternative

For non-inferiority testing, not only do people have to select the acceptable
cost, but they also have to specify what is the effect size under the alternative.
However, we can simplify everyone's life by breaking down what are the three
plausible scenarios under the alternative, given we already have the acceptable cost:
  - if we don't expect any change under the alternative then the effect size is
set to 0
  - if we expect a degradation then the effect size under the alternative is set
to a decrease of half of the acceptable cost
  - if we expect an improvement (but for some reason still want to perform a
non-inferiority test) then the effect size under the alternative is set to
the acceptatble cost (we hypothesize that people wouldn't care for an improvement
smaller than the acceptable cost and would in this case rather select the "no change"
case.

We also moved the acceptable cost selection to the impact box (rightmost column)
to improve the UX (no backing data on that though)