### PR TITLE
Add multi-variant calculations for even splits

### DIFF
--- a/dist/powercalculator.css
+++ b/dist/powercalculator.css
@@ -21,22 +21,47 @@
 /* layout */
 .pc-main-header {
     display: grid;
-    grid-template-columns: min-content  min-content auto min-content min-content;
+    grid-template-columns: 33.33% 33.33% 33.33%;
     grid-template-rows: auto;
     grid-template-areas:
-        "test-type calc-options title false-positive power";
+        "controls-left title controls-right";
     align-items: center;
-    margin: 25px 0 25px 10px;
+    margin: 25px 10px;
+}
+.pc-controls-left {
+    grid-area: controls-left;
+    display: grid;
+    grid-template-columns: min-content min-content min-content min-content;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "test-type traffic comparison calc-options";
+    align-items: center;
+}
+.pc-controls-right {
+    grid-area: controls-right;
+    display: grid;
+    grid-template-columns: auto min-content min-content;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "variants false-positive power";
+    align-items: center;
+    justify-items: end;
 }
 .pc-title {
     grid-area: title;
     font-size: 30px;
     text-align: center;
 }
+.pc-traffic-mode {
+    grid-area: traffic;
+}
 .pc-non-inf-label,
 .pc-test-type,
 .pc-false-positive,
-.pc-power {
+.pc-power,
+.pc-traffic-mode,
+.pc-variants,
+.pc-comparison-mode {
     font-size: 0.8em;
 }
 .pc-test-type {
@@ -45,21 +70,41 @@
 .pc-non-inferiority {
     grid-area: calc-options;
 }
+.pc-comparison-mode {
+    grid-area: comparison;
+}
+.pc-test-type-labels,
+.pc-traffic-mode-labels,
+.pc-non-inf-label,
+.pc-comparison-mode-label {
+    white-space: nowrap;
+}
+.pc-non-inferiority ,
+.pc-test-type,
+.pc-traffic-mode,
+.pc-comparison-mode {
+    margin-left: 15px;
+}
 .pc-test-type-tooltip-wrapper {
     display: inline-block;
 }
-.pc-test-type-labels {
-    margin: 0 20px;
+.pc-variants {
+    grid-area: variants;
     white-space: nowrap;
+    align-self: end;
 }
 .pc-false-positive {
     grid-area: false-positive;
+    margin-left: 15px;
     white-space: nowrap;
+    align-self: end;
 }
 .pc-power {
     grid-area: power;
-    margin-left: 10px;
+    margin-left: 15px;
+    margin-right: 15px;
     white-space: nowrap;
+    align-self: end;
 }
 .pc-blocks-wrapper {
     grid-area: pc-blocks-wrapper;
@@ -117,6 +162,87 @@
 .pc-block-to-calculate .pc-header {
     background: var(--dark-yellow);
 }
+.pc-hidden {
+    display: none!important;
+}
+
+
+/* components/pc-block-field.vue */
+
+.pc-value-field-wrapper {
+    --base-padding: 5px;
+    display: block;
+    position: relative;
+    box-sizing: border-box;
+    width: 100%;
+    filter: drop-shadow(0 4px 2px rgba(0,0,0,0.1));
+    border-radius: 5px;
+    background: var(--white);
+    padding: var(--base-padding);
+    overflow: hidden;
+}
+.pc-field--focused {
+    box-shadow: inset 0 0 0 1px var(--dark-blue);
+}
+.pc-value--formatted {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    width: 100%;
+}
+.pc-value-display {
+    box-sizing: border-box;
+    font-size: 1em;
+    line-height: 1.8em;
+    align-self: center;
+    min-height: 1em;
+    display: inline-block;
+}
+.pc-value-display:focus {
+    outline: 0;
+}
+.pc-non-inf-treshold-input,
+.pc-power-input,
+.pc-false-positive-input,
+.pc-variants-input {
+    display: inline-block;
+    vertical-align: middle;
+    padding: 4px 8px;
+    text-align: center;
+    width: 4em;
+    border: 2px solid var(--gray);
+    border-radius: 8px;
+    font-size: inherit;
+}
+.pc-variants-input {
+    width: 6.5em;
+}
+.pc-top-fields-error {
+    color: var(--red);
+}
+/* prefixes and suffixes */
+.pc-value-formatting:before {
+    color: var(--gray);
+    content: attr(data-prefix);
+}
+.pc-value-formatting:after {
+    color: var(--gray);
+    content: attr(data-suffix);
+}
+/* block to calculate override rules*/
+.pc-block-to-calculate .pc-value-field-wrapper:not(.pc-value-display) {
+    background: var(--light-yellow);
+    outline: 2px solid var(--dark-yellow);
+}
+.pc-block-to-calculate .pc-value .pc-value-formatting:before {
+    content: "=" attr(data-prefix);
+    color: var(--black);
+}
+.pc-block-to-calculate .pc-value-formatting:after {
+    color: var(--black);
+}
 
 
 /* components/svg-graph.vue */
@@ -161,14 +287,49 @@
 }
 
 
-/* components/svg-graph-tab-item.vue */
+/* components/impact-comp.vue */
 
-/*# sourceMappingURL=svg-graph-tab-item.vue.map */
+/*# sourceMappingURL=impact-comp.vue.map */
 
-/* components/pc-block-field.vue */
+/* components/pc-tooltip.vue */
 
-.pc-value-field-wrapper {
+.pc-tooltip {
+    --tooltip-background-color: var(--black);
+    position: relative;
+}
+.tooltip-wrapper {
+    position: absolute;
+    left: 0;
+    top: calc(100% + 10px);
+    background: var(--tooltip-background-color);
+    color: var(--light-gray);
+    padding: 5px;
+    border-radius: 4px;
+    z-index: 10;
+    width: 400px;
+    white-space: normal;
+    pointer-events: none;
+}
+.tooltip-wrapper:after {
+    --size: 5px;
+    content: '';
+    position: absolute;
+    left: 50px;
+    bottom: calc(100% - var(--size));
+    transform: translate(-50%, 0) rotateZ(45deg);
+    border: var(--size) solid var(--tooltip-background-color);
+    border-right-color: transparent;
+    border-bottom-color: transparent;
+}
+
+
+/* components/non-inferiority-comp.vue */
+
+.pc-non-inf-select {
     --base-padding: 5px;
+    font-size: inherit;
+    line-height: 28px;
+    border: none;
     display: block;
     position: relative;
     box-sizing: border-box;
@@ -178,64 +339,44 @@
     background: var(--white);
     padding: var(--base-padding);
     overflow: hidden;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
 }
-.pc-field--focused {
+.pc-non-inf-select:focus {
+    outline: 0;
     box-shadow: inset 0 0 0 1px var(--dark-blue);
 }
-.pc-value--formatted {
+.pc-non-inf-select-wrapper {
+    position: relative;
+}
+.pc-non-inf-select-wrapper:after {
+    --border-size: 7px;
+    content: '';
     position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
+    right: 5px;
+    bottom: 0;
     pointer-events: none;
-    width: 100%;
+    border: var(--border-size) solid transparent;
+    border-top: var(--border-size) solid var(--gray);
+    transform: translateY(calc(-50% - var(--border-size)/2));
 }
-.pc-value-display {
-    box-sizing: border-box;
-    font-size: 1em;
-    line-height: 1.8em;
-    align-self: center;
-    min-height: 1em;
-    display: inline-block;
+.no-sub-title {
+    margin: 15px 0 10px 0;
 }
-.pc-value-display:focus {
-    outline: 0;
+
+
+/* components/non-inferiority.vue */
+
+.pc-non-inf-label {
+    white-space: nowrap;
 }
-.pc-non-inf-treshold-input,
-.pc-power-input,
-.pc-false-positive-input {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 4px 8px;
-    text-align: center;
-    width: 4em;
-    border: 2px solid var(--gray);
-    border-radius: 8px;
-    font-size: inherit;
+.pc-non-inf-treshold {
+    display: flex;
+    align-items: center;
 }
-.pc-top-fields-error {
-    color: var(--red);
-}
-/* prefixes and suffixes */
-.pc-value-formatting:before {
-    color: var(--gray);
-    content: attr(data-prefix);
-}
-.pc-value-formatting:after {
-    color: var(--gray);
-    content: attr(data-suffix);
-}
-/* block to calculate override rules*/
-.pc-block-to-calculate .pc-value-field-wrapper:not(.pc-value-display) {
-    background: var(--light-yellow);
-    outline: 2px solid var(--dark-yellow);
-}
-.pc-block-to-calculate .pc-value .pc-value-formatting:before {
-    content: "=" attr(data-prefix);
-    color: var(--black);
-}
-.pc-block-to-calculate .pc-value-formatting:after {
-    color: var(--black);
+.pc-non-inf-treshold-input {
+    margin-left: 5px;
 }
 
 
@@ -269,6 +410,9 @@
 .pc-value-field--lockable.pc-value-field--locked .pc-value-field-wrapper[data-v-297fe272] {
     background: linear-gradient(0deg, var(--light-gray) 0%, var(--white) 100%);
 }
+.pc-inputs-no-grid[data-v-297fe272] {
+    display: block;
+}
 
 
 /* components/sample-comp.vue */
@@ -295,6 +439,32 @@
     color: var(--dark-gray);
 }
 
+
+/* components/base-comp.vue */
+
+.pc-input-left[data-v-0d0bef2b] {
+    position: relative;
+    z-index: 2;
+}
+
+
+/* components/base-comp.vue */
+
+.pc-input-sd-rate {
+    margin-top: -10px;
+    z-index: 1;
+    position: relative;
+    text-align: center;
+}
+.pc-field-sdRate {
+    width: 90%;
+    display: inline-block;
+}
+
+
+/* components/svg-graph-tab-item.vue */
+
+/*# sourceMappingURL=svg-graph-tab-item.vue.map */
 
 /* components/pc-block.vue */
 
@@ -389,120 +559,5 @@
     top: 138px;
     pointer-events: none;
     z-index: 0;
-}
-
-
-/* components/impact-comp.vue */
-
-/*# sourceMappingURL=impact-comp.vue.map */
-
-/* components/base-comp.vue */
-
-.pc-input-left[data-v-0d0bef2b] {
-    position: relative;
-    z-index: 2;
-}
-
-
-/* components/base-comp.vue */
-
-.pc-input-sd-rate {
-    margin-top: -10px;
-    z-index: 1;
-    position: relative;
-    text-align: center;
-}
-.pc-field-sdRate {
-    width: 90%;
-    display: inline-block;
-}
-
-
-/* components/pc-tooltip.vue */
-
-.pc-tooltip {
-    --tooltip-background-color: var(--black);
-    position: relative;
-}
-.tooltip-wrapper {
-    position: absolute;
-    left: 0;
-    top: calc(100% + 10px);
-    background: var(--tooltip-background-color);
-    color: var(--light-gray);
-    padding: 5px;
-    border-radius: 4px;
-    z-index: 10;
-    width: 400px;
-    white-space: normal;
-    pointer-events: none;
-}
-.tooltip-wrapper:after {
-    --size: 5px;
-    content: '';
-    position: absolute;
-    left: 50px;
-    bottom: calc(100% - var(--size));
-    transform: translate(-50%, 0) rotateZ(45deg);
-    border: var(--size) solid var(--tooltip-background-color);
-    border-right-color: transparent;
-    border-bottom-color: transparent;
-}
-
-
-/* components/non-inferiority.vue */
-
-.pc-non-inf-label {
-    white-space: nowrap;
-}
-.pc-non-inf-treshold {
-    display: flex;
-    align-items: center;
-}
-.pc-non-inf-treshold-input {
-    margin-left: 5px;
-}
-
-
-/* components/non-inferiority-comp.vue */
-
-.pc-non-inf-select {
-    --base-padding: 5px;
-    font-size: inherit;
-    line-height: 28px;
-    border: none;
-    display: block;
-    position: relative;
-    box-sizing: border-box;
-    width: 100%;
-    filter: drop-shadow(0 4px 2px rgba(0,0,0,0.1));
-    border-radius: 5px;
-    background: var(--white);
-    padding: var(--base-padding);
-    overflow: hidden;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-}
-.pc-non-inf-select:focus {
-    outline: 0;
-    box-shadow: inset 0 0 0 1px var(--dark-blue);
-}
-.pc-non-inf-select-wrapper {
-    position: relative;
-}
-.pc-non-inf-select-wrapper:after {
-    --border-size: 7px;
-    content: '';
-    position: absolute;
-    right: 5px;
-    bottom: 0;
-    pointer-events: none;
-    border: var(--border-size) solid transparent;
-    border-top: var(--border-size) solid var(--gray);
-    transform: translateY(calc(-50% - var(--border-size)/2));
-}
-.no-sub-title {
-    margin: 15px 0 10px 0;
 }
 

--- a/dist/powercalculator.css
+++ b/dist/powercalculator.css
@@ -31,10 +31,11 @@
 .pc-controls-left {
     grid-area: controls-left;
     display: grid;
-    grid-template-columns: min-content min-content min-content min-content;
-    grid-template-rows: auto;
+    grid-template-columns: min-content min-content min-content;
+    grid-template-rows: 2;
     grid-template-areas:
-        "test-type traffic comparison calc-options";
+        "calc-options calc-options calc-options"
+        "test-type traffic comparison";
     align-items: center;
 }
 .pc-controls-right {
@@ -69,6 +70,7 @@
 }
 .pc-non-inferiority {
     grid-area: calc-options;
+    margin-bottom: 8px;
 }
 .pc-comparison-mode {
     grid-area: comparison;
@@ -167,6 +169,48 @@
 }
 
 
+/* components/svg-graph.vue */
+
+/* graph radio styles */
+.pc-graph-controls {
+    display: flex;
+    flex-direction: row;
+    padding: 30px 0 0 60px;
+    margin-bottom: 5px;
+    border-bottom: 1px solid var(--blue);
+}
+.pc-graph-radio-label {
+    position: relative;
+    font-size: 13px;
+    color: var(--blue);
+    margin-right: 20px;
+}
+.pc-graph-radio-input {
+    position: absolute;
+    visibility: hidden;
+}
+.pc-graph-radio-text {
+    display: block;
+    padding: 0 5px 15px;
+    position: relative;
+}
+.pc-graph-radio-input:checked + .pc-graph-radio-text::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    height: 4px;
+    background: var(--blue);
+}
+/* graph layout */
+.pc-graph {
+    padding: 10px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+
 /* components/pc-block-field.vue */
 
 .pc-value-field-wrapper {
@@ -245,48 +289,6 @@
 }
 
 
-/* components/svg-graph.vue */
-
-/* graph radio styles */
-.pc-graph-controls {
-    display: flex;
-    flex-direction: row;
-    padding: 30px 0 0 60px;
-    margin-bottom: 5px;
-    border-bottom: 1px solid var(--blue);
-}
-.pc-graph-radio-label {
-    position: relative;
-    font-size: 13px;
-    color: var(--blue);
-    margin-right: 20px;
-}
-.pc-graph-radio-input {
-    position: absolute;
-    visibility: hidden;
-}
-.pc-graph-radio-text {
-    display: block;
-    padding: 0 5px 15px;
-    position: relative;
-}
-.pc-graph-radio-input:checked + .pc-graph-radio-text::after {
-    content: '';
-    position: absolute;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    height: 4px;
-    background: var(--blue);
-}
-/* graph layout */
-.pc-graph {
-    padding: 10px;
-    width: 100%;
-    box-sizing: border-box;
-}
-
-
 /* components/impact-comp.vue */
 
 /*# sourceMappingURL=impact-comp.vue.map */
@@ -320,6 +322,20 @@
     border: var(--size) solid var(--tooltip-background-color);
     border-right-color: transparent;
     border-bottom-color: transparent;
+}
+
+
+/* components/non-inferiority.vue */
+
+.pc-non-inf-label {
+    white-space: nowrap;
+}
+.pc-non-inf-treshold {
+    display: flex;
+    align-items: center;
+}
+.pc-non-inf-treshold-input {
+    margin-left: 5px;
 }
 
 
@@ -363,20 +379,6 @@
 }
 .no-sub-title {
     margin: 15px 0 10px 0;
-}
-
-
-/* components/non-inferiority.vue */
-
-.pc-non-inf-label {
-    white-space: nowrap;
-}
-.pc-non-inf-treshold {
-    display: flex;
-    align-items: center;
-}
-.pc-non-inf-treshold-input {
-    margin-left: 5px;
 }
 
 

--- a/dist/powercalculator.js
+++ b/dist/powercalculator.js
@@ -3,5444 +3,5402 @@
 /** https://github.com/bookingcom/powercalculator */
 
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
-	typeof define === 'function' && define.amd ? define('powercalculator', factory) :
-	(global.powercalculator = factory());
-}(this, (function () { 'use strict';
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+    typeof define === 'function' && define.amd ? define('powercalculator', factory) :
+    (global = global || self, global.powercalculator = factory());
+}(this, function () { 'use strict';
 
-var _impact = {
-    getGraphYTicks () {
-        let impact = isNaN(this.impact) ? 0 : this.impact,
-            arr = [impact/1.50, impact/1.25, impact, impact*1.25, impact*1.50];
-        return arr
-    },
-    getGraphYTicksFormatted (y) {
-        let num = window.parseFloat(y);
-        if ((num % 1) !== 0) {
-            num = num.toFixed(2);
+    var _impact = {
+        getGraphYTicks () {
+            let impact = isNaN(this.impact) ? 0 : this.impact,
+                arr = [impact/1.50, impact/1.25, impact, impact*1.25, impact*1.50];
+            return arr
+        },
+        getGraphYTicksFormatted (y) {
+            let num = window.parseFloat(y);
+            if ((num % 1) !== 0) {
+                num = num.toFixed(2);
+            }
+
+            if (isNaN(num)) {
+                num = 0;
+            }
+
+            return `${num}%`
+        },
+        updateClonedValues (clonedObj, value) {
+            clonedObj.effect_size = this.$store.getters.extractValue('impact', value);
+
+            return clonedObj;
+        },
+        getCurrentYValue () {
+            return this.impact
+        },
+        getGraphXTicksFormatted (x) {
+            let result = x;
+
+            result += '%';
+
+            return result
+        },
+    };
+
+    var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+
+    function createCommonjsModule(fn, module) {
+    	return module = { exports: {} }, fn(module, module.exports), module.exports;
+    }
+
+    var jstat = createCommonjsModule(function (module, exports) {
+    (function (window, factory) {
+        {
+            module.exports = factory();
+        }
+    })(commonjsGlobal, function () {
+    var jStat = (function(Math, undefined$1) {
+
+    // For quick reference.
+    var concat = Array.prototype.concat;
+    var slice = Array.prototype.slice;
+    var toString = Object.prototype.toString;
+
+    // Calculate correction for IEEE error
+    // TODO: This calculation can be improved.
+    function calcRdx(n, m) {
+      var val = n > m ? n : m;
+      return Math.pow(10,
+                      17 - ~~(Math.log(((val > 0) ? val : -val)) * Math.LOG10E));
+    }
+
+
+    var isArray = Array.isArray || function isArray(arg) {
+      return toString.call(arg) === '[object Array]';
+    };
+
+
+    function isFunction(arg) {
+      return toString.call(arg) === '[object Function]';
+    }
+
+
+    function isNumber(arg) {
+      return typeof arg === 'number' && arg === arg;
+    }
+
+
+    // Converts the jStat matrix to vector.
+    function toVector(arr) {
+      return concat.apply([], arr);
+    }
+
+
+    // The one and only jStat constructor.
+    function jStat() {
+      return new jStat._init(arguments);
+    }
+
+
+    // TODO: Remove after all references in src files have been removed.
+    jStat.fn = jStat.prototype;
+
+
+    // By separating the initializer from the constructor it's easier to handle
+    // always returning a new instance whether "new" was used or not.
+    jStat._init = function _init(args) {
+      var i;
+
+      // If first argument is an array, must be vector or matrix.
+      if (isArray(args[0])) {
+        // Check if matrix.
+        if (isArray(args[0][0])) {
+          // See if a mapping function was also passed.
+          if (isFunction(args[1]))
+            args[0] = jStat.map(args[0], args[1]);
+          // Iterate over each is faster than this.push.apply(this, args[0].
+          for (var i = 0; i < args[0].length; i++)
+            this[i] = args[0][i];
+          this.length = args[0].length;
+
+        // Otherwise must be a vector.
+        } else {
+          this[0] = isFunction(args[1]) ? jStat.map(args[0], args[1]) : args[0];
+          this.length = 1;
         }
 
-        if (isNaN(num)) {
-            num = 0;
-        }
-
-        return `${num}%`
-    },
-    updateClonedValues (clonedObj, value) {
-        clonedObj.effect_size = this.$store.getters.extractValue('impact', value);
-
-        return clonedObj;
-    },
-    getCurrentYValue () {
-        return this.impact
-    },
-    getGraphXTicksFormatted (x) {
-        let result = x;
-
-        result += '%';
-
-        return result
-    },
-};
-
-var commonjsGlobal = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
-
-
-
-
-
-function createCommonjsModule(fn, module) {
-	return module = { exports: {} }, fn(module, module.exports), module.exports;
-}
-
-var jstat = createCommonjsModule(function (module, exports) {
-(function (window, factory) {
-    {
-        module.exports = factory();
-    }
-})(commonjsGlobal, function () {
-var jStat = (function(Math, undefined) {
-
-// For quick reference.
-var concat = Array.prototype.concat;
-var slice = Array.prototype.slice;
-var toString = Object.prototype.toString;
-
-// Calculate correction for IEEE error
-// TODO: This calculation can be improved.
-function calcRdx(n, m) {
-  var val = n > m ? n : m;
-  return Math.pow(10,
-                  17 - ~~(Math.log(((val > 0) ? val : -val)) * Math.LOG10E));
-}
-
-
-var isArray = Array.isArray || function isArray(arg) {
-  return toString.call(arg) === '[object Array]';
-};
-
-
-function isFunction(arg) {
-  return toString.call(arg) === '[object Function]';
-}
-
-
-function isNumber(arg) {
-  return typeof arg === 'number' && arg === arg;
-}
-
-
-// Converts the jStat matrix to vector.
-function toVector(arr) {
-  return concat.apply([], arr);
-}
-
-
-// The one and only jStat constructor.
-function jStat() {
-  return new jStat._init(arguments);
-}
-
-
-// TODO: Remove after all references in src files have been removed.
-jStat.fn = jStat.prototype;
-
-
-// By separating the initializer from the constructor it's easier to handle
-// always returning a new instance whether "new" was used or not.
-jStat._init = function _init(args) {
-  var i;
-
-  // If first argument is an array, must be vector or matrix.
-  if (isArray(args[0])) {
-    // Check if matrix.
-    if (isArray(args[0][0])) {
-      // See if a mapping function was also passed.
-      if (isFunction(args[1]))
-        args[0] = jStat.map(args[0], args[1]);
-      // Iterate over each is faster than this.push.apply(this, args[0].
-      for (var i = 0; i < args[0].length; i++)
-        this[i] = args[0][i];
-      this.length = args[0].length;
-
-    // Otherwise must be a vector.
-    } else {
-      this[0] = isFunction(args[1]) ? jStat.map(args[0], args[1]) : args[0];
-      this.length = 1;
-    }
-
-  // If first argument is number, assume creation of sequence.
-  } else if (isNumber(args[0])) {
-    this[0] = jStat.seq.apply(null, args);
-    this.length = 1;
-
-  // Handle case when jStat object is passed to jStat.
-  } else if (args[0] instanceof jStat) {
-    // Duplicate the object and pass it back.
-    return jStat(args[0].toArray());
-
-  // Unexpected argument value, return empty jStat object.
-  // TODO: This is strange behavior. Shouldn't this throw or some such to let
-  // the user know they had bad arguments?
-  } else {
-    this[0] = [];
-    this.length = 1;
-  }
-
-  return this;
-};
-jStat._init.prototype = jStat.prototype;
-jStat._init.constructor = jStat;
-
-
-// Utility functions.
-// TODO: for internal use only?
-jStat.utils = {
-  calcRdx: calcRdx,
-  isArray: isArray,
-  isFunction: isFunction,
-  isNumber: isNumber,
-  toVector: toVector
-};
-
-
-// Easily extend the jStat object.
-// TODO: is this seriously necessary?
-jStat.extend = function extend(obj) {
-  var i, j;
-
-  if (arguments.length === 1) {
-    for (j in obj)
-      jStat[j] = obj[j];
-    return this;
-  }
-
-  for (var i = 1; i < arguments.length; i++) {
-    for (j in arguments[i])
-      obj[j] = arguments[i][j];
-  }
-
-  return obj;
-};
-
-
-// Returns the number of rows in the matrix.
-jStat.rows = function rows(arr) {
-  return arr.length || 1;
-};
-
-
-// Returns the number of columns in the matrix.
-jStat.cols = function cols(arr) {
-  return arr[0].length || 1;
-};
-
-
-// Returns the dimensions of the object { rows: i, cols: j }
-jStat.dimensions = function dimensions(arr) {
-  return {
-    rows: jStat.rows(arr),
-    cols: jStat.cols(arr)
-  };
-};
-
-
-// Returns a specified row as a vector or return a sub matrix by pick some rows
-jStat.row = function row(arr, index) {
-  if (isArray(index)) {
-    return index.map(function(i) {
-      return jStat.row(arr, i);
-    })
-  }
-  return arr[index];
-};
-
-
-// return row as array
-// rowa([[1,2],[3,4]],0) -> [1,2]
-jStat.rowa = function rowa(arr, i) {
-  return jStat.row(arr, i);
-};
-
-
-// Returns the specified column as a vector or return a sub matrix by pick some
-// columns
-jStat.col = function col(arr, index) {
-  if (isArray(index)) {
-    var submat = jStat.arange(arr.length).map(function(i) {
-      return new Array(index.length);
-    });
-    index.forEach(function(ind, i){
-      jStat.arange(arr.length).forEach(function(j) {
-        submat[j][i] = arr[j][ind];
-      });
-    });
-    return submat;
-  }
-  var column = new Array(arr.length);
-  for (var i = 0; i < arr.length; i++)
-    column[i] = [arr[i][index]];
-  return column;
-};
-
-
-// return column as array
-// cola([[1,2],[3,4]],0) -> [1,3]
-jStat.cola = function cola(arr, i) {
-  return jStat.col(arr, i).map(function(a){ return a[0] });
-};
-
-
-// Returns the diagonal of the matrix
-jStat.diag = function diag(arr) {
-  var nrow = jStat.rows(arr);
-  var res = new Array(nrow);
-  for (var row = 0; row < nrow; row++)
-    res[row] = [arr[row][row]];
-  return res;
-};
-
-
-// Returns the anti-diagonal of the matrix
-jStat.antidiag = function antidiag(arr) {
-  var nrow = jStat.rows(arr) - 1;
-  var res = new Array(nrow);
-  for (var i = 0; nrow >= 0; nrow--, i++)
-    res[i] = [arr[i][nrow]];
-  return res;
-};
-
-// Transpose a matrix or array.
-jStat.transpose = function transpose(arr) {
-  var obj = [];
-  var objArr, rows, cols, j, i;
-
-  // Make sure arr is in matrix format.
-  if (!isArray(arr[0]))
-    arr = [arr];
-
-  rows = arr.length;
-  cols = arr[0].length;
-
-  for (var i = 0; i < cols; i++) {
-    objArr = new Array(rows);
-    for (j = 0; j < rows; j++)
-      objArr[j] = arr[j][i];
-    obj.push(objArr);
-  }
-
-  // If obj is vector, return only single array.
-  return obj.length === 1 ? obj[0] : obj;
-};
-
-
-// Map a function to an array or array of arrays.
-// "toAlter" is an internal variable.
-jStat.map = function map(arr, func, toAlter) {
-  var row, nrow, ncol, res, col;
-
-  if (!isArray(arr[0]))
-    arr = [arr];
-
-  nrow = arr.length;
-  ncol = arr[0].length;
-  res = toAlter ? arr : new Array(nrow);
-
-  for (row = 0; row < nrow; row++) {
-    // if the row doesn't exist, create it
-    if (!res[row])
-      res[row] = new Array(ncol);
-    for (col = 0; col < ncol; col++)
-      res[row][col] = func(arr[row][col], row, col);
-  }
-
-  return res.length === 1 ? res[0] : res;
-};
-
-
-// Cumulatively combine the elements of an array or array of arrays using a function.
-jStat.cumreduce = function cumreduce(arr, func, toAlter) {
-  var row, nrow, ncol, res, col;
-
-  if (!isArray(arr[0]))
-    arr = [arr];
-
-  nrow = arr.length;
-  ncol = arr[0].length;
-  res = toAlter ? arr : new Array(nrow);
-
-  for (row = 0; row < nrow; row++) {
-    // if the row doesn't exist, create it
-    if (!res[row])
-      res[row] = new Array(ncol);
-    if (ncol > 0)
-      res[row][0] = arr[row][0];
-    for (col = 1; col < ncol; col++)
-      res[row][col] = func(res[row][col-1], arr[row][col]);
-  }
-  return res.length === 1 ? res[0] : res;
-};
-
-
-// Destructively alter an array.
-jStat.alter = function alter(arr, func) {
-  return jStat.map(arr, func, true);
-};
-
-
-// Generate a rows x cols matrix according to the supplied function.
-jStat.create = function  create(rows, cols, func) {
-  var res = new Array(rows);
-  var i, j;
-
-  if (isFunction(cols)) {
-    func = cols;
-    cols = rows;
-  }
-
-  for (var i = 0; i < rows; i++) {
-    res[i] = new Array(cols);
-    for (j = 0; j < cols; j++)
-      res[i][j] = func(i, j);
-  }
-
-  return res;
-};
-
-
-function retZero() { return 0; }
-
-
-// Generate a rows x cols matrix of zeros.
-jStat.zeros = function zeros(rows, cols) {
-  if (!isNumber(cols))
-    cols = rows;
-  return jStat.create(rows, cols, retZero);
-};
-
-
-function retOne() { return 1; }
-
-
-// Generate a rows x cols matrix of ones.
-jStat.ones = function ones(rows, cols) {
-  if (!isNumber(cols))
-    cols = rows;
-  return jStat.create(rows, cols, retOne);
-};
-
-
-// Generate a rows x cols matrix of uniformly random numbers.
-jStat.rand = function rand(rows, cols) {
-  if (!isNumber(cols))
-    cols = rows;
-  return jStat.create(rows, cols, Math.random);
-};
-
-
-function retIdent(i, j) { return i === j ? 1 : 0; }
-
-
-// Generate an identity matrix of size row x cols.
-jStat.identity = function identity(rows, cols) {
-  if (!isNumber(cols))
-    cols = rows;
-  return jStat.create(rows, cols, retIdent);
-};
-
-
-// Tests whether a matrix is symmetric
-jStat.symmetric = function symmetric(arr) {
-  var size = arr.length;
-  var row, col;
-
-  if (arr.length !== arr[0].length)
-    return false;
-
-  for (row = 0; row < size; row++) {
-    for (col = 0; col < size; col++)
-      if (arr[col][row] !== arr[row][col])
-        return false;
-  }
-
-  return true;
-};
-
-
-// Set all values to zero.
-jStat.clear = function clear(arr) {
-  return jStat.alter(arr, retZero);
-};
-
-
-// Generate sequence.
-jStat.seq = function seq(min, max, length, func) {
-  if (!isFunction(func))
-    func = false;
-
-  var arr = [];
-  var hival = calcRdx(min, max);
-  var step = (max * hival - min * hival) / ((length - 1) * hival);
-  var current = min;
-  var cnt;
-
-  // Current is assigned using a technique to compensate for IEEE error.
-  // TODO: Needs better implementation.
-  for (cnt = 0;
-       current <= max && cnt < length;
-       cnt++, current = (min * hival + step * hival * cnt) / hival) {
-    arr.push((func ? func(current, cnt) : current));
-  }
-
-  return arr;
-};
-
-
-// arange(5) -> [0,1,2,3,4]
-// arange(1,5) -> [1,2,3,4]
-// arange(5,1,-1) -> [5,4,3,2]
-jStat.arange = function arange(start, end, step) {
-  var rl = [];
-  step = step || 1;
-  if (end === undefined) {
-    end = start;
-    start = 0;
-  }
-  if (start === end || step === 0) {
-    return [];
-  }
-  if (start < end && step < 0) {
-    return [];
-  }
-  if (start > end && step > 0) {
-    return [];
-  }
-  if (step > 0) {
-    for (i = start; i < end; i += step) {
-      rl.push(i);
-    }
-  } else {
-    for (i = start; i > end; i += step) {
-      rl.push(i);
-    }
-  }
-  return rl;
-};
-
-
-// A=[[1,2,3],[4,5,6],[7,8,9]]
-// slice(A,{row:{end:2},col:{start:1}}) -> [[2,3],[5,6]]
-// slice(A,1,{start:1}) -> [5,6]
-// as numpy code A[:2,1:]
-jStat.slice = (function(){
-  function _slice(list, start, end, step) {
-    // note it's not equal to range.map mode it's a bug
-    var i;
-    var rl = [];
-    var length = list.length;
-    if (start === undefined && end === undefined && step === undefined) {
-      return jStat.copy(list);
-    }
-
-    start = start || 0;
-    end = end || list.length;
-    start = start >= 0 ? start : length + start;
-    end = end >= 0 ? end : length + end;
-    step = step || 1;
-    if (start === end || step === 0) {
-      return [];
-    }
-    if (start < end && step < 0) {
-      return [];
-    }
-    if (start > end && step > 0) {
-      return [];
-    }
-    if (step > 0) {
-      for (i = start; i < end; i += step) {
-        rl.push(list[i]);
-      }
-    } else {
-      for (i = start; i > end;i += step) {
-        rl.push(list[i]);
-      }
-    }
-    return rl;
-  }
-
-  function slice(list, rcSlice) {
-    rcSlice = rcSlice || {};
-    if (isNumber(rcSlice.row)) {
-      if (isNumber(rcSlice.col))
-        return list[rcSlice.row][rcSlice.col];
-      var row = jStat.rowa(list, rcSlice.row);
-      var colSlice = rcSlice.col || {};
-      return _slice(row, colSlice.start, colSlice.end, colSlice.step);
-    }
-
-    if (isNumber(rcSlice.col)) {
-      var col = jStat.cola(list, rcSlice.col);
-      var rowSlice = rcSlice.row || {};
-      return _slice(col, rowSlice.start, rowSlice.end, rowSlice.step);
-    }
-
-    var rowSlice = rcSlice.row || {};
-    var colSlice = rcSlice.col || {};
-    var rows = _slice(list, rowSlice.start, rowSlice.end, rowSlice.step);
-    return rows.map(function(row) {
-      return _slice(row, colSlice.start, colSlice.end, colSlice.step);
-    });
-  }
-
-  return slice;
-}());
-
-
-// A=[[1,2,3],[4,5,6],[7,8,9]]
-// sliceAssign(A,{row:{start:1},col:{start:1}},[[0,0],[0,0]])
-// A=[[1,2,3],[4,0,0],[7,0,0]]
-jStat.sliceAssign = function sliceAssign(A, rcSlice, B) {
-  if (isNumber(rcSlice.row)) {
-    if (isNumber(rcSlice.col))
-      return A[rcSlice.row][rcSlice.col] = B;
-    rcSlice.col = rcSlice.col || {};
-    rcSlice.col.start = rcSlice.col.start || 0;
-    rcSlice.col.end = rcSlice.col.end || A[0].length;
-    rcSlice.col.step = rcSlice.col.step || 1;
-    var nl = jStat.arange(rcSlice.col.start,
-                          Math.min(A.length, rcSlice.col.end),
-                          rcSlice.col.step);
-    var m = rcSlice.row;
-    nl.forEach(function(n, i) {
-      A[m][n] = B[i];
-    });
-    return A;
-  }
-
-  if (isNumber(rcSlice.col)) {
-    rcSlice.row = rcSlice.row || {};
-    rcSlice.row.start = rcSlice.row.start || 0;
-    rcSlice.row.end = rcSlice.row.end || A.length;
-    rcSlice.row.step = rcSlice.row.step || 1;
-    var ml = jStat.arange(rcSlice.row.start,
-                          Math.min(A[0].length, rcSlice.row.end),
-                          rcSlice.row.step);
-    var n = rcSlice.col;
-    ml.forEach(function(m, j) {
-      A[m][n] = B[j];
-    });
-    return A;
-  }
-
-  if (B[0].length === undefined) {
-    B = [B];
-  }
-  rcSlice.row.start = rcSlice.row.start || 0;
-  rcSlice.row.end = rcSlice.row.end || A.length;
-  rcSlice.row.step = rcSlice.row.step || 1;
-  rcSlice.col.start = rcSlice.col.start || 0;
-  rcSlice.col.end = rcSlice.col.end || A[0].length;
-  rcSlice.col.step = rcSlice.col.step || 1;
-  var ml = jStat.arange(rcSlice.row.start,
-                        Math.min(A.length, rcSlice.row.end),
-                        rcSlice.row.step);
-  var nl = jStat.arange(rcSlice.col.start,
-                        Math.min(A[0].length, rcSlice.col.end),
-                        rcSlice.col.step);
-  ml.forEach(function(m, i) {
-    nl.forEach(function(n, j) {
-      A[m][n] = B[i][j];
-    });
-  });
-  return A;
-};
-
-
-// [1,2,3] ->
-// [[1,0,0],[0,2,0],[0,0,3]]
-jStat.diagonal = function diagonal(diagArray) {
-  var mat = jStat.zeros(diagArray.length, diagArray.length);
-  diagArray.forEach(function(t, i) {
-    mat[i][i] = t;
-  });
-  return mat;
-};
-
-
-// return copy of A
-jStat.copy = function copy(A) {
-  return A.map(function(row) {
-    if (isNumber(row))
-      return row;
-    return row.map(function(t) {
-      return t;
-    });
-  });
-};
-
-
-// TODO: Go over this entire implementation. Seems a tragic waste of resources
-// doing all this work. Instead, and while ugly, use new Function() to generate
-// a custom function for each static method.
-
-// Quick reference.
-var jProto = jStat.prototype;
-
-// Default length.
-jProto.length = 0;
-
-// For internal use only.
-// TODO: Check if they're actually used, and if they are then rename them
-// to _*
-jProto.push = Array.prototype.push;
-jProto.sort = Array.prototype.sort;
-jProto.splice = Array.prototype.splice;
-jProto.slice = Array.prototype.slice;
-
-
-// Return a clean array.
-jProto.toArray = function toArray() {
-  return this.length > 1 ? slice.call(this) : slice.call(this)[0];
-};
-
-
-// Map a function to a matrix or vector.
-jProto.map = function map(func, toAlter) {
-  return jStat(jStat.map(this, func, toAlter));
-};
-
-
-// Cumulatively combine the elements of a matrix or vector using a function.
-jProto.cumreduce = function cumreduce(func, toAlter) {
-  return jStat(jStat.cumreduce(this, func, toAlter));
-};
-
-
-// Destructively alter an array.
-jProto.alter = function alter(func) {
-  jStat.alter(this, func);
-  return this;
-};
-
-
-// Extend prototype with methods that have no argument.
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jProto[passfunc] = function(func) {
-      var self = this,
-      results;
-      // Check for callback.
-      if (func) {
-        setTimeout(function() {
-          func.call(self, jProto[passfunc].call(self));
-        });
-        return this;
-      }
-      results = jStat[passfunc](this);
-      return isArray(results) ? jStat(results) : results;
-    };
-  })(funcs[i]);
-})('transpose clear symmetric rows cols dimensions diag antidiag'.split(' '));
-
-
-// Extend prototype with methods that have one argument.
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jProto[passfunc] = function(index, func) {
-      var self = this;
-      // check for callback
-      if (func) {
-        setTimeout(function() {
-          func.call(self, jProto[passfunc].call(self, index));
-        });
-        return this;
-      }
-      return jStat(jStat[passfunc](this, index));
-    };
-  })(funcs[i]);
-})('row col'.split(' '));
-
-
-// Extend prototype with simple shortcut methods.
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jProto[passfunc] = new Function(
-        'return jStat(jStat.' + passfunc + '.apply(null, arguments));');
-  })(funcs[i]);
-})('create zeros ones rand identity'.split(' '));
-
-
-// Exposing jStat.
-return jStat;
-
-}(Math));
-(function(jStat, Math) {
-
-var isFunction = jStat.utils.isFunction;
-
-// Ascending functions for sort
-function ascNum(a, b) { return a - b; }
-
-function clip(arg, min, max) {
-  return Math.max(min, Math.min(arg, max));
-}
-
-
-// sum of an array
-jStat.sum = function sum(arr) {
-  var sum = 0;
-  var i = arr.length;
-  while (--i >= 0)
-    sum += arr[i];
-  return sum;
-};
-
-
-// sum squared
-jStat.sumsqrd = function sumsqrd(arr) {
-  var sum = 0;
-  var i = arr.length;
-  while (--i >= 0)
-    sum += arr[i] * arr[i];
-  return sum;
-};
-
-
-// sum of squared errors of prediction (SSE)
-jStat.sumsqerr = function sumsqerr(arr) {
-  var mean = jStat.mean(arr);
-  var sum = 0;
-  var i = arr.length;
-  var tmp;
-  while (--i >= 0) {
-    tmp = arr[i] - mean;
-    sum += tmp * tmp;
-  }
-  return sum;
-};
-
-// sum of an array in each row
-jStat.sumrow = function sumrow(arr) {
-  var sum = 0;
-  var i = arr.length;
-  while (--i >= 0)
-    sum += arr[i];
-  return sum;
-};
-
-// product of an array
-jStat.product = function product(arr) {
-  var prod = 1;
-  var i = arr.length;
-  while (--i >= 0)
-    prod *= arr[i];
-  return prod;
-};
-
-
-// minimum value of an array
-jStat.min = function min(arr) {
-  var low = arr[0];
-  var i = 0;
-  while (++i < arr.length)
-    if (arr[i] < low)
-      low = arr[i];
-  return low;
-};
-
-
-// maximum value of an array
-jStat.max = function max(arr) {
-  var high = arr[0];
-  var i = 0;
-  while (++i < arr.length)
-    if (arr[i] > high)
-      high = arr[i];
-  return high;
-};
-
-
-// unique values of an array
-jStat.unique = function unique(arr) {
-  var hash = {}, _arr = [];
-  for(var i = 0; i < arr.length; i++) {
-    if (!hash[arr[i]]) {
-      hash[arr[i]] = true;
-      _arr.push(arr[i]);
-    }
-  }
-  return _arr;
-};
-
-
-// mean value of an array
-jStat.mean = function mean(arr) {
-  return jStat.sum(arr) / arr.length;
-};
-
-
-// mean squared error (MSE)
-jStat.meansqerr = function meansqerr(arr) {
-  return jStat.sumsqerr(arr) / arr.length;
-};
-
-
-// geometric mean of an array
-jStat.geomean = function geomean(arr) {
-  return Math.pow(jStat.product(arr), 1 / arr.length);
-};
-
-
-// median of an array
-jStat.median = function median(arr) {
-  var arrlen = arr.length;
-  var _arr = arr.slice().sort(ascNum);
-  // check if array is even or odd, then return the appropriate
-  return !(arrlen & 1)
-    ? (_arr[(arrlen / 2) - 1 ] + _arr[(arrlen / 2)]) / 2
-    : _arr[(arrlen / 2) | 0 ];
-};
-
-
-// cumulative sum of an array
-jStat.cumsum = function cumsum(arr) {
-  return jStat.cumreduce(arr, function (a, b) { return a + b; });
-};
-
-
-// cumulative product of an array
-jStat.cumprod = function cumprod(arr) {
-  return jStat.cumreduce(arr, function (a, b) { return a * b; });
-};
-
-
-// successive differences of a sequence
-jStat.diff = function diff(arr) {
-  var diffs = [];
-  var arrLen = arr.length;
-  var i;
-  for (var i = 1; i < arrLen; i++)
-    diffs.push(arr[i] - arr[i - 1]);
-  return diffs;
-};
-
-
-// ranks of an array
-jStat.rank = function (arr) {
-  var arrlen = arr.length;
-  var sorted = arr.slice().sort(ascNum);
-  var ranks = new Array(arrlen);
-  for (var i = 0; i < arrlen; i++) {
-    var first = sorted.indexOf(arr[i]);
-    var last = sorted.lastIndexOf(arr[i]);
-    if (first === last) {
-      var val = first;
-    } else {
-      var val = (first + last) / 2;
-    }
-    ranks[i] = val + 1;
-  }
-  return ranks;
-};
-
-
-// mode of an array
-// if there are multiple modes of an array, return all of them
-// is this the appropriate way of handling it?
-jStat.mode = function mode(arr) {
-  var arrLen = arr.length;
-  var _arr = arr.slice().sort(ascNum);
-  var count = 1;
-  var maxCount = 0;
-  var numMaxCount = 0;
-  var mode_arr = [];
-  var i;
-
-  for (var i = 0; i < arrLen; i++) {
-    if (_arr[i] === _arr[i + 1]) {
-      count++;
-    } else {
-      if (count > maxCount) {
-        mode_arr = [_arr[i]];
-        maxCount = count;
-        numMaxCount = 0;
-      }
-      // are there multiple max counts
-      else if (count === maxCount) {
-        mode_arr.push(_arr[i]);
-        numMaxCount++;
-      }
-      // resetting count for new value in array
-      count = 1;
-    }
-  }
-
-  return numMaxCount === 0 ? mode_arr[0] : mode_arr;
-};
-
-
-// range of an array
-jStat.range = function range(arr) {
-  return jStat.max(arr) - jStat.min(arr);
-};
-
-// variance of an array
-// flag = true indicates sample instead of population
-jStat.variance = function variance(arr, flag) {
-  return jStat.sumsqerr(arr) / (arr.length - (flag ? 1 : 0));
-};
-
-// pooled variance of an array of arrays
-jStat.pooledvariance = function pooledvariance(arr) {
-  var sumsqerr = arr.reduce(function (a, samples) {return a + jStat.sumsqerr(samples);}, 0);
-  var count = arr.reduce(function (a, samples) {return a + samples.length;}, 0);
-  return sumsqerr / (count - arr.length);
-};
-
-// deviation of an array
-jStat.deviation = function (arr) {
-  var mean = jStat.mean(arr);
-  var arrlen = arr.length;
-  var dev = new Array(arrlen);
-  for (var i = 0; i < arrlen; i++) {
-    dev[i] = arr[i] - mean;
-  }
-  return dev;
-};
-
-// standard deviation of an array
-// flag = true indicates sample instead of population
-jStat.stdev = function stdev(arr, flag) {
-  return Math.sqrt(jStat.variance(arr, flag));
-};
-
-// pooled standard deviation of an array of arrays
-jStat.pooledstdev = function pooledstdev(arr) {
-  return Math.sqrt(jStat.pooledvariance(arr));
-};
-
-// mean deviation (mean absolute deviation) of an array
-jStat.meandev = function meandev(arr) {
-  var mean = jStat.mean(arr);
-  var a = [];
-  for (var i = arr.length - 1; i >= 0; i--) {
-    a.push(Math.abs(arr[i] - mean));
-  }
-  return jStat.mean(a);
-};
-
-
-// median deviation (median absolute deviation) of an array
-jStat.meddev = function meddev(arr) {
-  var median = jStat.median(arr);
-  var a = [];
-  for (var i = arr.length - 1; i >= 0; i--) {
-    a.push(Math.abs(arr[i] - median));
-  }
-  return jStat.median(a);
-};
-
-
-// coefficient of variation
-jStat.coeffvar = function coeffvar(arr) {
-  return jStat.stdev(arr) / jStat.mean(arr);
-};
-
-
-// quartiles of an array
-jStat.quartiles = function quartiles(arr) {
-  var arrlen = arr.length;
-  var _arr = arr.slice().sort(ascNum);
-  return [
-    _arr[ Math.round((arrlen) / 4) - 1 ],
-    _arr[ Math.round((arrlen) / 2) - 1 ],
-    _arr[ Math.round((arrlen) * 3 / 4) - 1 ]
-  ];
-};
-
-
-// Arbitary quantiles of an array. Direct port of the scipy.stats
-// implementation by Pierre GF Gerard-Marchant.
-jStat.quantiles = function quantiles(arr, quantilesArray, alphap, betap) {
-  var sortedArray = arr.slice().sort(ascNum);
-  var quantileVals = [quantilesArray.length];
-  var n = arr.length;
-  var i, p, m, aleph, k, gamma;
-
-  if (typeof alphap === 'undefined')
-    alphap = 3 / 8;
-  if (typeof betap === 'undefined')
-    betap = 3 / 8;
-
-  for (var i = 0; i < quantilesArray.length; i++) {
-    p = quantilesArray[i];
-    m = alphap + p * (1 - alphap - betap);
-    aleph = n * p + m;
-    k = Math.floor(clip(aleph, 1, n - 1));
-    gamma = clip(aleph - k, 0, 1);
-    quantileVals[i] = (1 - gamma) * sortedArray[k - 1] + gamma * sortedArray[k];
-  }
-
-  return quantileVals;
-};
-
-// Returns the k-th percentile of values in a range, where k is in the
-// range 0..1, exclusive.
-jStat.percentile = function percentile(arr, k) {
-  var _arr = arr.slice().sort(ascNum);
-  var realIndex = k * (_arr.length - 1);
-  var index = parseInt(realIndex);
-  var frac = realIndex - index;
-
-  if (index + 1 < _arr.length) {
-    return _arr[index] * (1 - frac) + _arr[index + 1] * frac;
-  } else {
-    return _arr[index];
-  }
-};
-
-
-// The percentile rank of score in a given array. Returns the percentage
-// of all values in the input array that are less than (kind='strict') or
-// less or equal than (kind='weak') score. Default is weak.
-jStat.percentileOfScore = function percentileOfScore(arr, score, kind) {
-  var counter = 0;
-  var len = arr.length;
-  var strict = false;
-  var value, i;
-
-  if (kind === 'strict')
-    strict = true;
-
-  for (var i = 0; i < len; i++) {
-    value = arr[i];
-    if ((strict && value < score) ||
-        (!strict && value <= score)) {
-      counter++;
-    }
-  }
-
-  return counter / len;
-};
-
-
-// Histogram (bin count) data
-jStat.histogram = function histogram(arr, bins) {
-  var first = jStat.min(arr);
-  var binCnt = bins || 4;
-  var binWidth = (jStat.max(arr) - first) / binCnt;
-  var len = arr.length;
-  var bins = [];
-  var i;
-
-  for (var i = 0; i < binCnt; i++)
-    bins[i] = 0;
-  for (var i = 0; i < len; i++)
-    bins[Math.min(Math.floor(((arr[i] - first) / binWidth)), binCnt - 1)] += 1;
-
-  return bins;
-};
-
-
-// covariance of two arrays
-jStat.covariance = function covariance(arr1, arr2) {
-  var u = jStat.mean(arr1);
-  var v = jStat.mean(arr2);
-  var arr1Len = arr1.length;
-  var sq_dev = new Array(arr1Len);
-  var i;
-
-  for (var i = 0; i < arr1Len; i++)
-    sq_dev[i] = (arr1[i] - u) * (arr2[i] - v);
-
-  return jStat.sum(sq_dev) / (arr1Len - 1);
-};
-
-
-// (pearson's) population correlation coefficient, rho
-jStat.corrcoeff = function corrcoeff(arr1, arr2) {
-  return jStat.covariance(arr1, arr2) /
-      jStat.stdev(arr1, 1) /
-      jStat.stdev(arr2, 1);
-};
-
-  // (spearman's) rank correlation coefficient, sp
-jStat.spearmancoeff =  function (arr1, arr2) {
-  arr1 = jStat.rank(arr1);
-  arr2 = jStat.rank(arr2);
-  //return pearson's correlation of the ranks:
-  return jStat.corrcoeff(arr1, arr2);
-};
-
-
-// statistical standardized moments (general form of skew/kurt)
-jStat.stanMoment = function stanMoment(arr, n) {
-  var mu = jStat.mean(arr);
-  var sigma = jStat.stdev(arr);
-  var len = arr.length;
-  var skewSum = 0;
-
-  for (var i = 0; i < len; i++)
-    skewSum += Math.pow((arr[i] - mu) / sigma, n);
-
-  return skewSum / arr.length;
-};
-
-// (pearson's) moment coefficient of skewness
-jStat.skewness = function skewness(arr) {
-  return jStat.stanMoment(arr, 3);
-};
-
-// (pearson's) (excess) kurtosis
-jStat.kurtosis = function kurtosis(arr) {
-  return jStat.stanMoment(arr, 4) - 3;
-};
-
-
-var jProto = jStat.prototype;
-
-
-// Extend jProto with method for calculating cumulative sums and products.
-// This differs from the similar extension below as cumsum and cumprod should
-// not be run again in the case fullbool === true.
-// If a matrix is passed, automatically assume operation should be done on the
-// columns.
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    // If a matrix is passed, automatically assume operation should be done on
-    // the columns.
-    jProto[passfunc] = function(fullbool, func) {
-      var arr = [];
-      var i = 0;
-      var tmpthis = this;
-      // Assignment reassignation depending on how parameters were passed in.
-      if (isFunction(fullbool)) {
-        func = fullbool;
-        fullbool = false;
-      }
-      // Check if a callback was passed with the function.
-      if (func) {
-        setTimeout(function() {
-          func.call(tmpthis, jProto[passfunc].call(tmpthis, fullbool));
-        });
-        return this;
-      }
-      // Check if matrix and run calculations.
-      if (this.length > 1) {
-        tmpthis = fullbool === true ? this : this.transpose();
-        for (; i < tmpthis.length; i++)
-          arr[i] = jStat[passfunc](tmpthis[i]);
-        return arr;
-      }
-      // Pass fullbool if only vector, not a matrix. for variance and stdev.
-      return jStat[passfunc](this[0], fullbool);
-    };
-  })(funcs[i]);
-})(('cumsum cumprod').split(' '));
-
-
-// Extend jProto with methods which don't require arguments and work on columns.
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    // If a matrix is passed, automatically assume operation should be done on
-    // the columns.
-    jProto[passfunc] = function(fullbool, func) {
-      var arr = [];
-      var i = 0;
-      var tmpthis = this;
-      // Assignment reassignation depending on how parameters were passed in.
-      if (isFunction(fullbool)) {
-        func = fullbool;
-        fullbool = false;
-      }
-      // Check if a callback was passed with the function.
-      if (func) {
-        setTimeout(function() {
-          func.call(tmpthis, jProto[passfunc].call(tmpthis, fullbool));
-        });
-        return this;
-      }
-      // Check if matrix and run calculations.
-      if (this.length > 1) {
-        if (passfunc !== 'sumrow')
-          tmpthis = fullbool === true ? this : this.transpose();
-        for (; i < tmpthis.length; i++)
-          arr[i] = jStat[passfunc](tmpthis[i]);
-        return fullbool === true
-            ? jStat[passfunc](jStat.utils.toVector(arr))
-            : arr;
-      }
-      // Pass fullbool if only vector, not a matrix. for variance and stdev.
-      return jStat[passfunc](this[0], fullbool);
-    };
-  })(funcs[i]);
-})(('sum sumsqrd sumsqerr sumrow product min max unique mean meansqerr ' +
-    'geomean median diff rank mode range variance deviation stdev meandev ' +
-    'meddev coeffvar quartiles histogram skewness kurtosis').split(' '));
-
-
-// Extend jProto with functions that take arguments. Operations on matrices are
-// done on columns.
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jProto[passfunc] = function() {
-      var arr = [];
-      var i = 0;
-      var tmpthis = this;
-      var args = Array.prototype.slice.call(arguments);
-
-      // If the last argument is a function, we assume it's a callback; we
-      // strip the callback out and call the function again.
-      if (isFunction(args[args.length - 1])) {
-        var callbackFunction = args[args.length - 1];
-        var argsToPass = args.slice(0, args.length - 1);
-
-        setTimeout(function() {
-          callbackFunction.call(tmpthis,
-                                jProto[passfunc].apply(tmpthis, argsToPass));
-        });
-        return this;
-
-      // Otherwise we curry the function args and call normally.
+      // If first argument is number, assume creation of sequence.
+      } else if (isNumber(args[0])) {
+        this[0] = jStat.seq.apply(null, args);
+        this.length = 1;
+
+      // Handle case when jStat object is passed to jStat.
+      } else if (args[0] instanceof jStat) {
+        // Duplicate the object and pass it back.
+        return jStat(args[0].toArray());
+
+      // Unexpected argument value, return empty jStat object.
+      // TODO: This is strange behavior. Shouldn't this throw or some such to let
+      // the user know they had bad arguments?
       } else {
-        var callbackFunction = undefined;
-        var curriedFunction = function curriedFunction(vector) {
-          return jStat[passfunc].apply(tmpthis, [vector].concat(args));
-        };
+        this[0] = [];
+        this.length = 1;
       }
 
-      // If this is a matrix, run column-by-column.
-      if (this.length > 1) {
-        tmpthis = tmpthis.transpose();
-        for (; i < tmpthis.length; i++)
-          arr[i] = curriedFunction(tmpthis[i]);
-        return arr;
-      }
-
-      // Otherwise run on the vector.
-      return curriedFunction(this[0]);
-    };
-  })(funcs[i]);
-})('quantiles percentileOfScore'.split(' '));
-
-}(jStat, Math));
-// Special functions //
-(function(jStat, Math) {
-
-// Log-gamma function
-jStat.gammaln = function gammaln(x) {
-  var j = 0;
-  var cof = [
-    76.18009172947146, -86.50532032941677, 24.01409824083091,
-    -1.231739572450155, 0.1208650973866179e-2, -0.5395239384953e-5
-  ];
-  var ser = 1.000000000190015;
-  var xx, y, tmp;
-  tmp = (y = xx = x) + 5.5;
-  tmp -= (xx + 0.5) * Math.log(tmp);
-  for (; j < 6; j++)
-    ser += cof[j] / ++y;
-  return Math.log(2.5066282746310005 * ser / xx) - tmp;
-};
-
-
-// gamma of x
-jStat.gammafn = function gammafn(x) {
-  var p = [-1.716185138865495, 24.76565080557592, -379.80425647094563,
-           629.3311553128184, 866.9662027904133, -31451.272968848367,
-           -36144.413418691176, 66456.14382024054
-  ];
-  var q = [-30.8402300119739, 315.35062697960416, -1015.1563674902192,
-           -3107.771671572311, 22538.118420980151, 4755.8462775278811,
-           -134659.9598649693, -115132.2596755535];
-  var fact = false;
-  var n = 0;
-  var xden = 0;
-  var xnum = 0;
-  var y = x;
-  var i, z, yi, res;
-  if (y <= 0) {
-    res = y % 1 + 3.6e-16;
-    if (res) {
-      fact = (!(y & 1) ? 1 : -1) * Math.PI / Math.sin(Math.PI * res);
-      y = 1 - y;
-    } else {
-      return Infinity;
-    }
-  }
-  yi = y;
-  if (y < 1) {
-    z = y++;
-  } else {
-    z = (y -= n = (y | 0) - 1) - 1;
-  }
-  for (var i = 0; i < 8; ++i) {
-    xnum = (xnum + p[i]) * z;
-    xden = xden * z + q[i];
-  }
-  res = xnum / xden + 1;
-  if (yi < y) {
-    res /= yi;
-  } else if (yi > y) {
-    for (var i = 0; i < n; ++i) {
-      res *= y;
-      y++;
-    }
-  }
-  if (fact) {
-    res = fact / res;
-  }
-  return res;
-};
-
-
-// lower incomplete gamma function, which is usually typeset with a
-// lower-case greek gamma as the function symbol
-jStat.gammap = function gammap(a, x) {
-  return jStat.lowRegGamma(a, x) * jStat.gammafn(a);
-};
-
-
-// The lower regularized incomplete gamma function, usually written P(a,x)
-jStat.lowRegGamma = function lowRegGamma(a, x) {
-  var aln = jStat.gammaln(a);
-  var ap = a;
-  var sum = 1 / a;
-  var del = sum;
-  var b = x + 1 - a;
-  var c = 1 / 1.0e-30;
-  var d = 1 / b;
-  var h = d;
-  var i = 1;
-  // calculate maximum number of itterations required for a
-  var ITMAX = -~(Math.log((a >= 1) ? a : 1 / a) * 8.5 + a * 0.4 + 17);
-  var an;
-
-  if (x < 0 || a <= 0) {
-    return NaN;
-  } else if (x < a + 1) {
-    for (; i <= ITMAX; i++) {
-      sum += del *= x / ++ap;
-    }
-    return (sum * Math.exp(-x + a * Math.log(x) - (aln)));
-  }
-
-  for (; i <= ITMAX; i++) {
-    an = -i * (i - a);
-    b += 2;
-    d = an * d + b;
-    c = b + an / c;
-    d = 1 / d;
-    h *= d * c;
-  }
-
-  return (1 - h * Math.exp(-x + a * Math.log(x) - (aln)));
-};
-
-// natural log factorial of n
-jStat.factorialln = function factorialln(n) {
-  return n < 0 ? NaN : jStat.gammaln(n + 1);
-};
-
-// factorial of n
-jStat.factorial = function factorial(n) {
-  return n < 0 ? NaN : jStat.gammafn(n + 1);
-};
-
-// combinations of n, m
-jStat.combination = function combination(n, m) {
-  // make sure n or m don't exceed the upper limit of usable values
-  return (n > 170 || m > 170)
-      ? Math.exp(jStat.combinationln(n, m))
-      : (jStat.factorial(n) / jStat.factorial(m)) / jStat.factorial(n - m);
-};
-
-
-jStat.combinationln = function combinationln(n, m){
-  return jStat.factorialln(n) - jStat.factorialln(m) - jStat.factorialln(n - m);
-};
-
-
-// permutations of n, m
-jStat.permutation = function permutation(n, m) {
-  return jStat.factorial(n) / jStat.factorial(n - m);
-};
-
-
-// beta function
-jStat.betafn = function betafn(x, y) {
-  // ensure arguments are positive
-  if (x <= 0 || y <= 0)
-    return undefined;
-  // make sure x + y doesn't exceed the upper limit of usable values
-  return (x + y > 170)
-      ? Math.exp(jStat.betaln(x, y))
-      : jStat.gammafn(x) * jStat.gammafn(y) / jStat.gammafn(x + y);
-};
-
-
-// natural logarithm of beta function
-jStat.betaln = function betaln(x, y) {
-  return jStat.gammaln(x) + jStat.gammaln(y) - jStat.gammaln(x + y);
-};
-
-
-// Evaluates the continued fraction for incomplete beta function by modified
-// Lentz's method.
-jStat.betacf = function betacf(x, a, b) {
-  var fpmin = 1e-30;
-  var m = 1;
-  var qab = a + b;
-  var qap = a + 1;
-  var qam = a - 1;
-  var c = 1;
-  var d = 1 - qab * x / qap;
-  var m2, aa, del, h;
-
-  // These q's will be used in factors that occur in the coefficients
-  if (Math.abs(d) < fpmin)
-    d = fpmin;
-  d = 1 / d;
-  h = d;
-
-  for (; m <= 100; m++) {
-    m2 = 2 * m;
-    aa = m * (b - m) * x / ((qam + m2) * (a + m2));
-    // One step (the even one) of the recurrence
-    d = 1 + aa * d;
-    if (Math.abs(d) < fpmin)
-      d = fpmin;
-    c = 1 + aa / c;
-    if (Math.abs(c) < fpmin)
-      c = fpmin;
-    d = 1 / d;
-    h *= d * c;
-    aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2));
-    // Next step of the recurrence (the odd one)
-    d = 1 + aa * d;
-    if (Math.abs(d) < fpmin)
-      d = fpmin;
-    c = 1 + aa / c;
-    if (Math.abs(c) < fpmin)
-      c = fpmin;
-    d = 1 / d;
-    del = d * c;
-    h *= del;
-    if (Math.abs(del - 1.0) < 3e-7)
-      break;
-  }
-
-  return h;
-};
-
-
-// Returns the inverse of the lower regularized inomplete gamma function
-jStat.gammapinv = function gammapinv(p, a) {
-  var j = 0;
-  var a1 = a - 1;
-  var EPS = 1e-8;
-  var gln = jStat.gammaln(a);
-  var x, err, t, u, pp, lna1, afac;
-
-  if (p >= 1)
-    return Math.max(100, a + 100 * Math.sqrt(a));
-  if (p <= 0)
-    return 0;
-  if (a > 1) {
-    lna1 = Math.log(a1);
-    afac = Math.exp(a1 * (lna1 - 1) - gln);
-    pp = (p < 0.5) ? p : 1 - p;
-    t = Math.sqrt(-2 * Math.log(pp));
-    x = (2.30753 + t * 0.27061) / (1 + t * (0.99229 + t * 0.04481)) - t;
-    if (p < 0.5)
-      x = -x;
-    x = Math.max(1e-3,
-                 a * Math.pow(1 - 1 / (9 * a) - x / (3 * Math.sqrt(a)), 3));
-  } else {
-    t = 1 - a * (0.253 + a * 0.12);
-    if (p < t)
-      x = Math.pow(p / t, 1 / a);
-    else
-      x = 1 - Math.log(1 - (p - t) / (1 - t));
-  }
-
-  for(; j < 12; j++) {
-    if (x <= 0)
-      return 0;
-    err = jStat.lowRegGamma(a, x) - p;
-    if (a > 1)
-      t = afac * Math.exp(-(x - a1) + a1 * (Math.log(x) - lna1));
-    else
-      t = Math.exp(-x + a1 * Math.log(x) - gln);
-    u = err / t;
-    x -= (t = u / (1 - 0.5 * Math.min(1, u * ((a - 1) / x - 1))));
-    if (x <= 0)
-      x = 0.5 * (x + t);
-    if (Math.abs(t) < EPS * x)
-      break;
-  }
-
-  return x;
-};
-
-
-// Returns the error function erf(x)
-jStat.erf = function erf(x) {
-  var cof = [-1.3026537197817094, 6.4196979235649026e-1, 1.9476473204185836e-2,
-             -9.561514786808631e-3, -9.46595344482036e-4, 3.66839497852761e-4,
-             4.2523324806907e-5, -2.0278578112534e-5, -1.624290004647e-6,
-             1.303655835580e-6, 1.5626441722e-8, -8.5238095915e-8,
-             6.529054439e-9, 5.059343495e-9, -9.91364156e-10,
-             -2.27365122e-10, 9.6467911e-11, 2.394038e-12,
-             -6.886027e-12, 8.94487e-13, 3.13092e-13,
-             -1.12708e-13, 3.81e-16, 7.106e-15,
-             -1.523e-15, -9.4e-17, 1.21e-16,
-             -2.8e-17];
-  var j = cof.length - 1;
-  var isneg = false;
-  var d = 0;
-  var dd = 0;
-  var t, ty, tmp, res;
-
-  if (x < 0) {
-    x = -x;
-    isneg = true;
-  }
-
-  t = 2 / (2 + x);
-  ty = 4 * t - 2;
-
-  for(; j > 0; j--) {
-    tmp = d;
-    d = ty * d - dd + cof[j];
-    dd = tmp;
-  }
-
-  res = t * Math.exp(-x * x + 0.5 * (cof[0] + ty * d) - dd);
-  return isneg ? res - 1 : 1 - res;
-};
-
-
-// Returns the complmentary error function erfc(x)
-jStat.erfc = function erfc(x) {
-  return 1 - jStat.erf(x);
-};
-
-
-// Returns the inverse of the complementary error function
-jStat.erfcinv = function erfcinv(p) {
-  var j = 0;
-  var x, err, t, pp;
-  if (p >= 2)
-    return -100;
-  if (p <= 0)
-    return 100;
-  pp = (p < 1) ? p : 2 - p;
-  t = Math.sqrt(-2 * Math.log(pp / 2));
-  x = -0.70711 * ((2.30753 + t * 0.27061) /
-                  (1 + t * (0.99229 + t * 0.04481)) - t);
-  for (; j < 2; j++) {
-    err = jStat.erfc(x) - pp;
-    x += err / (1.12837916709551257 * Math.exp(-x * x) - x * err);
-  }
-  return (p < 1) ? x : -x;
-};
-
-
-// Returns the inverse of the incomplete beta function
-jStat.ibetainv = function ibetainv(p, a, b) {
-  var EPS = 1e-8;
-  var a1 = a - 1;
-  var b1 = b - 1;
-  var j = 0;
-  var lna, lnb, pp, t, u, err, x, al, h, w, afac;
-  if (p <= 0)
-    return 0;
-  if (p >= 1)
-    return 1;
-  if (a >= 1 && b >= 1) {
-    pp = (p < 0.5) ? p : 1 - p;
-    t = Math.sqrt(-2 * Math.log(pp));
-    x = (2.30753 + t * 0.27061) / (1 + t* (0.99229 + t * 0.04481)) - t;
-    if (p < 0.5)
-      x = -x;
-    al = (x * x - 3) / 6;
-    h = 2 / (1 / (2 * a - 1)  + 1 / (2 * b - 1));
-    w = (x * Math.sqrt(al + h) / h) - (1 / (2 * b - 1) - 1 / (2 * a - 1)) *
-        (al + 5 / 6 - 2 / (3 * h));
-    x = a / (a + b * Math.exp(2 * w));
-  } else {
-    lna = Math.log(a / (a + b));
-    lnb = Math.log(b / (a + b));
-    t = Math.exp(a * lna) / a;
-    u = Math.exp(b * lnb) / b;
-    w = t + u;
-    if (p < t / w)
-      x = Math.pow(a * w * p, 1 / a);
-    else
-      x = 1 - Math.pow(b * w * (1 - p), 1 / b);
-  }
-  afac = -jStat.gammaln(a) - jStat.gammaln(b) + jStat.gammaln(a + b);
-  for(; j < 10; j++) {
-    if (x === 0 || x === 1)
-      return x;
-    err = jStat.ibeta(x, a, b) - p;
-    t = Math.exp(a1 * Math.log(x) + b1 * Math.log(1 - x) + afac);
-    u = err / t;
-    x -= (t = u / (1 - 0.5 * Math.min(1, u * (a1 / x - b1 / (1 - x)))));
-    if (x <= 0)
-      x = 0.5 * (x + t);
-    if (x >= 1)
-      x = 0.5 * (x + t + 1);
-    if (Math.abs(t) < EPS * x && j > 0)
-      break;
-  }
-  return x;
-};
-
-
-// Returns the incomplete beta function I_x(a,b)
-jStat.ibeta = function ibeta(x, a, b) {
-  // Factors in front of the continued fraction.
-  var bt = (x === 0 || x === 1) ?  0 :
-    Math.exp(jStat.gammaln(a + b) - jStat.gammaln(a) -
-             jStat.gammaln(b) + a * Math.log(x) + b *
-             Math.log(1 - x));
-  if (x < 0 || x > 1)
-    return false;
-  if (x < (a + 1) / (a + b + 2))
-    // Use continued fraction directly.
-    return bt * jStat.betacf(x, a, b) / a;
-  // else use continued fraction after making the symmetry transformation.
-  return 1 - bt * jStat.betacf(1 - x, b, a) / b;
-};
-
-
-// Returns a normal deviate (mu=0, sigma=1).
-// If n and m are specified it returns a object of normal deviates.
-jStat.randn = function randn(n, m) {
-  var u, v, x, y, q;
-  if (!m)
-    m = n;
-  if (n)
-    return jStat.create(n, m, function() { return jStat.randn(); });
-  do {
-    u = Math.random();
-    v = 1.7156 * (Math.random() - 0.5);
-    x = u - 0.449871;
-    y = Math.abs(v) + 0.386595;
-    q = x * x + y * (0.19600 * y - 0.25472 * x);
-  } while (q > 0.27597 && (q > 0.27846 || v * v > -4 * Math.log(u) * u * u));
-  return v / u;
-};
-
-
-// Returns a gamma deviate by the method of Marsaglia and Tsang.
-jStat.randg = function randg(shape, n, m) {
-  var oalph = shape;
-  var a1, a2, u, v, x, mat;
-  if (!m)
-    m = n;
-  if (!shape)
-    shape = 1;
-  if (n) {
-    mat = jStat.zeros(n,m);
-    mat.alter(function() { return jStat.randg(shape); });
-    return mat;
-  }
-  if (shape < 1)
-    shape += 1;
-  a1 = shape - 1 / 3;
-  a2 = 1 / Math.sqrt(9 * a1);
-  do {
-    do {
-      x = jStat.randn();
-      v = 1 + a2 * x;
-    } while(v <= 0);
-    v = v * v * v;
-    u = Math.random();
-  } while(u > 1 - 0.331 * Math.pow(x, 4) &&
-          Math.log(u) > 0.5 * x*x + a1 * (1 - v + Math.log(v)));
-  // alpha > 1
-  if (shape == oalph)
-    return a1 * v;
-  // alpha < 1
-  do {
-    u = Math.random();
-  } while(u === 0);
-  return Math.pow(u, 1 / oalph) * a1 * v;
-};
-
-
-// making use of static methods on the instance
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jStat.fn[passfunc] = function() {
-      return jStat(
-          jStat.map(this, function(value) { return jStat[passfunc](value); }));
-    };
-  })(funcs[i]);
-})('gammaln gammafn factorial factorialln'.split(' '));
-
-
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jStat.fn[passfunc] = function() {
-      return jStat(jStat[passfunc].apply(null, arguments));
-    };
-  })(funcs[i]);
-})('randn'.split(' '));
-
-}(jStat, Math));
-(function(jStat, Math) {
-
-// generate all distribution instance methods
-(function(list) {
-  for (var i = 0; i < list.length; i++) (function(func) {
-    // distribution instance method
-    jStat[func] = function(a, b, c) {
-      if (!(this instanceof arguments.callee))
-        return new arguments.callee(a, b, c);
-      this._a = a;
-      this._b = b;
-      this._c = c;
       return this;
     };
-    // distribution method to be used on a jStat instance
-    jStat.fn[func] = function(a, b, c) {
-      var newthis = jStat[func](a, b, c);
-      newthis.data = this;
-      return newthis;
+    jStat._init.prototype = jStat.prototype;
+    jStat._init.constructor = jStat;
+
+
+    // Utility functions.
+    // TODO: for internal use only?
+    jStat.utils = {
+      calcRdx: calcRdx,
+      isArray: isArray,
+      isFunction: isFunction,
+      isNumber: isNumber,
+      toVector: toVector
     };
-    // sample instance method
-    jStat[func].prototype.sample = function(arr) {
-      var a = this._a;
-      var b = this._b;
-      var c = this._c;
-      if (arr)
-        return jStat.alter(arr, function() {
-          return jStat[func].sample(a, b, c);
+
+
+    // Easily extend the jStat object.
+    // TODO: is this seriously necessary?
+    jStat.extend = function extend(obj) {
+      var i, j;
+
+      if (arguments.length === 1) {
+        for (j in obj)
+          jStat[j] = obj[j];
+        return this;
+      }
+
+      for (var i = 1; i < arguments.length; i++) {
+        for (j in arguments[i])
+          obj[j] = arguments[i][j];
+      }
+
+      return obj;
+    };
+
+
+    // Returns the number of rows in the matrix.
+    jStat.rows = function rows(arr) {
+      return arr.length || 1;
+    };
+
+
+    // Returns the number of columns in the matrix.
+    jStat.cols = function cols(arr) {
+      return arr[0].length || 1;
+    };
+
+
+    // Returns the dimensions of the object { rows: i, cols: j }
+    jStat.dimensions = function dimensions(arr) {
+      return {
+        rows: jStat.rows(arr),
+        cols: jStat.cols(arr)
+      };
+    };
+
+
+    // Returns a specified row as a vector or return a sub matrix by pick some rows
+    jStat.row = function row(arr, index) {
+      if (isArray(index)) {
+        return index.map(function(i) {
+          return jStat.row(arr, i);
+        })
+      }
+      return arr[index];
+    };
+
+
+    // return row as array
+    // rowa([[1,2],[3,4]],0) -> [1,2]
+    jStat.rowa = function rowa(arr, i) {
+      return jStat.row(arr, i);
+    };
+
+
+    // Returns the specified column as a vector or return a sub matrix by pick some
+    // columns
+    jStat.col = function col(arr, index) {
+      if (isArray(index)) {
+        var submat = jStat.arange(arr.length).map(function(i) {
+          return new Array(index.length);
         });
-      else
-        return jStat[func].sample(a, b, c);
+        index.forEach(function(ind, i){
+          jStat.arange(arr.length).forEach(function(j) {
+            submat[j][i] = arr[j][ind];
+          });
+        });
+        return submat;
+      }
+      var column = new Array(arr.length);
+      for (var i = 0; i < arr.length; i++)
+        column[i] = [arr[i][index]];
+      return column;
     };
-    // generate the pdf, cdf and inv instance methods
-    (function(vals) {
-      for (var i = 0; i < vals.length; i++) (function(fnfunc) {
-        jStat[func].prototype[fnfunc] = function(x) {
+
+
+    // return column as array
+    // cola([[1,2],[3,4]],0) -> [1,3]
+    jStat.cola = function cola(arr, i) {
+      return jStat.col(arr, i).map(function(a){ return a[0] });
+    };
+
+
+    // Returns the diagonal of the matrix
+    jStat.diag = function diag(arr) {
+      var nrow = jStat.rows(arr);
+      var res = new Array(nrow);
+      for (var row = 0; row < nrow; row++)
+        res[row] = [arr[row][row]];
+      return res;
+    };
+
+
+    // Returns the anti-diagonal of the matrix
+    jStat.antidiag = function antidiag(arr) {
+      var nrow = jStat.rows(arr) - 1;
+      var res = new Array(nrow);
+      for (var i = 0; nrow >= 0; nrow--, i++)
+        res[i] = [arr[i][nrow]];
+      return res;
+    };
+
+    // Transpose a matrix or array.
+    jStat.transpose = function transpose(arr) {
+      var obj = [];
+      var objArr, rows, cols, j, i;
+
+      // Make sure arr is in matrix format.
+      if (!isArray(arr[0]))
+        arr = [arr];
+
+      rows = arr.length;
+      cols = arr[0].length;
+
+      for (var i = 0; i < cols; i++) {
+        objArr = new Array(rows);
+        for (j = 0; j < rows; j++)
+          objArr[j] = arr[j][i];
+        obj.push(objArr);
+      }
+
+      // If obj is vector, return only single array.
+      return obj.length === 1 ? obj[0] : obj;
+    };
+
+
+    // Map a function to an array or array of arrays.
+    // "toAlter" is an internal variable.
+    jStat.map = function map(arr, func, toAlter) {
+      var row, nrow, ncol, res, col;
+
+      if (!isArray(arr[0]))
+        arr = [arr];
+
+      nrow = arr.length;
+      ncol = arr[0].length;
+      res = toAlter ? arr : new Array(nrow);
+
+      for (row = 0; row < nrow; row++) {
+        // if the row doesn't exist, create it
+        if (!res[row])
+          res[row] = new Array(ncol);
+        for (col = 0; col < ncol; col++)
+          res[row][col] = func(arr[row][col], row, col);
+      }
+
+      return res.length === 1 ? res[0] : res;
+    };
+
+
+    // Cumulatively combine the elements of an array or array of arrays using a function.
+    jStat.cumreduce = function cumreduce(arr, func, toAlter) {
+      var row, nrow, ncol, res, col;
+
+      if (!isArray(arr[0]))
+        arr = [arr];
+
+      nrow = arr.length;
+      ncol = arr[0].length;
+      res = toAlter ? arr : new Array(nrow);
+
+      for (row = 0; row < nrow; row++) {
+        // if the row doesn't exist, create it
+        if (!res[row])
+          res[row] = new Array(ncol);
+        if (ncol > 0)
+          res[row][0] = arr[row][0];
+        for (col = 1; col < ncol; col++)
+          res[row][col] = func(res[row][col-1], arr[row][col]);
+      }
+      return res.length === 1 ? res[0] : res;
+    };
+
+
+    // Destructively alter an array.
+    jStat.alter = function alter(arr, func) {
+      return jStat.map(arr, func, true);
+    };
+
+
+    // Generate a rows x cols matrix according to the supplied function.
+    jStat.create = function  create(rows, cols, func) {
+      var res = new Array(rows);
+      var i, j;
+
+      if (isFunction(cols)) {
+        func = cols;
+        cols = rows;
+      }
+
+      for (var i = 0; i < rows; i++) {
+        res[i] = new Array(cols);
+        for (j = 0; j < cols; j++)
+          res[i][j] = func(i, j);
+      }
+
+      return res;
+    };
+
+
+    function retZero() { return 0; }
+
+
+    // Generate a rows x cols matrix of zeros.
+    jStat.zeros = function zeros(rows, cols) {
+      if (!isNumber(cols))
+        cols = rows;
+      return jStat.create(rows, cols, retZero);
+    };
+
+
+    function retOne() { return 1; }
+
+
+    // Generate a rows x cols matrix of ones.
+    jStat.ones = function ones(rows, cols) {
+      if (!isNumber(cols))
+        cols = rows;
+      return jStat.create(rows, cols, retOne);
+    };
+
+
+    // Generate a rows x cols matrix of uniformly random numbers.
+    jStat.rand = function rand(rows, cols) {
+      if (!isNumber(cols))
+        cols = rows;
+      return jStat.create(rows, cols, Math.random);
+    };
+
+
+    function retIdent(i, j) { return i === j ? 1 : 0; }
+
+
+    // Generate an identity matrix of size row x cols.
+    jStat.identity = function identity(rows, cols) {
+      if (!isNumber(cols))
+        cols = rows;
+      return jStat.create(rows, cols, retIdent);
+    };
+
+
+    // Tests whether a matrix is symmetric
+    jStat.symmetric = function symmetric(arr) {
+      var size = arr.length;
+      var row, col;
+
+      if (arr.length !== arr[0].length)
+        return false;
+
+      for (row = 0; row < size; row++) {
+        for (col = 0; col < size; col++)
+          if (arr[col][row] !== arr[row][col])
+            return false;
+      }
+
+      return true;
+    };
+
+
+    // Set all values to zero.
+    jStat.clear = function clear(arr) {
+      return jStat.alter(arr, retZero);
+    };
+
+
+    // Generate sequence.
+    jStat.seq = function seq(min, max, length, func) {
+      if (!isFunction(func))
+        func = false;
+
+      var arr = [];
+      var hival = calcRdx(min, max);
+      var step = (max * hival - min * hival) / ((length - 1) * hival);
+      var current = min;
+      var cnt;
+
+      // Current is assigned using a technique to compensate for IEEE error.
+      // TODO: Needs better implementation.
+      for (cnt = 0;
+           current <= max && cnt < length;
+           cnt++, current = (min * hival + step * hival * cnt) / hival) {
+        arr.push((func ? func(current, cnt) : current));
+      }
+
+      return arr;
+    };
+
+
+    // arange(5) -> [0,1,2,3,4]
+    // arange(1,5) -> [1,2,3,4]
+    // arange(5,1,-1) -> [5,4,3,2]
+    jStat.arange = function arange(start, end, step) {
+      var rl = [];
+      step = step || 1;
+      if (end === undefined$1) {
+        end = start;
+        start = 0;
+      }
+      if (start === end || step === 0) {
+        return [];
+      }
+      if (start < end && step < 0) {
+        return [];
+      }
+      if (start > end && step > 0) {
+        return [];
+      }
+      if (step > 0) {
+        for (i = start; i < end; i += step) {
+          rl.push(i);
+        }
+      } else {
+        for (i = start; i > end; i += step) {
+          rl.push(i);
+        }
+      }
+      return rl;
+    };
+
+
+    // A=[[1,2,3],[4,5,6],[7,8,9]]
+    // slice(A,{row:{end:2},col:{start:1}}) -> [[2,3],[5,6]]
+    // slice(A,1,{start:1}) -> [5,6]
+    // as numpy code A[:2,1:]
+    jStat.slice = (function(){
+      function _slice(list, start, end, step) {
+        // note it's not equal to range.map mode it's a bug
+        var i;
+        var rl = [];
+        var length = list.length;
+        if (start === undefined$1 && end === undefined$1 && step === undefined$1) {
+          return jStat.copy(list);
+        }
+
+        start = start || 0;
+        end = end || list.length;
+        start = start >= 0 ? start : length + start;
+        end = end >= 0 ? end : length + end;
+        step = step || 1;
+        if (start === end || step === 0) {
+          return [];
+        }
+        if (start < end && step < 0) {
+          return [];
+        }
+        if (start > end && step > 0) {
+          return [];
+        }
+        if (step > 0) {
+          for (i = start; i < end; i += step) {
+            rl.push(list[i]);
+          }
+        } else {
+          for (i = start; i > end;i += step) {
+            rl.push(list[i]);
+          }
+        }
+        return rl;
+      }
+
+      function slice(list, rcSlice) {
+        rcSlice = rcSlice || {};
+        if (isNumber(rcSlice.row)) {
+          if (isNumber(rcSlice.col))
+            return list[rcSlice.row][rcSlice.col];
+          var row = jStat.rowa(list, rcSlice.row);
+          var colSlice = rcSlice.col || {};
+          return _slice(row, colSlice.start, colSlice.end, colSlice.step);
+        }
+
+        if (isNumber(rcSlice.col)) {
+          var col = jStat.cola(list, rcSlice.col);
+          var rowSlice = rcSlice.row || {};
+          return _slice(col, rowSlice.start, rowSlice.end, rowSlice.step);
+        }
+
+        var rowSlice = rcSlice.row || {};
+        var colSlice = rcSlice.col || {};
+        var rows = _slice(list, rowSlice.start, rowSlice.end, rowSlice.step);
+        return rows.map(function(row) {
+          return _slice(row, colSlice.start, colSlice.end, colSlice.step);
+        });
+      }
+
+      return slice;
+    }());
+
+
+    // A=[[1,2,3],[4,5,6],[7,8,9]]
+    // sliceAssign(A,{row:{start:1},col:{start:1}},[[0,0],[0,0]])
+    // A=[[1,2,3],[4,0,0],[7,0,0]]
+    jStat.sliceAssign = function sliceAssign(A, rcSlice, B) {
+      if (isNumber(rcSlice.row)) {
+        if (isNumber(rcSlice.col))
+          return A[rcSlice.row][rcSlice.col] = B;
+        rcSlice.col = rcSlice.col || {};
+        rcSlice.col.start = rcSlice.col.start || 0;
+        rcSlice.col.end = rcSlice.col.end || A[0].length;
+        rcSlice.col.step = rcSlice.col.step || 1;
+        var nl = jStat.arange(rcSlice.col.start,
+                              Math.min(A.length, rcSlice.col.end),
+                              rcSlice.col.step);
+        var m = rcSlice.row;
+        nl.forEach(function(n, i) {
+          A[m][n] = B[i];
+        });
+        return A;
+      }
+
+      if (isNumber(rcSlice.col)) {
+        rcSlice.row = rcSlice.row || {};
+        rcSlice.row.start = rcSlice.row.start || 0;
+        rcSlice.row.end = rcSlice.row.end || A.length;
+        rcSlice.row.step = rcSlice.row.step || 1;
+        var ml = jStat.arange(rcSlice.row.start,
+                              Math.min(A[0].length, rcSlice.row.end),
+                              rcSlice.row.step);
+        var n = rcSlice.col;
+        ml.forEach(function(m, j) {
+          A[m][n] = B[j];
+        });
+        return A;
+      }
+
+      if (B[0].length === undefined$1) {
+        B = [B];
+      }
+      rcSlice.row.start = rcSlice.row.start || 0;
+      rcSlice.row.end = rcSlice.row.end || A.length;
+      rcSlice.row.step = rcSlice.row.step || 1;
+      rcSlice.col.start = rcSlice.col.start || 0;
+      rcSlice.col.end = rcSlice.col.end || A[0].length;
+      rcSlice.col.step = rcSlice.col.step || 1;
+      var ml = jStat.arange(rcSlice.row.start,
+                            Math.min(A.length, rcSlice.row.end),
+                            rcSlice.row.step);
+      var nl = jStat.arange(rcSlice.col.start,
+                            Math.min(A[0].length, rcSlice.col.end),
+                            rcSlice.col.step);
+      ml.forEach(function(m, i) {
+        nl.forEach(function(n, j) {
+          A[m][n] = B[i][j];
+        });
+      });
+      return A;
+    };
+
+
+    // [1,2,3] ->
+    // [[1,0,0],[0,2,0],[0,0,3]]
+    jStat.diagonal = function diagonal(diagArray) {
+      var mat = jStat.zeros(diagArray.length, diagArray.length);
+      diagArray.forEach(function(t, i) {
+        mat[i][i] = t;
+      });
+      return mat;
+    };
+
+
+    // return copy of A
+    jStat.copy = function copy(A) {
+      return A.map(function(row) {
+        if (isNumber(row))
+          return row;
+        return row.map(function(t) {
+          return t;
+        });
+      });
+    };
+
+
+    // TODO: Go over this entire implementation. Seems a tragic waste of resources
+    // doing all this work. Instead, and while ugly, use new Function() to generate
+    // a custom function for each static method.
+
+    // Quick reference.
+    var jProto = jStat.prototype;
+
+    // Default length.
+    jProto.length = 0;
+
+    // For internal use only.
+    // TODO: Check if they're actually used, and if they are then rename them
+    // to _*
+    jProto.push = Array.prototype.push;
+    jProto.sort = Array.prototype.sort;
+    jProto.splice = Array.prototype.splice;
+    jProto.slice = Array.prototype.slice;
+
+
+    // Return a clean array.
+    jProto.toArray = function toArray() {
+      return this.length > 1 ? slice.call(this) : slice.call(this)[0];
+    };
+
+
+    // Map a function to a matrix or vector.
+    jProto.map = function map(func, toAlter) {
+      return jStat(jStat.map(this, func, toAlter));
+    };
+
+
+    // Cumulatively combine the elements of a matrix or vector using a function.
+    jProto.cumreduce = function cumreduce(func, toAlter) {
+      return jStat(jStat.cumreduce(this, func, toAlter));
+    };
+
+
+    // Destructively alter an array.
+    jProto.alter = function alter(func) {
+      jStat.alter(this, func);
+      return this;
+    };
+
+
+    // Extend prototype with methods that have no argument.
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jProto[passfunc] = function(func) {
+          var self = this,
+          results;
+          // Check for callback.
+          if (func) {
+            setTimeout(function() {
+              func.call(self, jProto[passfunc].call(self));
+            });
+            return this;
+          }
+          results = jStat[passfunc](this);
+          return isArray(results) ? jStat(results) : results;
+        };
+      })(funcs[i]);
+    })('transpose clear symmetric rows cols dimensions diag antidiag'.split(' '));
+
+
+    // Extend prototype with methods that have one argument.
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jProto[passfunc] = function(index, func) {
+          var self = this;
+          // check for callback
+          if (func) {
+            setTimeout(function() {
+              func.call(self, jProto[passfunc].call(self, index));
+            });
+            return this;
+          }
+          return jStat(jStat[passfunc](this, index));
+        };
+      })(funcs[i]);
+    })('row col'.split(' '));
+
+
+    // Extend prototype with simple shortcut methods.
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jProto[passfunc] = new Function(
+            'return jStat(jStat.' + passfunc + '.apply(null, arguments));');
+      })(funcs[i]);
+    })('create zeros ones rand identity'.split(' '));
+
+
+    // Exposing jStat.
+    return jStat;
+
+    }(Math));
+    (function(jStat, Math) {
+
+    var isFunction = jStat.utils.isFunction;
+
+    // Ascending functions for sort
+    function ascNum(a, b) { return a - b; }
+
+    function clip(arg, min, max) {
+      return Math.max(min, Math.min(arg, max));
+    }
+
+
+    // sum of an array
+    jStat.sum = function sum(arr) {
+      var sum = 0;
+      var i = arr.length;
+      while (--i >= 0)
+        sum += arr[i];
+      return sum;
+    };
+
+
+    // sum squared
+    jStat.sumsqrd = function sumsqrd(arr) {
+      var sum = 0;
+      var i = arr.length;
+      while (--i >= 0)
+        sum += arr[i] * arr[i];
+      return sum;
+    };
+
+
+    // sum of squared errors of prediction (SSE)
+    jStat.sumsqerr = function sumsqerr(arr) {
+      var mean = jStat.mean(arr);
+      var sum = 0;
+      var i = arr.length;
+      var tmp;
+      while (--i >= 0) {
+        tmp = arr[i] - mean;
+        sum += tmp * tmp;
+      }
+      return sum;
+    };
+
+    // sum of an array in each row
+    jStat.sumrow = function sumrow(arr) {
+      var sum = 0;
+      var i = arr.length;
+      while (--i >= 0)
+        sum += arr[i];
+      return sum;
+    };
+
+    // product of an array
+    jStat.product = function product(arr) {
+      var prod = 1;
+      var i = arr.length;
+      while (--i >= 0)
+        prod *= arr[i];
+      return prod;
+    };
+
+
+    // minimum value of an array
+    jStat.min = function min(arr) {
+      var low = arr[0];
+      var i = 0;
+      while (++i < arr.length)
+        if (arr[i] < low)
+          low = arr[i];
+      return low;
+    };
+
+
+    // maximum value of an array
+    jStat.max = function max(arr) {
+      var high = arr[0];
+      var i = 0;
+      while (++i < arr.length)
+        if (arr[i] > high)
+          high = arr[i];
+      return high;
+    };
+
+
+    // unique values of an array
+    jStat.unique = function unique(arr) {
+      var hash = {}, _arr = [];
+      for(var i = 0; i < arr.length; i++) {
+        if (!hash[arr[i]]) {
+          hash[arr[i]] = true;
+          _arr.push(arr[i]);
+        }
+      }
+      return _arr;
+    };
+
+
+    // mean value of an array
+    jStat.mean = function mean(arr) {
+      return jStat.sum(arr) / arr.length;
+    };
+
+
+    // mean squared error (MSE)
+    jStat.meansqerr = function meansqerr(arr) {
+      return jStat.sumsqerr(arr) / arr.length;
+    };
+
+
+    // geometric mean of an array
+    jStat.geomean = function geomean(arr) {
+      return Math.pow(jStat.product(arr), 1 / arr.length);
+    };
+
+
+    // median of an array
+    jStat.median = function median(arr) {
+      var arrlen = arr.length;
+      var _arr = arr.slice().sort(ascNum);
+      // check if array is even or odd, then return the appropriate
+      return !(arrlen & 1)
+        ? (_arr[(arrlen / 2) - 1 ] + _arr[(arrlen / 2)]) / 2
+        : _arr[(arrlen / 2) | 0 ];
+    };
+
+
+    // cumulative sum of an array
+    jStat.cumsum = function cumsum(arr) {
+      return jStat.cumreduce(arr, function (a, b) { return a + b; });
+    };
+
+
+    // cumulative product of an array
+    jStat.cumprod = function cumprod(arr) {
+      return jStat.cumreduce(arr, function (a, b) { return a * b; });
+    };
+
+
+    // successive differences of a sequence
+    jStat.diff = function diff(arr) {
+      var diffs = [];
+      var arrLen = arr.length;
+      var i;
+      for (var i = 1; i < arrLen; i++)
+        diffs.push(arr[i] - arr[i - 1]);
+      return diffs;
+    };
+
+
+    // ranks of an array
+    jStat.rank = function (arr) {
+      var arrlen = arr.length;
+      var sorted = arr.slice().sort(ascNum);
+      var ranks = new Array(arrlen);
+      for (var i = 0; i < arrlen; i++) {
+        var first = sorted.indexOf(arr[i]);
+        var last = sorted.lastIndexOf(arr[i]);
+        if (first === last) {
+          var val = first;
+        } else {
+          var val = (first + last) / 2;
+        }
+        ranks[i] = val + 1;
+      }
+      return ranks;
+    };
+
+
+    // mode of an array
+    // if there are multiple modes of an array, return all of them
+    // is this the appropriate way of handling it?
+    jStat.mode = function mode(arr) {
+      var arrLen = arr.length;
+      var _arr = arr.slice().sort(ascNum);
+      var count = 1;
+      var maxCount = 0;
+      var numMaxCount = 0;
+      var mode_arr = [];
+      var i;
+
+      for (var i = 0; i < arrLen; i++) {
+        if (_arr[i] === _arr[i + 1]) {
+          count++;
+        } else {
+          if (count > maxCount) {
+            mode_arr = [_arr[i]];
+            maxCount = count;
+            numMaxCount = 0;
+          }
+          // are there multiple max counts
+          else if (count === maxCount) {
+            mode_arr.push(_arr[i]);
+            numMaxCount++;
+          }
+          // resetting count for new value in array
+          count = 1;
+        }
+      }
+
+      return numMaxCount === 0 ? mode_arr[0] : mode_arr;
+    };
+
+
+    // range of an array
+    jStat.range = function range(arr) {
+      return jStat.max(arr) - jStat.min(arr);
+    };
+
+    // variance of an array
+    // flag = true indicates sample instead of population
+    jStat.variance = function variance(arr, flag) {
+      return jStat.sumsqerr(arr) / (arr.length - (flag ? 1 : 0));
+    };
+
+    // pooled variance of an array of arrays
+    jStat.pooledvariance = function pooledvariance(arr) {
+      var sumsqerr = arr.reduce(function (a, samples) {return a + jStat.sumsqerr(samples);}, 0);
+      var count = arr.reduce(function (a, samples) {return a + samples.length;}, 0);
+      return sumsqerr / (count - arr.length);
+    };
+
+    // deviation of an array
+    jStat.deviation = function (arr) {
+      var mean = jStat.mean(arr);
+      var arrlen = arr.length;
+      var dev = new Array(arrlen);
+      for (var i = 0; i < arrlen; i++) {
+        dev[i] = arr[i] - mean;
+      }
+      return dev;
+    };
+
+    // standard deviation of an array
+    // flag = true indicates sample instead of population
+    jStat.stdev = function stdev(arr, flag) {
+      return Math.sqrt(jStat.variance(arr, flag));
+    };
+
+    // pooled standard deviation of an array of arrays
+    jStat.pooledstdev = function pooledstdev(arr) {
+      return Math.sqrt(jStat.pooledvariance(arr));
+    };
+
+    // mean deviation (mean absolute deviation) of an array
+    jStat.meandev = function meandev(arr) {
+      var mean = jStat.mean(arr);
+      var a = [];
+      for (var i = arr.length - 1; i >= 0; i--) {
+        a.push(Math.abs(arr[i] - mean));
+      }
+      return jStat.mean(a);
+    };
+
+
+    // median deviation (median absolute deviation) of an array
+    jStat.meddev = function meddev(arr) {
+      var median = jStat.median(arr);
+      var a = [];
+      for (var i = arr.length - 1; i >= 0; i--) {
+        a.push(Math.abs(arr[i] - median));
+      }
+      return jStat.median(a);
+    };
+
+
+    // coefficient of variation
+    jStat.coeffvar = function coeffvar(arr) {
+      return jStat.stdev(arr) / jStat.mean(arr);
+    };
+
+
+    // quartiles of an array
+    jStat.quartiles = function quartiles(arr) {
+      var arrlen = arr.length;
+      var _arr = arr.slice().sort(ascNum);
+      return [
+        _arr[ Math.round((arrlen) / 4) - 1 ],
+        _arr[ Math.round((arrlen) / 2) - 1 ],
+        _arr[ Math.round((arrlen) * 3 / 4) - 1 ]
+      ];
+    };
+
+
+    // Arbitary quantiles of an array. Direct port of the scipy.stats
+    // implementation by Pierre GF Gerard-Marchant.
+    jStat.quantiles = function quantiles(arr, quantilesArray, alphap, betap) {
+      var sortedArray = arr.slice().sort(ascNum);
+      var quantileVals = [quantilesArray.length];
+      var n = arr.length;
+      var i, p, m, aleph, k, gamma;
+
+      if (typeof alphap === 'undefined')
+        alphap = 3 / 8;
+      if (typeof betap === 'undefined')
+        betap = 3 / 8;
+
+      for (var i = 0; i < quantilesArray.length; i++) {
+        p = quantilesArray[i];
+        m = alphap + p * (1 - alphap - betap);
+        aleph = n * p + m;
+        k = Math.floor(clip(aleph, 1, n - 1));
+        gamma = clip(aleph - k, 0, 1);
+        quantileVals[i] = (1 - gamma) * sortedArray[k - 1] + gamma * sortedArray[k];
+      }
+
+      return quantileVals;
+    };
+
+    // Returns the k-th percentile of values in a range, where k is in the
+    // range 0..1, exclusive.
+    jStat.percentile = function percentile(arr, k) {
+      var _arr = arr.slice().sort(ascNum);
+      var realIndex = k * (_arr.length - 1);
+      var index = parseInt(realIndex);
+      var frac = realIndex - index;
+
+      if (index + 1 < _arr.length) {
+        return _arr[index] * (1 - frac) + _arr[index + 1] * frac;
+      } else {
+        return _arr[index];
+      }
+    };
+
+
+    // The percentile rank of score in a given array. Returns the percentage
+    // of all values in the input array that are less than (kind='strict') or
+    // less or equal than (kind='weak') score. Default is weak.
+    jStat.percentileOfScore = function percentileOfScore(arr, score, kind) {
+      var counter = 0;
+      var len = arr.length;
+      var strict = false;
+      var value, i;
+
+      if (kind === 'strict')
+        strict = true;
+
+      for (var i = 0; i < len; i++) {
+        value = arr[i];
+        if ((strict && value < score) ||
+            (!strict && value <= score)) {
+          counter++;
+        }
+      }
+
+      return counter / len;
+    };
+
+
+    // Histogram (bin count) data
+    jStat.histogram = function histogram(arr, bins) {
+      var first = jStat.min(arr);
+      var binCnt = bins || 4;
+      var binWidth = (jStat.max(arr) - first) / binCnt;
+      var len = arr.length;
+      var bins = [];
+      var i;
+
+      for (var i = 0; i < binCnt; i++)
+        bins[i] = 0;
+      for (var i = 0; i < len; i++)
+        bins[Math.min(Math.floor(((arr[i] - first) / binWidth)), binCnt - 1)] += 1;
+
+      return bins;
+    };
+
+
+    // covariance of two arrays
+    jStat.covariance = function covariance(arr1, arr2) {
+      var u = jStat.mean(arr1);
+      var v = jStat.mean(arr2);
+      var arr1Len = arr1.length;
+      var sq_dev = new Array(arr1Len);
+      var i;
+
+      for (var i = 0; i < arr1Len; i++)
+        sq_dev[i] = (arr1[i] - u) * (arr2[i] - v);
+
+      return jStat.sum(sq_dev) / (arr1Len - 1);
+    };
+
+
+    // (pearson's) population correlation coefficient, rho
+    jStat.corrcoeff = function corrcoeff(arr1, arr2) {
+      return jStat.covariance(arr1, arr2) /
+          jStat.stdev(arr1, 1) /
+          jStat.stdev(arr2, 1);
+    };
+
+      // (spearman's) rank correlation coefficient, sp
+    jStat.spearmancoeff =  function (arr1, arr2) {
+      arr1 = jStat.rank(arr1);
+      arr2 = jStat.rank(arr2);
+      //return pearson's correlation of the ranks:
+      return jStat.corrcoeff(arr1, arr2);
+    };
+
+
+    // statistical standardized moments (general form of skew/kurt)
+    jStat.stanMoment = function stanMoment(arr, n) {
+      var mu = jStat.mean(arr);
+      var sigma = jStat.stdev(arr);
+      var len = arr.length;
+      var skewSum = 0;
+
+      for (var i = 0; i < len; i++)
+        skewSum += Math.pow((arr[i] - mu) / sigma, n);
+
+      return skewSum / arr.length;
+    };
+
+    // (pearson's) moment coefficient of skewness
+    jStat.skewness = function skewness(arr) {
+      return jStat.stanMoment(arr, 3);
+    };
+
+    // (pearson's) (excess) kurtosis
+    jStat.kurtosis = function kurtosis(arr) {
+      return jStat.stanMoment(arr, 4) - 3;
+    };
+
+
+    var jProto = jStat.prototype;
+
+
+    // Extend jProto with method for calculating cumulative sums and products.
+    // This differs from the similar extension below as cumsum and cumprod should
+    // not be run again in the case fullbool === true.
+    // If a matrix is passed, automatically assume operation should be done on the
+    // columns.
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        // If a matrix is passed, automatically assume operation should be done on
+        // the columns.
+        jProto[passfunc] = function(fullbool, func) {
+          var arr = [];
+          var i = 0;
+          var tmpthis = this;
+          // Assignment reassignation depending on how parameters were passed in.
+          if (isFunction(fullbool)) {
+            func = fullbool;
+            fullbool = false;
+          }
+          // Check if a callback was passed with the function.
+          if (func) {
+            setTimeout(function() {
+              func.call(tmpthis, jProto[passfunc].call(tmpthis, fullbool));
+            });
+            return this;
+          }
+          // Check if matrix and run calculations.
+          if (this.length > 1) {
+            tmpthis = fullbool === true ? this : this.transpose();
+            for (; i < tmpthis.length; i++)
+              arr[i] = jStat[passfunc](tmpthis[i]);
+            return arr;
+          }
+          // Pass fullbool if only vector, not a matrix. for variance and stdev.
+          return jStat[passfunc](this[0], fullbool);
+        };
+      })(funcs[i]);
+    })(('cumsum cumprod').split(' '));
+
+
+    // Extend jProto with methods which don't require arguments and work on columns.
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        // If a matrix is passed, automatically assume operation should be done on
+        // the columns.
+        jProto[passfunc] = function(fullbool, func) {
+          var arr = [];
+          var i = 0;
+          var tmpthis = this;
+          // Assignment reassignation depending on how parameters were passed in.
+          if (isFunction(fullbool)) {
+            func = fullbool;
+            fullbool = false;
+          }
+          // Check if a callback was passed with the function.
+          if (func) {
+            setTimeout(function() {
+              func.call(tmpthis, jProto[passfunc].call(tmpthis, fullbool));
+            });
+            return this;
+          }
+          // Check if matrix and run calculations.
+          if (this.length > 1) {
+            if (passfunc !== 'sumrow')
+              tmpthis = fullbool === true ? this : this.transpose();
+            for (; i < tmpthis.length; i++)
+              arr[i] = jStat[passfunc](tmpthis[i]);
+            return fullbool === true
+                ? jStat[passfunc](jStat.utils.toVector(arr))
+                : arr;
+          }
+          // Pass fullbool if only vector, not a matrix. for variance and stdev.
+          return jStat[passfunc](this[0], fullbool);
+        };
+      })(funcs[i]);
+    })(('sum sumsqrd sumsqerr sumrow product min max unique mean meansqerr ' +
+        'geomean median diff rank mode range variance deviation stdev meandev ' +
+        'meddev coeffvar quartiles histogram skewness kurtosis').split(' '));
+
+
+    // Extend jProto with functions that take arguments. Operations on matrices are
+    // done on columns.
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jProto[passfunc] = function() {
+          var arr = [];
+          var i = 0;
+          var tmpthis = this;
+          var args = Array.prototype.slice.call(arguments);
+
+          // If the last argument is a function, we assume it's a callback; we
+          // strip the callback out and call the function again.
+          if (isFunction(args[args.length - 1])) {
+            var callbackFunction = args[args.length - 1];
+            var argsToPass = args.slice(0, args.length - 1);
+
+            setTimeout(function() {
+              callbackFunction.call(tmpthis,
+                                    jProto[passfunc].apply(tmpthis, argsToPass));
+            });
+            return this;
+
+          // Otherwise we curry the function args and call normally.
+          } else {
+            var callbackFunction = undefined;
+            var curriedFunction = function curriedFunction(vector) {
+              return jStat[passfunc].apply(tmpthis, [vector].concat(args));
+            };
+          }
+
+          // If this is a matrix, run column-by-column.
+          if (this.length > 1) {
+            tmpthis = tmpthis.transpose();
+            for (; i < tmpthis.length; i++)
+              arr[i] = curriedFunction(tmpthis[i]);
+            return arr;
+          }
+
+          // Otherwise run on the vector.
+          return curriedFunction(this[0]);
+        };
+      })(funcs[i]);
+    })('quantiles percentileOfScore'.split(' '));
+
+    }(jStat, Math));
+    // Special functions //
+    (function(jStat, Math) {
+
+    // Log-gamma function
+    jStat.gammaln = function gammaln(x) {
+      var j = 0;
+      var cof = [
+        76.18009172947146, -86.50532032941677, 24.01409824083091,
+        -1.231739572450155, 0.1208650973866179e-2, -0.5395239384953e-5
+      ];
+      var ser = 1.000000000190015;
+      var xx, y, tmp;
+      tmp = (y = xx = x) + 5.5;
+      tmp -= (xx + 0.5) * Math.log(tmp);
+      for (; j < 6; j++)
+        ser += cof[j] / ++y;
+      return Math.log(2.5066282746310005 * ser / xx) - tmp;
+    };
+
+
+    // gamma of x
+    jStat.gammafn = function gammafn(x) {
+      var p = [-1.716185138865495, 24.76565080557592, -379.80425647094563,
+               629.3311553128184, 866.9662027904133, -31451.272968848367,
+               -36144.413418691176, 66456.14382024054
+      ];
+      var q = [-30.8402300119739, 315.35062697960416, -1015.1563674902192,
+               -3107.771671572311, 22538.118420980151, 4755.8462775278811,
+               -134659.9598649693, -115132.2596755535];
+      var fact = false;
+      var n = 0;
+      var xden = 0;
+      var xnum = 0;
+      var y = x;
+      var i, z, yi, res;
+      if (y <= 0) {
+        res = y % 1 + 3.6e-16;
+        if (res) {
+          fact = (!(y & 1) ? 1 : -1) * Math.PI / Math.sin(Math.PI * res);
+          y = 1 - y;
+        } else {
+          return Infinity;
+        }
+      }
+      yi = y;
+      if (y < 1) {
+        z = y++;
+      } else {
+        z = (y -= n = (y | 0) - 1) - 1;
+      }
+      for (var i = 0; i < 8; ++i) {
+        xnum = (xnum + p[i]) * z;
+        xden = xden * z + q[i];
+      }
+      res = xnum / xden + 1;
+      if (yi < y) {
+        res /= yi;
+      } else if (yi > y) {
+        for (var i = 0; i < n; ++i) {
+          res *= y;
+          y++;
+        }
+      }
+      if (fact) {
+        res = fact / res;
+      }
+      return res;
+    };
+
+
+    // lower incomplete gamma function, which is usually typeset with a
+    // lower-case greek gamma as the function symbol
+    jStat.gammap = function gammap(a, x) {
+      return jStat.lowRegGamma(a, x) * jStat.gammafn(a);
+    };
+
+
+    // The lower regularized incomplete gamma function, usually written P(a,x)
+    jStat.lowRegGamma = function lowRegGamma(a, x) {
+      var aln = jStat.gammaln(a);
+      var ap = a;
+      var sum = 1 / a;
+      var del = sum;
+      var b = x + 1 - a;
+      var c = 1 / 1.0e-30;
+      var d = 1 / b;
+      var h = d;
+      var i = 1;
+      // calculate maximum number of itterations required for a
+      var ITMAX = -~(Math.log((a >= 1) ? a : 1 / a) * 8.5 + a * 0.4 + 17);
+      var an;
+
+      if (x < 0 || a <= 0) {
+        return NaN;
+      } else if (x < a + 1) {
+        for (; i <= ITMAX; i++) {
+          sum += del *= x / ++ap;
+        }
+        return (sum * Math.exp(-x + a * Math.log(x) - (aln)));
+      }
+
+      for (; i <= ITMAX; i++) {
+        an = -i * (i - a);
+        b += 2;
+        d = an * d + b;
+        c = b + an / c;
+        d = 1 / d;
+        h *= d * c;
+      }
+
+      return (1 - h * Math.exp(-x + a * Math.log(x) - (aln)));
+    };
+
+    // natural log factorial of n
+    jStat.factorialln = function factorialln(n) {
+      return n < 0 ? NaN : jStat.gammaln(n + 1);
+    };
+
+    // factorial of n
+    jStat.factorial = function factorial(n) {
+      return n < 0 ? NaN : jStat.gammafn(n + 1);
+    };
+
+    // combinations of n, m
+    jStat.combination = function combination(n, m) {
+      // make sure n or m don't exceed the upper limit of usable values
+      return (n > 170 || m > 170)
+          ? Math.exp(jStat.combinationln(n, m))
+          : (jStat.factorial(n) / jStat.factorial(m)) / jStat.factorial(n - m);
+    };
+
+
+    jStat.combinationln = function combinationln(n, m){
+      return jStat.factorialln(n) - jStat.factorialln(m) - jStat.factorialln(n - m);
+    };
+
+
+    // permutations of n, m
+    jStat.permutation = function permutation(n, m) {
+      return jStat.factorial(n) / jStat.factorial(n - m);
+    };
+
+
+    // beta function
+    jStat.betafn = function betafn(x, y) {
+      // ensure arguments are positive
+      if (x <= 0 || y <= 0)
+        return undefined;
+      // make sure x + y doesn't exceed the upper limit of usable values
+      return (x + y > 170)
+          ? Math.exp(jStat.betaln(x, y))
+          : jStat.gammafn(x) * jStat.gammafn(y) / jStat.gammafn(x + y);
+    };
+
+
+    // natural logarithm of beta function
+    jStat.betaln = function betaln(x, y) {
+      return jStat.gammaln(x) + jStat.gammaln(y) - jStat.gammaln(x + y);
+    };
+
+
+    // Evaluates the continued fraction for incomplete beta function by modified
+    // Lentz's method.
+    jStat.betacf = function betacf(x, a, b) {
+      var fpmin = 1e-30;
+      var m = 1;
+      var qab = a + b;
+      var qap = a + 1;
+      var qam = a - 1;
+      var c = 1;
+      var d = 1 - qab * x / qap;
+      var m2, aa, del, h;
+
+      // These q's will be used in factors that occur in the coefficients
+      if (Math.abs(d) < fpmin)
+        d = fpmin;
+      d = 1 / d;
+      h = d;
+
+      for (; m <= 100; m++) {
+        m2 = 2 * m;
+        aa = m * (b - m) * x / ((qam + m2) * (a + m2));
+        // One step (the even one) of the recurrence
+        d = 1 + aa * d;
+        if (Math.abs(d) < fpmin)
+          d = fpmin;
+        c = 1 + aa / c;
+        if (Math.abs(c) < fpmin)
+          c = fpmin;
+        d = 1 / d;
+        h *= d * c;
+        aa = -(a + m) * (qab + m) * x / ((a + m2) * (qap + m2));
+        // Next step of the recurrence (the odd one)
+        d = 1 + aa * d;
+        if (Math.abs(d) < fpmin)
+          d = fpmin;
+        c = 1 + aa / c;
+        if (Math.abs(c) < fpmin)
+          c = fpmin;
+        d = 1 / d;
+        del = d * c;
+        h *= del;
+        if (Math.abs(del - 1.0) < 3e-7)
+          break;
+      }
+
+      return h;
+    };
+
+
+    // Returns the inverse of the lower regularized inomplete gamma function
+    jStat.gammapinv = function gammapinv(p, a) {
+      var j = 0;
+      var a1 = a - 1;
+      var EPS = 1e-8;
+      var gln = jStat.gammaln(a);
+      var x, err, t, u, pp, lna1, afac;
+
+      if (p >= 1)
+        return Math.max(100, a + 100 * Math.sqrt(a));
+      if (p <= 0)
+        return 0;
+      if (a > 1) {
+        lna1 = Math.log(a1);
+        afac = Math.exp(a1 * (lna1 - 1) - gln);
+        pp = (p < 0.5) ? p : 1 - p;
+        t = Math.sqrt(-2 * Math.log(pp));
+        x = (2.30753 + t * 0.27061) / (1 + t * (0.99229 + t * 0.04481)) - t;
+        if (p < 0.5)
+          x = -x;
+        x = Math.max(1e-3,
+                     a * Math.pow(1 - 1 / (9 * a) - x / (3 * Math.sqrt(a)), 3));
+      } else {
+        t = 1 - a * (0.253 + a * 0.12);
+        if (p < t)
+          x = Math.pow(p / t, 1 / a);
+        else
+          x = 1 - Math.log(1 - (p - t) / (1 - t));
+      }
+
+      for(; j < 12; j++) {
+        if (x <= 0)
+          return 0;
+        err = jStat.lowRegGamma(a, x) - p;
+        if (a > 1)
+          t = afac * Math.exp(-(x - a1) + a1 * (Math.log(x) - lna1));
+        else
+          t = Math.exp(-x + a1 * Math.log(x) - gln);
+        u = err / t;
+        x -= (t = u / (1 - 0.5 * Math.min(1, u * ((a - 1) / x - 1))));
+        if (x <= 0)
+          x = 0.5 * (x + t);
+        if (Math.abs(t) < EPS * x)
+          break;
+      }
+
+      return x;
+    };
+
+
+    // Returns the error function erf(x)
+    jStat.erf = function erf(x) {
+      var cof = [-1.3026537197817094, 6.4196979235649026e-1, 1.9476473204185836e-2,
+                 -9.561514786808631e-3, -9.46595344482036e-4, 3.66839497852761e-4,
+                 4.2523324806907e-5, -2.0278578112534e-5, -1.624290004647e-6,
+                 1.303655835580e-6, 1.5626441722e-8, -8.5238095915e-8,
+                 6.529054439e-9, 5.059343495e-9, -9.91364156e-10,
+                 -2.27365122e-10, 9.6467911e-11, 2.394038e-12,
+                 -6.886027e-12, 8.94487e-13, 3.13092e-13,
+                 -1.12708e-13, 3.81e-16, 7.106e-15,
+                 -1.523e-15, -9.4e-17, 1.21e-16,
+                 -2.8e-17];
+      var j = cof.length - 1;
+      var isneg = false;
+      var d = 0;
+      var dd = 0;
+      var t, ty, tmp, res;
+
+      if (x < 0) {
+        x = -x;
+        isneg = true;
+      }
+
+      t = 2 / (2 + x);
+      ty = 4 * t - 2;
+
+      for(; j > 0; j--) {
+        tmp = d;
+        d = ty * d - dd + cof[j];
+        dd = tmp;
+      }
+
+      res = t * Math.exp(-x * x + 0.5 * (cof[0] + ty * d) - dd);
+      return isneg ? res - 1 : 1 - res;
+    };
+
+
+    // Returns the complmentary error function erfc(x)
+    jStat.erfc = function erfc(x) {
+      return 1 - jStat.erf(x);
+    };
+
+
+    // Returns the inverse of the complementary error function
+    jStat.erfcinv = function erfcinv(p) {
+      var j = 0;
+      var x, err, t, pp;
+      if (p >= 2)
+        return -100;
+      if (p <= 0)
+        return 100;
+      pp = (p < 1) ? p : 2 - p;
+      t = Math.sqrt(-2 * Math.log(pp / 2));
+      x = -0.70711 * ((2.30753 + t * 0.27061) /
+                      (1 + t * (0.99229 + t * 0.04481)) - t);
+      for (; j < 2; j++) {
+        err = jStat.erfc(x) - pp;
+        x += err / (1.12837916709551257 * Math.exp(-x * x) - x * err);
+      }
+      return (p < 1) ? x : -x;
+    };
+
+
+    // Returns the inverse of the incomplete beta function
+    jStat.ibetainv = function ibetainv(p, a, b) {
+      var EPS = 1e-8;
+      var a1 = a - 1;
+      var b1 = b - 1;
+      var j = 0;
+      var lna, lnb, pp, t, u, err, x, al, h, w, afac;
+      if (p <= 0)
+        return 0;
+      if (p >= 1)
+        return 1;
+      if (a >= 1 && b >= 1) {
+        pp = (p < 0.5) ? p : 1 - p;
+        t = Math.sqrt(-2 * Math.log(pp));
+        x = (2.30753 + t * 0.27061) / (1 + t* (0.99229 + t * 0.04481)) - t;
+        if (p < 0.5)
+          x = -x;
+        al = (x * x - 3) / 6;
+        h = 2 / (1 / (2 * a - 1)  + 1 / (2 * b - 1));
+        w = (x * Math.sqrt(al + h) / h) - (1 / (2 * b - 1) - 1 / (2 * a - 1)) *
+            (al + 5 / 6 - 2 / (3 * h));
+        x = a / (a + b * Math.exp(2 * w));
+      } else {
+        lna = Math.log(a / (a + b));
+        lnb = Math.log(b / (a + b));
+        t = Math.exp(a * lna) / a;
+        u = Math.exp(b * lnb) / b;
+        w = t + u;
+        if (p < t / w)
+          x = Math.pow(a * w * p, 1 / a);
+        else
+          x = 1 - Math.pow(b * w * (1 - p), 1 / b);
+      }
+      afac = -jStat.gammaln(a) - jStat.gammaln(b) + jStat.gammaln(a + b);
+      for(; j < 10; j++) {
+        if (x === 0 || x === 1)
+          return x;
+        err = jStat.ibeta(x, a, b) - p;
+        t = Math.exp(a1 * Math.log(x) + b1 * Math.log(1 - x) + afac);
+        u = err / t;
+        x -= (t = u / (1 - 0.5 * Math.min(1, u * (a1 / x - b1 / (1 - x)))));
+        if (x <= 0)
+          x = 0.5 * (x + t);
+        if (x >= 1)
+          x = 0.5 * (x + t + 1);
+        if (Math.abs(t) < EPS * x && j > 0)
+          break;
+      }
+      return x;
+    };
+
+
+    // Returns the incomplete beta function I_x(a,b)
+    jStat.ibeta = function ibeta(x, a, b) {
+      // Factors in front of the continued fraction.
+      var bt = (x === 0 || x === 1) ?  0 :
+        Math.exp(jStat.gammaln(a + b) - jStat.gammaln(a) -
+                 jStat.gammaln(b) + a * Math.log(x) + b *
+                 Math.log(1 - x));
+      if (x < 0 || x > 1)
+        return false;
+      if (x < (a + 1) / (a + b + 2))
+        // Use continued fraction directly.
+        return bt * jStat.betacf(x, a, b) / a;
+      // else use continued fraction after making the symmetry transformation.
+      return 1 - bt * jStat.betacf(1 - x, b, a) / b;
+    };
+
+
+    // Returns a normal deviate (mu=0, sigma=1).
+    // If n and m are specified it returns a object of normal deviates.
+    jStat.randn = function randn(n, m) {
+      var u, v, x, y, q;
+      if (!m)
+        m = n;
+      if (n)
+        return jStat.create(n, m, function() { return jStat.randn(); });
+      do {
+        u = Math.random();
+        v = 1.7156 * (Math.random() - 0.5);
+        x = u - 0.449871;
+        y = Math.abs(v) + 0.386595;
+        q = x * x + y * (0.19600 * y - 0.25472 * x);
+      } while (q > 0.27597 && (q > 0.27846 || v * v > -4 * Math.log(u) * u * u));
+      return v / u;
+    };
+
+
+    // Returns a gamma deviate by the method of Marsaglia and Tsang.
+    jStat.randg = function randg(shape, n, m) {
+      var oalph = shape;
+      var a1, a2, u, v, x, mat;
+      if (!m)
+        m = n;
+      if (!shape)
+        shape = 1;
+      if (n) {
+        mat = jStat.zeros(n,m);
+        mat.alter(function() { return jStat.randg(shape); });
+        return mat;
+      }
+      if (shape < 1)
+        shape += 1;
+      a1 = shape - 1 / 3;
+      a2 = 1 / Math.sqrt(9 * a1);
+      do {
+        do {
+          x = jStat.randn();
+          v = 1 + a2 * x;
+        } while(v <= 0);
+        v = v * v * v;
+        u = Math.random();
+      } while(u > 1 - 0.331 * Math.pow(x, 4) &&
+              Math.log(u) > 0.5 * x*x + a1 * (1 - v + Math.log(v)));
+      // alpha > 1
+      if (shape == oalph)
+        return a1 * v;
+      // alpha < 1
+      do {
+        u = Math.random();
+      } while(u === 0);
+      return Math.pow(u, 1 / oalph) * a1 * v;
+    };
+
+
+    // making use of static methods on the instance
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jStat.fn[passfunc] = function() {
+          return jStat(
+              jStat.map(this, function(value) { return jStat[passfunc](value); }));
+        };
+      })(funcs[i]);
+    })('gammaln gammafn factorial factorialln'.split(' '));
+
+
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jStat.fn[passfunc] = function() {
+          return jStat(jStat[passfunc].apply(null, arguments));
+        };
+      })(funcs[i]);
+    })('randn'.split(' '));
+
+    }(jStat, Math));
+    (function(jStat, Math) {
+
+    // generate all distribution instance methods
+    (function(list) {
+      for (var i = 0; i < list.length; i++) (function(func) {
+        // distribution instance method
+        jStat[func] = function(a, b, c) {
+          if (!(this instanceof arguments.callee))
+            return new arguments.callee(a, b, c);
+          this._a = a;
+          this._b = b;
+          this._c = c;
+          return this;
+        };
+        // distribution method to be used on a jStat instance
+        jStat.fn[func] = function(a, b, c) {
+          var newthis = jStat[func](a, b, c);
+          newthis.data = this;
+          return newthis;
+        };
+        // sample instance method
+        jStat[func].prototype.sample = function(arr) {
           var a = this._a;
           var b = this._b;
           var c = this._c;
-          if (!x && x !== 0)
-            x = this.data;
-          if (typeof x !== 'number') {
-            return jStat.fn.map.call(x, function(x) {
-              return jStat[func][fnfunc](x, a, b, c);
+          if (arr)
+            return jStat.alter(arr, function() {
+              return jStat[func].sample(a, b, c);
             });
-          }
-          return jStat[func][fnfunc](x, a, b, c);
+          else
+            return jStat[func].sample(a, b, c);
         };
-      })(vals[i]);
-    })('pdf cdf inv'.split(' '));
-    // generate the mean, median, mode and variance instance methods
-    (function(vals) {
-      for (var i = 0; i < vals.length; i++) (function(fnfunc) {
-        jStat[func].prototype[fnfunc] = function() {
-          return jStat[func][fnfunc](this._a, this._b, this._c);
-        };
-      })(vals[i]);
-    })('mean median mode variance'.split(' '));
-  })(list[i]);
-})((
-  'beta centralF cauchy chisquare exponential gamma invgamma kumaraswamy ' +
-  'laplace lognormal noncentralt normal pareto studentt weibull uniform ' +
-  'binomial negbin hypgeom poisson triangular tukey arcsine'
-).split(' '));
+        // generate the pdf, cdf and inv instance methods
+        (function(vals) {
+          for (var i = 0; i < vals.length; i++) (function(fnfunc) {
+            jStat[func].prototype[fnfunc] = function(x) {
+              var a = this._a;
+              var b = this._b;
+              var c = this._c;
+              if (!x && x !== 0)
+                x = this.data;
+              if (typeof x !== 'number') {
+                return jStat.fn.map.call(x, function(x) {
+                  return jStat[func][fnfunc](x, a, b, c);
+                });
+              }
+              return jStat[func][fnfunc](x, a, b, c);
+            };
+          })(vals[i]);
+        })('pdf cdf inv'.split(' '));
+        // generate the mean, median, mode and variance instance methods
+        (function(vals) {
+          for (var i = 0; i < vals.length; i++) (function(fnfunc) {
+            jStat[func].prototype[fnfunc] = function() {
+              return jStat[func][fnfunc](this._a, this._b, this._c);
+            };
+          })(vals[i]);
+        })('mean median mode variance'.split(' '));
+      })(list[i]);
+    })((
+      'beta centralF cauchy chisquare exponential gamma invgamma kumaraswamy ' +
+      'laplace lognormal noncentralt normal pareto studentt weibull uniform ' +
+      'binomial negbin hypgeom poisson triangular tukey arcsine'
+    ).split(' '));
 
 
 
-// extend beta function with static methods
-jStat.extend(jStat.beta, {
-  pdf: function pdf(x, alpha, beta) {
-    // PDF is zero outside the support
-    if (x > 1 || x < 0)
-      return 0;
-    // PDF is one for the uniform case
-    if (alpha == 1 && beta == 1)
-      return 1;
+    // extend beta function with static methods
+    jStat.extend(jStat.beta, {
+      pdf: function pdf(x, alpha, beta) {
+        // PDF is zero outside the support
+        if (x > 1 || x < 0)
+          return 0;
+        // PDF is one for the uniform case
+        if (alpha == 1 && beta == 1)
+          return 1;
 
-    if (alpha < 512 && beta < 512) {
-      return (Math.pow(x, alpha - 1) * Math.pow(1 - x, beta - 1)) /
-          jStat.betafn(alpha, beta);
-    } else {
-      return Math.exp((alpha - 1) * Math.log(x) +
-                      (beta - 1) * Math.log(1 - x) -
-                      jStat.betaln(alpha, beta));
-    }
-  },
+        if (alpha < 512 && beta < 512) {
+          return (Math.pow(x, alpha - 1) * Math.pow(1 - x, beta - 1)) /
+              jStat.betafn(alpha, beta);
+        } else {
+          return Math.exp((alpha - 1) * Math.log(x) +
+                          (beta - 1) * Math.log(1 - x) -
+                          jStat.betaln(alpha, beta));
+        }
+      },
 
-  cdf: function cdf(x, alpha, beta) {
-    return (x > 1 || x < 0) ? (x > 1) * 1 : jStat.ibeta(x, alpha, beta);
-  },
+      cdf: function cdf(x, alpha, beta) {
+        return (x > 1 || x < 0) ? (x > 1) * 1 : jStat.ibeta(x, alpha, beta);
+      },
 
-  inv: function inv(x, alpha, beta) {
-    return jStat.ibetainv(x, alpha, beta);
-  },
+      inv: function inv(x, alpha, beta) {
+        return jStat.ibetainv(x, alpha, beta);
+      },
 
-  mean: function mean(alpha, beta) {
-    return alpha / (alpha + beta);
-  },
+      mean: function mean(alpha, beta) {
+        return alpha / (alpha + beta);
+      },
 
-  median: function median(alpha, beta) {
-    return jStat.ibetainv(0.5, alpha, beta);
-  },
+      median: function median(alpha, beta) {
+        return jStat.ibetainv(0.5, alpha, beta);
+      },
 
-  mode: function mode(alpha, beta) {
-    return (alpha - 1 ) / ( alpha + beta - 2);
-  },
+      mode: function mode(alpha, beta) {
+        return (alpha - 1 ) / ( alpha + beta - 2);
+      },
 
-  // return a random sample
-  sample: function sample(alpha, beta) {
-    var u = jStat.randg(alpha);
-    return u / (u + jStat.randg(beta));
-  },
+      // return a random sample
+      sample: function sample(alpha, beta) {
+        var u = jStat.randg(alpha);
+        return u / (u + jStat.randg(beta));
+      },
 
-  variance: function variance(alpha, beta) {
-    return (alpha * beta) / (Math.pow(alpha + beta, 2) * (alpha + beta + 1));
-  }
-});
-
-// extend F function with static methods
-jStat.extend(jStat.centralF, {
-  // This implementation of the pdf function avoids float overflow
-  // See the way that R calculates this value:
-  // https://svn.r-project.org/R/trunk/src/nmath/df.c
-  pdf: function pdf(x, df1, df2) {
-    var p, q, f;
-
-    if (x < 0)
-      return 0;
-
-    if (df1 <= 2) {
-      if (x === 0 && df1 < 2) {
-        return Infinity;
+      variance: function variance(alpha, beta) {
+        return (alpha * beta) / (Math.pow(alpha + beta, 2) * (alpha + beta + 1));
       }
-      if (x === 0 && df1 === 2) {
+    });
+
+    // extend F function with static methods
+    jStat.extend(jStat.centralF, {
+      // This implementation of the pdf function avoids float overflow
+      // See the way that R calculates this value:
+      // https://svn.r-project.org/R/trunk/src/nmath/df.c
+      pdf: function pdf(x, df1, df2) {
+        var p, q, f;
+
+        if (x < 0)
+          return 0;
+
+        if (df1 <= 2) {
+          if (x === 0 && df1 < 2) {
+            return Infinity;
+          }
+          if (x === 0 && df1 === 2) {
+            return 1;
+          }
+          return (1 / jStat.betafn(df1 / 2, df2 / 2)) *
+                  Math.pow(df1 / df2, df1 / 2) *
+                  Math.pow(x, (df1/2) - 1) *
+                  Math.pow((1 + (df1 / df2) * x), -(df1 + df2) / 2);
+        }
+
+        p = (df1 * x) / (df2 + x * df1);
+        q = df2 / (df2 + x * df1);
+        f = df1 * q / 2.0;
+        return f * jStat.binomial.pdf((df1 - 2) / 2, (df1 + df2 - 2) / 2, p);
+      },
+
+      cdf: function cdf(x, df1, df2) {
+        if (x < 0)
+          return 0;
+        return jStat.ibeta((df1 * x) / (df1 * x + df2), df1 / 2, df2 / 2);
+      },
+
+      inv: function inv(x, df1, df2) {
+        return df2 / (df1 * (1 / jStat.ibetainv(x, df1 / 2, df2 / 2) - 1));
+      },
+
+      mean: function mean(df1, df2) {
+        return (df2 > 2) ? df2 / (df2 - 2) : undefined;
+      },
+
+      mode: function mode(df1, df2) {
+        return (df1 > 2) ? (df2 * (df1 - 2)) / (df1 * (df2 + 2)) : undefined;
+      },
+
+      // return a random sample
+      sample: function sample(df1, df2) {
+        var x1 = jStat.randg(df1 / 2) * 2;
+        var x2 = jStat.randg(df2 / 2) * 2;
+        return (x1 / df1) / (x2 / df2);
+      },
+
+      variance: function variance(df1, df2) {
+        if (df2 <= 4)
+          return undefined;
+        return 2 * df2 * df2 * (df1 + df2 - 2) /
+            (df1 * (df2 - 2) * (df2 - 2) * (df2 - 4));
+      }
+    });
+
+
+    // extend cauchy function with static methods
+    jStat.extend(jStat.cauchy, {
+      pdf: function pdf(x, local, scale) {
+        if (scale < 0) { return 0; }
+
+        return (scale / (Math.pow(x - local, 2) + Math.pow(scale, 2))) / Math.PI;
+      },
+
+      cdf: function cdf(x, local, scale) {
+        return Math.atan((x - local) / scale) / Math.PI + 0.5;
+      },
+
+      inv: function(p, local, scale) {
+        return local + scale * Math.tan(Math.PI * (p - 0.5));
+      },
+
+      median: function median(local, scale) {
+        return local;
+      },
+
+      mode: function mode(local, scale) {
+        return local;
+      },
+
+      sample: function sample(local, scale) {
+        return jStat.randn() *
+            Math.sqrt(1 / (2 * jStat.randg(0.5))) * scale + local;
+      }
+    });
+
+
+
+    // extend chisquare function with static methods
+    jStat.extend(jStat.chisquare, {
+      pdf: function pdf(x, dof) {
+        if (x < 0)
+          return 0;
+        return (x === 0 && dof === 2) ? 0.5 :
+            Math.exp((dof / 2 - 1) * Math.log(x) - x / 2 - (dof / 2) *
+                     Math.log(2) - jStat.gammaln(dof / 2));
+      },
+
+      cdf: function cdf(x, dof) {
+        if (x < 0)
+          return 0;
+        return jStat.lowRegGamma(dof / 2, x / 2);
+      },
+
+      inv: function(p, dof) {
+        return 2 * jStat.gammapinv(p, 0.5 * dof);
+      },
+
+      mean : function(dof) {
+        return dof;
+      },
+
+      // TODO: this is an approximation (is there a better way?)
+      median: function median(dof) {
+        return dof * Math.pow(1 - (2 / (9 * dof)), 3);
+      },
+
+      mode: function mode(dof) {
+        return (dof - 2 > 0) ? dof - 2 : 0;
+      },
+
+      sample: function sample(dof) {
+        return jStat.randg(dof / 2) * 2;
+      },
+
+      variance: function variance(dof) {
+        return 2 * dof;
+      }
+    });
+
+
+
+    // extend exponential function with static methods
+    jStat.extend(jStat.exponential, {
+      pdf: function pdf(x, rate) {
+        return x < 0 ? 0 : rate * Math.exp(-rate * x);
+      },
+
+      cdf: function cdf(x, rate) {
+        return x < 0 ? 0 : 1 - Math.exp(-rate * x);
+      },
+
+      inv: function(p, rate) {
+        return -Math.log(1 - p) / rate;
+      },
+
+      mean : function(rate) {
+        return 1 / rate;
+      },
+
+      median: function (rate) {
+        return (1 / rate) * Math.log(2);
+      },
+
+      mode: function mode(rate) {
+        return 0;
+      },
+
+      sample: function sample(rate) {
+        return -1 / rate * Math.log(Math.random());
+      },
+
+      variance : function(rate) {
+        return Math.pow(rate, -2);
+      }
+    });
+
+
+
+    // extend gamma function with static methods
+    jStat.extend(jStat.gamma, {
+      pdf: function pdf(x, shape, scale) {
+        if (x < 0)
+          return 0;
+        return (x === 0 && shape === 1) ? 1 / scale :
+                Math.exp((shape - 1) * Math.log(x) - x / scale -
+                        jStat.gammaln(shape) - shape * Math.log(scale));
+      },
+
+      cdf: function cdf(x, shape, scale) {
+        if (x < 0)
+          return 0;
+        return jStat.lowRegGamma(shape, x / scale);
+      },
+
+      inv: function(p, shape, scale) {
+        return jStat.gammapinv(p, shape) * scale;
+      },
+
+      mean : function(shape, scale) {
+        return shape * scale;
+      },
+
+      mode: function mode(shape, scale) {
+        if(shape > 1) return (shape - 1) * scale;
+        return undefined;
+      },
+
+      sample: function sample(shape, scale) {
+        return jStat.randg(shape) * scale;
+      },
+
+      variance: function variance(shape, scale) {
+        return shape * scale * scale;
+      }
+    });
+
+    // extend inverse gamma function with static methods
+    jStat.extend(jStat.invgamma, {
+      pdf: function pdf(x, shape, scale) {
+        if (x <= 0)
+          return 0;
+        return Math.exp(-(shape + 1) * Math.log(x) - scale / x -
+                        jStat.gammaln(shape) + shape * Math.log(scale));
+      },
+
+      cdf: function cdf(x, shape, scale) {
+        if (x <= 0)
+          return 0;
+        return 1 - jStat.lowRegGamma(shape, scale / x);
+      },
+
+      inv: function(p, shape, scale) {
+        return scale / jStat.gammapinv(1 - p, shape);
+      },
+
+      mean : function(shape, scale) {
+        return (shape > 1) ? scale / (shape - 1) : undefined;
+      },
+
+      mode: function mode(shape, scale) {
+        return scale / (shape + 1);
+      },
+
+      sample: function sample(shape, scale) {
+        return scale / jStat.randg(shape);
+      },
+
+      variance: function variance(shape, scale) {
+        if (shape <= 2)
+          return undefined;
+        return scale * scale / ((shape - 1) * (shape - 1) * (shape - 2));
+      }
+    });
+
+
+    // extend kumaraswamy function with static methods
+    jStat.extend(jStat.kumaraswamy, {
+      pdf: function pdf(x, alpha, beta) {
+        if (x === 0 && alpha === 1)
+          return beta;
+        else if (x === 1 && beta === 1)
+          return alpha;
+        return Math.exp(Math.log(alpha) + Math.log(beta) + (alpha - 1) *
+                        Math.log(x) + (beta - 1) *
+                        Math.log(1 - Math.pow(x, alpha)));
+      },
+
+      cdf: function cdf(x, alpha, beta) {
+        if (x < 0)
+          return 0;
+        else if (x > 1)
+          return 1;
+        return (1 - Math.pow(1 - Math.pow(x, alpha), beta));
+      },
+
+      inv: function inv(p, alpha, beta) {
+        return Math.pow(1 - Math.pow(1 - p, 1 / beta), 1 / alpha);
+      },
+
+      mean : function(alpha, beta) {
+        return (beta * jStat.gammafn(1 + 1 / alpha) *
+                jStat.gammafn(beta)) / (jStat.gammafn(1 + 1 / alpha + beta));
+      },
+
+      median: function median(alpha, beta) {
+        return Math.pow(1 - Math.pow(2, -1 / beta), 1 / alpha);
+      },
+
+      mode: function mode(alpha, beta) {
+        if (!(alpha >= 1 && beta >= 1 && (alpha !== 1 && beta !== 1)))
+          return undefined;
+        return Math.pow((alpha - 1) / (alpha * beta - 1), 1 / alpha);
+      },
+
+      variance: function variance(alpha, beta) {
+        throw new Error('variance not yet implemented');
+        // TODO: complete this
+      }
+    });
+
+
+
+    // extend lognormal function with static methods
+    jStat.extend(jStat.lognormal, {
+      pdf: function pdf(x, mu, sigma) {
+        if (x <= 0)
+          return 0;
+        return Math.exp(-Math.log(x) - 0.5 * Math.log(2 * Math.PI) -
+                        Math.log(sigma) - Math.pow(Math.log(x) - mu, 2) /
+                        (2 * sigma * sigma));
+      },
+
+      cdf: function cdf(x, mu, sigma) {
+        if (x < 0)
+          return 0;
+        return 0.5 +
+            (0.5 * jStat.erf((Math.log(x) - mu) / Math.sqrt(2 * sigma * sigma)));
+      },
+
+      inv: function(p, mu, sigma) {
+        return Math.exp(-1.41421356237309505 * sigma * jStat.erfcinv(2 * p) + mu);
+      },
+
+      mean: function mean(mu, sigma) {
+        return Math.exp(mu + sigma * sigma / 2);
+      },
+
+      median: function median(mu, sigma) {
+        return Math.exp(mu);
+      },
+
+      mode: function mode(mu, sigma) {
+        return Math.exp(mu - sigma * sigma);
+      },
+
+      sample: function sample(mu, sigma) {
+        return Math.exp(jStat.randn() * sigma + mu);
+      },
+
+      variance: function variance(mu, sigma) {
+        return (Math.exp(sigma * sigma) - 1) * Math.exp(2 * mu + sigma * sigma);
+      }
+    });
+
+
+
+    // extend noncentralt function with static methods
+    jStat.extend(jStat.noncentralt, {
+      pdf: function pdf(x, dof, ncp) {
+        var tol = 1e-14;
+        if (Math.abs(ncp) < tol)  // ncp approx 0; use student-t
+          return jStat.studentt.pdf(x, dof)
+
+        if (Math.abs(x) < tol) {  // different formula for x == 0
+          return Math.exp(jStat.gammaln((dof + 1) / 2) - ncp * ncp / 2 -
+                          0.5 * Math.log(Math.PI * dof) - jStat.gammaln(dof / 2));
+        }
+
+        // formula for x != 0
+        return dof / x *
+            (jStat.noncentralt.cdf(x * Math.sqrt(1 + 2 / dof), dof+2, ncp) -
+             jStat.noncentralt.cdf(x, dof, ncp));
+      },
+
+      cdf: function cdf(x, dof, ncp) {
+        var tol = 1e-14;
+        var min_iterations = 200;
+
+        if (Math.abs(ncp) < tol)  // ncp approx 0; use student-t
+          return jStat.studentt.cdf(x, dof);
+
+        // turn negative x into positive and flip result afterwards
+        var flip = false;
+        if (x < 0) {
+          flip = true;
+          ncp = -ncp;
+        }
+
+        var prob = jStat.normal.cdf(-ncp, 0, 1);
+        var value = tol + 1;
+        // use value at last two steps to determine convergence
+        var lastvalue = value;
+        var y = x * x / (x * x + dof);
+        var j = 0;
+        var p = Math.exp(-ncp * ncp / 2);
+        var q = Math.exp(-ncp * ncp / 2 - 0.5 * Math.log(2) -
+                         jStat.gammaln(3 / 2)) * ncp;
+        while (j < min_iterations || lastvalue > tol || value > tol) {
+          lastvalue = value;
+          if (j > 0) {
+            p *= (ncp * ncp) / (2 * j);
+            q *= (ncp * ncp) / (2 * (j + 1 / 2));
+          }
+          value = p * jStat.beta.cdf(y, j + 0.5, dof / 2) +
+              q * jStat.beta.cdf(y, j+1, dof/2);
+          prob += 0.5 * value;
+          j++;
+        }
+
+        return flip ? (1 - prob) : prob;
+      }
+    });
+
+
+    // extend normal function with static methods
+    jStat.extend(jStat.normal, {
+      pdf: function pdf(x, mean, std) {
+        return Math.exp(-0.5 * Math.log(2 * Math.PI) -
+                        Math.log(std) - Math.pow(x - mean, 2) / (2 * std * std));
+      },
+
+      cdf: function cdf(x, mean, std) {
+        return 0.5 * (1 + jStat.erf((x - mean) / Math.sqrt(2 * std * std)));
+      },
+
+      inv: function(p, mean, std) {
+        return -1.41421356237309505 * std * jStat.erfcinv(2 * p) + mean;
+      },
+
+      mean : function(mean, std) {
+        return mean;
+      },
+
+      median: function median(mean, std) {
+        return mean;
+      },
+
+      mode: function (mean, std) {
+        return mean;
+      },
+
+      sample: function sample(mean, std) {
+        return jStat.randn() * std + mean;
+      },
+
+      variance : function(mean, std) {
+        return std * std;
+      }
+    });
+
+
+
+    // extend pareto function with static methods
+    jStat.extend(jStat.pareto, {
+      pdf: function pdf(x, scale, shape) {
+        if (x < scale)
+          return 0;
+        return (shape * Math.pow(scale, shape)) / Math.pow(x, shape + 1);
+      },
+
+      cdf: function cdf(x, scale, shape) {
+        if (x < scale)
+          return 0;
+        return 1 - Math.pow(scale / x, shape);
+      },
+
+      inv: function inv(p, scale, shape) {
+        return scale / Math.pow(1 - p, 1 / shape);
+      },
+
+      mean: function mean(scale, shape) {
+        if (shape <= 1)
+          return undefined;
+        return (shape * Math.pow(scale, shape)) / (shape - 1);
+      },
+
+      median: function median(scale, shape) {
+        return scale * (shape * Math.SQRT2);
+      },
+
+      mode: function mode(scale, shape) {
+        return scale;
+      },
+
+      variance : function(scale, shape) {
+        if (shape <= 2)
+          return undefined;
+        return (scale*scale * shape) / (Math.pow(shape - 1, 2) * (shape - 2));
+      }
+    });
+
+
+
+    // extend studentt function with static methods
+    jStat.extend(jStat.studentt, {
+      pdf: function pdf(x, dof) {
+        dof = dof > 1e100 ? 1e100 : dof;
+        return (1/(Math.sqrt(dof) * jStat.betafn(0.5, dof/2))) *
+            Math.pow(1 + ((x * x) / dof), -((dof + 1) / 2));
+      },
+
+      cdf: function cdf(x, dof) {
+        var dof2 = dof / 2;
+        return jStat.ibeta((x + Math.sqrt(x * x + dof)) /
+                           (2 * Math.sqrt(x * x + dof)), dof2, dof2);
+      },
+
+      inv: function(p, dof) {
+        var x = jStat.ibetainv(2 * Math.min(p, 1 - p), 0.5 * dof, 0.5);
+        x = Math.sqrt(dof * (1 - x) / x);
+        return (p > 0.5) ? x : -x;
+      },
+
+      mean: function mean(dof) {
+        return (dof > 1) ? 0 : undefined;
+      },
+
+      median: function median(dof) {
+        return 0;
+      },
+
+      mode: function mode(dof) {
+        return 0;
+      },
+
+      sample: function sample(dof) {
+        return jStat.randn() * Math.sqrt(dof / (2 * jStat.randg(dof / 2)));
+      },
+
+      variance: function variance(dof) {
+        return (dof  > 2) ? dof / (dof - 2) : (dof > 1) ? Infinity : undefined;
+      }
+    });
+
+
+
+    // extend weibull function with static methods
+    jStat.extend(jStat.weibull, {
+      pdf: function pdf(x, scale, shape) {
+        if (x < 0 || scale < 0 || shape < 0)
+          return 0;
+        return (shape / scale) * Math.pow((x / scale), (shape - 1)) *
+            Math.exp(-(Math.pow((x / scale), shape)));
+      },
+
+      cdf: function cdf(x, scale, shape) {
+        return x < 0 ? 0 : 1 - Math.exp(-Math.pow((x / scale), shape));
+      },
+
+      inv: function(p, scale, shape) {
+        return scale * Math.pow(-Math.log(1 - p), 1 / shape);
+      },
+
+      mean : function(scale, shape) {
+        return scale * jStat.gammafn(1 + 1 / shape);
+      },
+
+      median: function median(scale, shape) {
+        return scale * Math.pow(Math.log(2), 1 / shape);
+      },
+
+      mode: function mode(scale, shape) {
+        if (shape <= 1)
+          return 0;
+        return scale * Math.pow((shape - 1) / shape, 1 / shape);
+      },
+
+      sample: function sample(scale, shape) {
+        return scale * Math.pow(-Math.log(Math.random()), 1 / shape);
+      },
+
+      variance: function variance(scale, shape) {
+        return scale * scale * jStat.gammafn(1 + 2 / shape) -
+            Math.pow(jStat.weibull.mean(scale, shape), 2);
+      }
+    });
+
+
+
+    // extend uniform function with static methods
+    jStat.extend(jStat.uniform, {
+      pdf: function pdf(x, a, b) {
+        return (x < a || x > b) ? 0 : 1 / (b - a);
+      },
+
+      cdf: function cdf(x, a, b) {
+        if (x < a)
+          return 0;
+        else if (x < b)
+          return (x - a) / (b - a);
+        return 1;
+      },
+
+      inv: function(p, a, b) {
+        return a + (p * (b - a));
+      },
+
+      mean: function mean(a, b) {
+        return 0.5 * (a + b);
+      },
+
+      median: function median(a, b) {
+        return jStat.mean(a, b);
+      },
+
+      mode: function mode(a, b) {
+        throw new Error('mode is not yet implemented');
+      },
+
+      sample: function sample(a, b) {
+        return (a / 2 + b / 2) + (b / 2 - a / 2) * (2 * Math.random() - 1);
+      },
+
+      variance: function variance(a, b) {
+        return Math.pow(b - a, 2) / 12;
+      }
+    });
+
+
+
+    // extend uniform function with static methods
+    jStat.extend(jStat.binomial, {
+      pdf: function pdf(k, n, p) {
+        return (p === 0 || p === 1) ?
+          ((n * p) === k ? 1 : 0) :
+          jStat.combination(n, k) * Math.pow(p, k) * Math.pow(1 - p, n - k);
+      },
+
+      cdf: function cdf(x, n, p) {
+        var binomarr = [],
+        k = 0;
+        if (x < 0) {
+          return 0;
+        }
+        if (x < n) {
+          for (; k <= x; k++) {
+            binomarr[ k ] = jStat.binomial.pdf(k, n, p);
+          }
+          return jStat.sum(binomarr);
+        }
         return 1;
       }
-      return (1 / jStat.betafn(df1 / 2, df2 / 2)) *
-              Math.pow(df1 / df2, df1 / 2) *
-              Math.pow(x, (df1/2) - 1) *
-              Math.pow((1 + (df1 / df2) * x), -(df1 + df2) / 2);
-    }
-
-    p = (df1 * x) / (df2 + x * df1);
-    q = df2 / (df2 + x * df1);
-    f = df1 * q / 2.0;
-    return f * jStat.binomial.pdf((df1 - 2) / 2, (df1 + df2 - 2) / 2, p);
-  },
-
-  cdf: function cdf(x, df1, df2) {
-    if (x < 0)
-      return 0;
-    return jStat.ibeta((df1 * x) / (df1 * x + df2), df1 / 2, df2 / 2);
-  },
-
-  inv: function inv(x, df1, df2) {
-    return df2 / (df1 * (1 / jStat.ibetainv(x, df1 / 2, df2 / 2) - 1));
-  },
-
-  mean: function mean(df1, df2) {
-    return (df2 > 2) ? df2 / (df2 - 2) : undefined;
-  },
-
-  mode: function mode(df1, df2) {
-    return (df1 > 2) ? (df2 * (df1 - 2)) / (df1 * (df2 + 2)) : undefined;
-  },
-
-  // return a random sample
-  sample: function sample(df1, df2) {
-    var x1 = jStat.randg(df1 / 2) * 2;
-    var x2 = jStat.randg(df2 / 2) * 2;
-    return (x1 / df1) / (x2 / df2);
-  },
-
-  variance: function variance(df1, df2) {
-    if (df2 <= 4)
-      return undefined;
-    return 2 * df2 * df2 * (df1 + df2 - 2) /
-        (df1 * (df2 - 2) * (df2 - 2) * (df2 - 4));
-  }
-});
-
-
-// extend cauchy function with static methods
-jStat.extend(jStat.cauchy, {
-  pdf: function pdf(x, local, scale) {
-    if (scale < 0) { return 0; }
-
-    return (scale / (Math.pow(x - local, 2) + Math.pow(scale, 2))) / Math.PI;
-  },
-
-  cdf: function cdf(x, local, scale) {
-    return Math.atan((x - local) / scale) / Math.PI + 0.5;
-  },
-
-  inv: function(p, local, scale) {
-    return local + scale * Math.tan(Math.PI * (p - 0.5));
-  },
-
-  median: function median(local, scale) {
-    return local;
-  },
-
-  mode: function mode(local, scale) {
-    return local;
-  },
-
-  sample: function sample(local, scale) {
-    return jStat.randn() *
-        Math.sqrt(1 / (2 * jStat.randg(0.5))) * scale + local;
-  }
-});
-
-
-
-// extend chisquare function with static methods
-jStat.extend(jStat.chisquare, {
-  pdf: function pdf(x, dof) {
-    if (x < 0)
-      return 0;
-    return (x === 0 && dof === 2) ? 0.5 :
-        Math.exp((dof / 2 - 1) * Math.log(x) - x / 2 - (dof / 2) *
-                 Math.log(2) - jStat.gammaln(dof / 2));
-  },
-
-  cdf: function cdf(x, dof) {
-    if (x < 0)
-      return 0;
-    return jStat.lowRegGamma(dof / 2, x / 2);
-  },
-
-  inv: function(p, dof) {
-    return 2 * jStat.gammapinv(p, 0.5 * dof);
-  },
-
-  mean : function(dof) {
-    return dof;
-  },
-
-  // TODO: this is an approximation (is there a better way?)
-  median: function median(dof) {
-    return dof * Math.pow(1 - (2 / (9 * dof)), 3);
-  },
-
-  mode: function mode(dof) {
-    return (dof - 2 > 0) ? dof - 2 : 0;
-  },
-
-  sample: function sample(dof) {
-    return jStat.randg(dof / 2) * 2;
-  },
-
-  variance: function variance(dof) {
-    return 2 * dof;
-  }
-});
-
-
-
-// extend exponential function with static methods
-jStat.extend(jStat.exponential, {
-  pdf: function pdf(x, rate) {
-    return x < 0 ? 0 : rate * Math.exp(-rate * x);
-  },
-
-  cdf: function cdf(x, rate) {
-    return x < 0 ? 0 : 1 - Math.exp(-rate * x);
-  },
-
-  inv: function(p, rate) {
-    return -Math.log(1 - p) / rate;
-  },
-
-  mean : function(rate) {
-    return 1 / rate;
-  },
-
-  median: function (rate) {
-    return (1 / rate) * Math.log(2);
-  },
-
-  mode: function mode(rate) {
-    return 0;
-  },
-
-  sample: function sample(rate) {
-    return -1 / rate * Math.log(Math.random());
-  },
-
-  variance : function(rate) {
-    return Math.pow(rate, -2);
-  }
-});
-
-
-
-// extend gamma function with static methods
-jStat.extend(jStat.gamma, {
-  pdf: function pdf(x, shape, scale) {
-    if (x < 0)
-      return 0;
-    return (x === 0 && shape === 1) ? 1 / scale :
-            Math.exp((shape - 1) * Math.log(x) - x / scale -
-                    jStat.gammaln(shape) - shape * Math.log(scale));
-  },
-
-  cdf: function cdf(x, shape, scale) {
-    if (x < 0)
-      return 0;
-    return jStat.lowRegGamma(shape, x / scale);
-  },
-
-  inv: function(p, shape, scale) {
-    return jStat.gammapinv(p, shape) * scale;
-  },
-
-  mean : function(shape, scale) {
-    return shape * scale;
-  },
-
-  mode: function mode(shape, scale) {
-    if(shape > 1) return (shape - 1) * scale;
-    return undefined;
-  },
-
-  sample: function sample(shape, scale) {
-    return jStat.randg(shape) * scale;
-  },
-
-  variance: function variance(shape, scale) {
-    return shape * scale * scale;
-  }
-});
-
-// extend inverse gamma function with static methods
-jStat.extend(jStat.invgamma, {
-  pdf: function pdf(x, shape, scale) {
-    if (x <= 0)
-      return 0;
-    return Math.exp(-(shape + 1) * Math.log(x) - scale / x -
-                    jStat.gammaln(shape) + shape * Math.log(scale));
-  },
-
-  cdf: function cdf(x, shape, scale) {
-    if (x <= 0)
-      return 0;
-    return 1 - jStat.lowRegGamma(shape, scale / x);
-  },
-
-  inv: function(p, shape, scale) {
-    return scale / jStat.gammapinv(1 - p, shape);
-  },
-
-  mean : function(shape, scale) {
-    return (shape > 1) ? scale / (shape - 1) : undefined;
-  },
-
-  mode: function mode(shape, scale) {
-    return scale / (shape + 1);
-  },
-
-  sample: function sample(shape, scale) {
-    return scale / jStat.randg(shape);
-  },
-
-  variance: function variance(shape, scale) {
-    if (shape <= 2)
-      return undefined;
-    return scale * scale / ((shape - 1) * (shape - 1) * (shape - 2));
-  }
-});
-
-
-// extend kumaraswamy function with static methods
-jStat.extend(jStat.kumaraswamy, {
-  pdf: function pdf(x, alpha, beta) {
-    if (x === 0 && alpha === 1)
-      return beta;
-    else if (x === 1 && beta === 1)
-      return alpha;
-    return Math.exp(Math.log(alpha) + Math.log(beta) + (alpha - 1) *
-                    Math.log(x) + (beta - 1) *
-                    Math.log(1 - Math.pow(x, alpha)));
-  },
-
-  cdf: function cdf(x, alpha, beta) {
-    if (x < 0)
-      return 0;
-    else if (x > 1)
-      return 1;
-    return (1 - Math.pow(1 - Math.pow(x, alpha), beta));
-  },
-
-  inv: function inv(p, alpha, beta) {
-    return Math.pow(1 - Math.pow(1 - p, 1 / beta), 1 / alpha);
-  },
-
-  mean : function(alpha, beta) {
-    return (beta * jStat.gammafn(1 + 1 / alpha) *
-            jStat.gammafn(beta)) / (jStat.gammafn(1 + 1 / alpha + beta));
-  },
-
-  median: function median(alpha, beta) {
-    return Math.pow(1 - Math.pow(2, -1 / beta), 1 / alpha);
-  },
-
-  mode: function mode(alpha, beta) {
-    if (!(alpha >= 1 && beta >= 1 && (alpha !== 1 && beta !== 1)))
-      return undefined;
-    return Math.pow((alpha - 1) / (alpha * beta - 1), 1 / alpha);
-  },
-
-  variance: function variance(alpha, beta) {
-    throw new Error('variance not yet implemented');
-    // TODO: complete this
-  }
-});
-
-
-
-// extend lognormal function with static methods
-jStat.extend(jStat.lognormal, {
-  pdf: function pdf(x, mu, sigma) {
-    if (x <= 0)
-      return 0;
-    return Math.exp(-Math.log(x) - 0.5 * Math.log(2 * Math.PI) -
-                    Math.log(sigma) - Math.pow(Math.log(x) - mu, 2) /
-                    (2 * sigma * sigma));
-  },
-
-  cdf: function cdf(x, mu, sigma) {
-    if (x < 0)
-      return 0;
-    return 0.5 +
-        (0.5 * jStat.erf((Math.log(x) - mu) / Math.sqrt(2 * sigma * sigma)));
-  },
-
-  inv: function(p, mu, sigma) {
-    return Math.exp(-1.41421356237309505 * sigma * jStat.erfcinv(2 * p) + mu);
-  },
-
-  mean: function mean(mu, sigma) {
-    return Math.exp(mu + sigma * sigma / 2);
-  },
-
-  median: function median(mu, sigma) {
-    return Math.exp(mu);
-  },
-
-  mode: function mode(mu, sigma) {
-    return Math.exp(mu - sigma * sigma);
-  },
-
-  sample: function sample(mu, sigma) {
-    return Math.exp(jStat.randn() * sigma + mu);
-  },
-
-  variance: function variance(mu, sigma) {
-    return (Math.exp(sigma * sigma) - 1) * Math.exp(2 * mu + sigma * sigma);
-  }
-});
-
-
-
-// extend noncentralt function with static methods
-jStat.extend(jStat.noncentralt, {
-  pdf: function pdf(x, dof, ncp) {
-    var tol = 1e-14;
-    if (Math.abs(ncp) < tol)  // ncp approx 0; use student-t
-      return jStat.studentt.pdf(x, dof)
-
-    if (Math.abs(x) < tol) {  // different formula for x == 0
-      return Math.exp(jStat.gammaln((dof + 1) / 2) - ncp * ncp / 2 -
-                      0.5 * Math.log(Math.PI * dof) - jStat.gammaln(dof / 2));
-    }
-
-    // formula for x != 0
-    return dof / x *
-        (jStat.noncentralt.cdf(x * Math.sqrt(1 + 2 / dof), dof+2, ncp) -
-         jStat.noncentralt.cdf(x, dof, ncp));
-  },
-
-  cdf: function cdf(x, dof, ncp) {
-    var tol = 1e-14;
-    var min_iterations = 200;
-
-    if (Math.abs(ncp) < tol)  // ncp approx 0; use student-t
-      return jStat.studentt.cdf(x, dof);
-
-    // turn negative x into positive and flip result afterwards
-    var flip = false;
-    if (x < 0) {
-      flip = true;
-      ncp = -ncp;
-    }
-
-    var prob = jStat.normal.cdf(-ncp, 0, 1);
-    var value = tol + 1;
-    // use value at last two steps to determine convergence
-    var lastvalue = value;
-    var y = x * x / (x * x + dof);
-    var j = 0;
-    var p = Math.exp(-ncp * ncp / 2);
-    var q = Math.exp(-ncp * ncp / 2 - 0.5 * Math.log(2) -
-                     jStat.gammaln(3 / 2)) * ncp;
-    while (j < min_iterations || lastvalue > tol || value > tol) {
-      lastvalue = value;
-      if (j > 0) {
-        p *= (ncp * ncp) / (2 * j);
-        q *= (ncp * ncp) / (2 * (j + 1 / 2));
-      }
-      value = p * jStat.beta.cdf(y, j + 0.5, dof / 2) +
-          q * jStat.beta.cdf(y, j+1, dof/2);
-      prob += 0.5 * value;
-      j++;
-    }
-
-    return flip ? (1 - prob) : prob;
-  }
-});
-
-
-// extend normal function with static methods
-jStat.extend(jStat.normal, {
-  pdf: function pdf(x, mean, std) {
-    return Math.exp(-0.5 * Math.log(2 * Math.PI) -
-                    Math.log(std) - Math.pow(x - mean, 2) / (2 * std * std));
-  },
-
-  cdf: function cdf(x, mean, std) {
-    return 0.5 * (1 + jStat.erf((x - mean) / Math.sqrt(2 * std * std)));
-  },
-
-  inv: function(p, mean, std) {
-    return -1.41421356237309505 * std * jStat.erfcinv(2 * p) + mean;
-  },
-
-  mean : function(mean, std) {
-    return mean;
-  },
-
-  median: function median(mean, std) {
-    return mean;
-  },
-
-  mode: function (mean, std) {
-    return mean;
-  },
-
-  sample: function sample(mean, std) {
-    return jStat.randn() * std + mean;
-  },
-
-  variance : function(mean, std) {
-    return std * std;
-  }
-});
-
-
-
-// extend pareto function with static methods
-jStat.extend(jStat.pareto, {
-  pdf: function pdf(x, scale, shape) {
-    if (x < scale)
-      return 0;
-    return (shape * Math.pow(scale, shape)) / Math.pow(x, shape + 1);
-  },
-
-  cdf: function cdf(x, scale, shape) {
-    if (x < scale)
-      return 0;
-    return 1 - Math.pow(scale / x, shape);
-  },
-
-  inv: function inv(p, scale, shape) {
-    return scale / Math.pow(1 - p, 1 / shape);
-  },
-
-  mean: function mean(scale, shape) {
-    if (shape <= 1)
-      return undefined;
-    return (shape * Math.pow(scale, shape)) / (shape - 1);
-  },
-
-  median: function median(scale, shape) {
-    return scale * (shape * Math.SQRT2);
-  },
-
-  mode: function mode(scale, shape) {
-    return scale;
-  },
-
-  variance : function(scale, shape) {
-    if (shape <= 2)
-      return undefined;
-    return (scale*scale * shape) / (Math.pow(shape - 1, 2) * (shape - 2));
-  }
-});
-
-
-
-// extend studentt function with static methods
-jStat.extend(jStat.studentt, {
-  pdf: function pdf(x, dof) {
-    dof = dof > 1e100 ? 1e100 : dof;
-    return (1/(Math.sqrt(dof) * jStat.betafn(0.5, dof/2))) *
-        Math.pow(1 + ((x * x) / dof), -((dof + 1) / 2));
-  },
-
-  cdf: function cdf(x, dof) {
-    var dof2 = dof / 2;
-    return jStat.ibeta((x + Math.sqrt(x * x + dof)) /
-                       (2 * Math.sqrt(x * x + dof)), dof2, dof2);
-  },
-
-  inv: function(p, dof) {
-    var x = jStat.ibetainv(2 * Math.min(p, 1 - p), 0.5 * dof, 0.5);
-    x = Math.sqrt(dof * (1 - x) / x);
-    return (p > 0.5) ? x : -x;
-  },
-
-  mean: function mean(dof) {
-    return (dof > 1) ? 0 : undefined;
-  },
-
-  median: function median(dof) {
-    return 0;
-  },
-
-  mode: function mode(dof) {
-    return 0;
-  },
-
-  sample: function sample(dof) {
-    return jStat.randn() * Math.sqrt(dof / (2 * jStat.randg(dof / 2)));
-  },
-
-  variance: function variance(dof) {
-    return (dof  > 2) ? dof / (dof - 2) : (dof > 1) ? Infinity : undefined;
-  }
-});
-
-
-
-// extend weibull function with static methods
-jStat.extend(jStat.weibull, {
-  pdf: function pdf(x, scale, shape) {
-    if (x < 0 || scale < 0 || shape < 0)
-      return 0;
-    return (shape / scale) * Math.pow((x / scale), (shape - 1)) *
-        Math.exp(-(Math.pow((x / scale), shape)));
-  },
-
-  cdf: function cdf(x, scale, shape) {
-    return x < 0 ? 0 : 1 - Math.exp(-Math.pow((x / scale), shape));
-  },
-
-  inv: function(p, scale, shape) {
-    return scale * Math.pow(-Math.log(1 - p), 1 / shape);
-  },
-
-  mean : function(scale, shape) {
-    return scale * jStat.gammafn(1 + 1 / shape);
-  },
-
-  median: function median(scale, shape) {
-    return scale * Math.pow(Math.log(2), 1 / shape);
-  },
-
-  mode: function mode(scale, shape) {
-    if (shape <= 1)
-      return 0;
-    return scale * Math.pow((shape - 1) / shape, 1 / shape);
-  },
-
-  sample: function sample(scale, shape) {
-    return scale * Math.pow(-Math.log(Math.random()), 1 / shape);
-  },
-
-  variance: function variance(scale, shape) {
-    return scale * scale * jStat.gammafn(1 + 2 / shape) -
-        Math.pow(jStat.weibull.mean(scale, shape), 2);
-  }
-});
-
-
-
-// extend uniform function with static methods
-jStat.extend(jStat.uniform, {
-  pdf: function pdf(x, a, b) {
-    return (x < a || x > b) ? 0 : 1 / (b - a);
-  },
-
-  cdf: function cdf(x, a, b) {
-    if (x < a)
-      return 0;
-    else if (x < b)
-      return (x - a) / (b - a);
-    return 1;
-  },
-
-  inv: function(p, a, b) {
-    return a + (p * (b - a));
-  },
-
-  mean: function mean(a, b) {
-    return 0.5 * (a + b);
-  },
-
-  median: function median(a, b) {
-    return jStat.mean(a, b);
-  },
-
-  mode: function mode(a, b) {
-    throw new Error('mode is not yet implemented');
-  },
-
-  sample: function sample(a, b) {
-    return (a / 2 + b / 2) + (b / 2 - a / 2) * (2 * Math.random() - 1);
-  },
-
-  variance: function variance(a, b) {
-    return Math.pow(b - a, 2) / 12;
-  }
-});
-
-
-
-// extend uniform function with static methods
-jStat.extend(jStat.binomial, {
-  pdf: function pdf(k, n, p) {
-    return (p === 0 || p === 1) ?
-      ((n * p) === k ? 1 : 0) :
-      jStat.combination(n, k) * Math.pow(p, k) * Math.pow(1 - p, n - k);
-  },
-
-  cdf: function cdf(x, n, p) {
-    var binomarr = [],
-    k = 0;
-    if (x < 0) {
-      return 0;
-    }
-    if (x < n) {
-      for (; k <= x; k++) {
-        binomarr[ k ] = jStat.binomial.pdf(k, n, p);
-      }
-      return jStat.sum(binomarr);
-    }
-    return 1;
-  }
-});
-
-
-
-// extend uniform function with static methods
-jStat.extend(jStat.negbin, {
-  pdf: function pdf(k, r, p) {
-    if (k !== k >>> 0)
-      return false;
-    if (k < 0)
-      return 0;
-    return jStat.combination(k + r - 1, r - 1) *
-        Math.pow(1 - p, k) * Math.pow(p, r);
-  },
-
-  cdf: function cdf(x, r, p) {
-    var sum = 0,
-    k = 0;
-    if (x < 0) return 0;
-    for (; k <= x; k++) {
-      sum += jStat.negbin.pdf(k, r, p);
-    }
-    return sum;
-  }
-});
-
-
-
-// extend uniform function with static methods
-jStat.extend(jStat.hypgeom, {
-  pdf: function pdf(k, N, m, n) {
-    // Hypergeometric PDF.
-
-    // A simplification of the CDF algorithm below.
-
-    // k = number of successes drawn
-    // N = population size
-    // m = number of successes in population
-    // n = number of items drawn from population
-
-    if(k !== k | 0) {
-      return false;
-    } else if(k < 0 || k < m - (N - n)) {
-      // It's impossible to have this few successes drawn.
-      return 0;
-    } else if(k > n || k > m) {
-      // It's impossible to have this many successes drawn.
-      return 0;
-    } else if (m * 2 > N) {
-      // More than half the population is successes.
-
-      if(n * 2 > N) {
-        // More than half the population is sampled.
-
-        return jStat.hypgeom.pdf(N - m - n + k, N, N - m, N - n)
-      } else {
-        // Half or less of the population is sampled.
-
-        return jStat.hypgeom.pdf(n - k, N, N - m, n);
-      }
-
-    } else if(n * 2 > N) {
-      // Half or less is successes.
-
-      return jStat.hypgeom.pdf(m - k, N, m, N - n);
-
-    } else if(m < n) {
-      // We want to have the number of things sampled to be less than the
-      // successes available. So swap the definitions of successful and sampled.
-      return jStat.hypgeom.pdf(k, N, n, m);
-    } else {
-      // If we get here, half or less of the population was sampled, half or
-      // less of it was successes, and we had fewer sampled things than
-      // successes. Now we can do this complicated iterative algorithm in an
-      // efficient way.
-
-      // The basic premise of the algorithm is that we partially normalize our
-      // intermediate product to keep it in a numerically good region, and then
-      // finish the normalization at the end.
-
-      // This variable holds the scaled probability of the current number of
-      // successes.
-      var scaledPDF = 1;
-
-      // This keeps track of how much we have normalized.
-      var samplesDone = 0;
-
-      for(var i = 0; i < k; i++) {
-        // For every possible number of successes up to that observed...
-
-        while(scaledPDF > 1 && samplesDone < n) {
-          // Intermediate result is growing too big. Apply some of the
-          // normalization to shrink everything.
-
-          scaledPDF *= 1 - (m / (N - samplesDone));
-
-          // Say we've normalized by this sample already.
-          samplesDone++;
+    });
+
+
+
+    // extend uniform function with static methods
+    jStat.extend(jStat.negbin, {
+      pdf: function pdf(k, r, p) {
+        if (k !== k >>> 0)
+          return false;
+        if (k < 0)
+          return 0;
+        return jStat.combination(k + r - 1, r - 1) *
+            Math.pow(1 - p, k) * Math.pow(p, r);
+      },
+
+      cdf: function cdf(x, r, p) {
+        var sum = 0,
+        k = 0;
+        if (x < 0) return 0;
+        for (; k <= x; k++) {
+          sum += jStat.negbin.pdf(k, r, p);
         }
-
-        // Work out the partially-normalized hypergeometric PDF for the next
-        // number of successes
-        scaledPDF *= (n - i) * (m - i) / ((i + 1) * (N - m - n + i + 1));
+        return sum;
       }
+    });
 
-      for(; samplesDone < n; samplesDone++) {
-        // Apply all the rest of the normalization
-        scaledPDF *= 1 - (m / (N - samplesDone));
-      }
 
-      // Bound answer sanely before returning.
-      return Math.min(1, Math.max(0, scaledPDF));
-    }
-  },
 
-  cdf: function cdf(x, N, m, n) {
-    // Hypergeometric CDF.
+    // extend uniform function with static methods
+    jStat.extend(jStat.hypgeom, {
+      pdf: function pdf(k, N, m, n) {
+        // Hypergeometric PDF.
 
-    // This algorithm is due to Prof. Thomas S. Ferguson, <tom@math.ucla.edu>,
-    // and comes from his hypergeometric test calculator at
-    // <http://www.math.ucla.edu/~tom/distributions/Hypergeometric.html>.
+        // A simplification of the CDF algorithm below.
 
-    // x = number of successes drawn
-    // N = population size
-    // m = number of successes in population
-    // n = number of items drawn from population
+        // k = number of successes drawn
+        // N = population size
+        // m = number of successes in population
+        // n = number of items drawn from population
 
-    if(x < 0 || x < m - (N - n)) {
-      // It's impossible to have this few successes drawn or fewer.
-      return 0;
-    } else if(x >= n || x >= m) {
-      // We will always have this many successes or fewer.
-      return 1;
-    } else if (m * 2 > N) {
-      // More than half the population is successes.
+        if(k !== k | 0) {
+          return false;
+        } else if(k < 0 || k < m - (N - n)) {
+          // It's impossible to have this few successes drawn.
+          return 0;
+        } else if(k > n || k > m) {
+          // It's impossible to have this many successes drawn.
+          return 0;
+        } else if (m * 2 > N) {
+          // More than half the population is successes.
 
-      if(n * 2 > N) {
-        // More than half the population is sampled.
+          if(n * 2 > N) {
+            // More than half the population is sampled.
 
-        return jStat.hypgeom.cdf(N - m - n + x, N, N - m, N - n)
-      } else {
-        // Half or less of the population is sampled.
-
-        return 1 - jStat.hypgeom.cdf(n - x - 1, N, N - m, n);
-      }
-
-    } else if(n * 2 > N) {
-      // Half or less is successes.
-
-      return 1 - jStat.hypgeom.cdf(m - x - 1, N, m, N - n);
-
-    } else if(m < n) {
-      // We want to have the number of things sampled to be less than the
-      // successes available. So swap the definitions of successful and sampled.
-      return jStat.hypgeom.cdf(x, N, n, m);
-    } else {
-      // If we get here, half or less of the population was sampled, half or
-      // less of it was successes, and we had fewer sampled things than
-      // successes. Now we can do this complicated iterative algorithm in an
-      // efficient way.
-
-      // The basic premise of the algorithm is that we partially normalize our
-      // intermediate sum to keep it in a numerically good region, and then
-      // finish the normalization at the end.
-
-      // Holds the intermediate, scaled total CDF.
-      var scaledCDF = 1;
-
-      // This variable holds the scaled probability of the current number of
-      // successes.
-      var scaledPDF = 1;
-
-      // This keeps track of how much we have normalized.
-      var samplesDone = 0;
-
-      for(var i = 0; i < x; i++) {
-        // For every possible number of successes up to that observed...
-
-        while(scaledCDF > 1 && samplesDone < n) {
-          // Intermediate result is growing too big. Apply some of the
-          // normalization to shrink everything.
-
-          var factor = 1 - (m / (N - samplesDone));
-
-          scaledPDF *= factor;
-          scaledCDF *= factor;
-
-          // Say we've normalized by this sample already.
-          samplesDone++;
-        }
-
-        // Work out the partially-normalized hypergeometric PDF for the next
-        // number of successes
-        scaledPDF *= (n - i) * (m - i) / ((i + 1) * (N - m - n + i + 1));
-
-        // Add to the CDF answer.
-        scaledCDF += scaledPDF;
-      }
-
-      for(; samplesDone < n; samplesDone++) {
-        // Apply all the rest of the normalization
-        scaledCDF *= 1 - (m / (N - samplesDone));
-      }
-
-      // Bound answer sanely before returning.
-      return Math.min(1, Math.max(0, scaledCDF));
-    }
-  }
-});
-
-
-
-// extend uniform function with static methods
-jStat.extend(jStat.poisson, {
-  pdf: function pdf(k, l) {
-    if (l < 0 || (k % 1) !== 0 || k < 0) {
-      return 0;
-    }
-
-    return Math.pow(l, k) * Math.exp(-l) / jStat.factorial(k);
-  },
-
-  cdf: function cdf(x, l) {
-    var sumarr = [],
-    k = 0;
-    if (x < 0) return 0;
-    for (; k <= x; k++) {
-      sumarr.push(jStat.poisson.pdf(k, l));
-    }
-    return jStat.sum(sumarr);
-  },
-
-  mean : function(l) {
-    return l;
-  },
-
-  variance : function(l) {
-    return l;
-  },
-
-  sample: function sample(l) {
-    var p = 1, k = 0, L = Math.exp(-l);
-    do {
-      k++;
-      p *= Math.random();
-    } while (p > L);
-    return k - 1;
-  }
-});
-
-// extend triangular function with static methods
-jStat.extend(jStat.triangular, {
-  pdf: function pdf(x, a, b, c) {
-    if (b <= a || c < a || c > b) {
-      return NaN;
-    } else {
-      if (x < a || x > b) {
-        return 0;
-      } else if (x < c) {
-          return (2 * (x - a)) / ((b - a) * (c - a));
-      } else if (x === c) {
-          return (2 / (b - a));
-      } else { // x > c
-          return (2 * (b - x)) / ((b - a) * (b - c));
-      }
-    }
-  },
-
-  cdf: function cdf(x, a, b, c) {
-    if (b <= a || c < a || c > b)
-      return NaN;
-    if (x <= a)
-      return 0;
-    else if (x >= b)
-      return 1;
-    if (x <= c)
-      return Math.pow(x - a, 2) / ((b - a) * (c - a));
-    else // x > c
-      return 1 - Math.pow(b - x, 2) / ((b - a) * (b - c));
-  },
-
-  inv: function inv(p, a, b, c) {
-    if (b <= a || c < a || c > b) {
-      return NaN;
-    } else {
-      if (p <= ((c - a) / (b - a))) {
-        return a + (b - a) * Math.sqrt(p * ((c - a) / (b - a)));
-      } else { // p > ((c - a) / (b - a))
-        return a + (b - a) * (1 - Math.sqrt((1 - p) * (1 - ((c - a) / (b - a)))));
-      }
-    }
-  },
-
-  mean: function mean(a, b, c) {
-    return (a + b + c) / 3;
-  },
-
-  median: function median(a, b, c) {
-    if (c <= (a + b) / 2) {
-      return b - Math.sqrt((b - a) * (b - c)) / Math.sqrt(2);
-    } else if (c > (a + b) / 2) {
-      return a + Math.sqrt((b - a) * (c - a)) / Math.sqrt(2);
-    }
-  },
-
-  mode: function mode(a, b, c) {
-    return c;
-  },
-
-  sample: function sample(a, b, c) {
-    var u = Math.random();
-    if (u < ((c - a) / (b - a)))
-      return a + Math.sqrt(u * (b - a) * (c - a))
-    return b - Math.sqrt((1 - u) * (b - a) * (b - c));
-  },
-
-  variance: function variance(a, b, c) {
-    return (a * a + b * b + c * c - a * b - a * c - b * c) / 18;
-  }
-});
-
-
-// extend arcsine function with static methods
-jStat.extend(jStat.arcsine, {
-  pdf: function pdf(x, a, b) {
-    if (b <= a) return NaN;
-
-    return (x <= a || x >= b) ? 0 :
-      (2 / Math.PI) *
-        Math.pow(Math.pow(b - a, 2) -
-                  Math.pow(2 * x - a - b, 2), -0.5);
-  },
-
-  cdf: function cdf(x, a, b) {
-    if (x < a)
-      return 0;
-    else if (x < b)
-      return (2 / Math.PI) * Math.asin(Math.sqrt((x - a)/(b - a)));
-    return 1;
-  },
-
-  inv: function(p, a, b) {
-    return a + (0.5 - 0.5 * Math.cos(Math.PI * p)) * (b - a);
-  },
-
-  mean: function mean(a, b) {
-    if (b <= a) return NaN;
-    return (a + b) / 2;
-  },
-
-  median: function median(a, b) {
-    if (b <= a) return NaN;
-    return (a + b) / 2;
-  },
-
-  mode: function mode(a, b) {
-    throw new Error('mode is not yet implemented');
-  },
-
-  sample: function sample(a, b) {
-    return ((a + b) / 2) + ((b - a) / 2) *
-      Math.sin(2 * Math.PI * jStat.uniform.sample(0, 1));
-  },
-
-  variance: function variance(a, b) {
-    if (b <= a) return NaN;
-    return Math.pow(b - a, 2) / 8;
-  }
-});
-
-
-function laplaceSign(x) { return x / Math.abs(x); }
-
-jStat.extend(jStat.laplace, {
-  pdf: function pdf(x, mu, b) {
-    return (b <= 0) ? 0 : (Math.exp(-Math.abs(x - mu) / b)) / (2 * b);
-  },
-
-  cdf: function cdf(x, mu, b) {
-    if (b <= 0) { return 0; }
-
-    if(x < mu) {
-      return 0.5 * Math.exp((x - mu) / b);
-    } else {
-      return 1 - 0.5 * Math.exp(- (x - mu) / b);
-    }
-  },
-
-  mean: function(mu, b) {
-    return mu;
-  },
-
-  median: function(mu, b) {
-    return mu;
-  },
-
-  mode: function(mu, b) {
-    return mu;
-  },
-
-  variance: function(mu, b) {
-    return 2 * b * b;
-  },
-
-  sample: function sample(mu, b) {
-    var u = Math.random() - 0.5;
-
-    return mu - (b * laplaceSign(u) * Math.log(1 - (2 * Math.abs(u))));
-  }
-});
-
-function tukeyWprob(w, rr, cc) {
-  var nleg = 12;
-  var ihalf = 6;
-
-  var C1 = -30;
-  var C2 = -50;
-  var C3 = 60;
-  var bb   = 8;
-  var wlar = 3;
-  var wincr1 = 2;
-  var wincr2 = 3;
-  var xleg = [
-    0.981560634246719250690549090149,
-    0.904117256370474856678465866119,
-    0.769902674194304687036893833213,
-    0.587317954286617447296702418941,
-    0.367831498998180193752691536644,
-    0.125233408511468915472441369464
-  ];
-  var aleg = [
-    0.047175336386511827194615961485,
-    0.106939325995318430960254718194,
-    0.160078328543346226334652529543,
-    0.203167426723065921749064455810,
-    0.233492536538354808760849898925,
-    0.249147045813402785000562436043
-  ];
-
-  var qsqz = w * 0.5;
-
-  // if w >= 16 then the integral lower bound (occurs for c=20)
-  // is 0.99999999999995 so return a value of 1.
-
-  if (qsqz >= bb)
-    return 1.0;
-
-  // find (f(w/2) - 1) ^ cc
-  // (first term in integral of hartley's form).
-
-  var pr_w = 2 * jStat.normal.cdf(qsqz, 0, 1, 1, 0) - 1; // erf(qsqz / M_SQRT2)
-  // if pr_w ^ cc < 2e-22 then set pr_w = 0
-  if (pr_w >= Math.exp(C2 / cc))
-    pr_w = Math.pow(pr_w, cc);
-  else
-    pr_w = 0.0;
-
-  // if w is large then the second component of the
-  // integral is small, so fewer intervals are needed.
-
-  var wincr;
-  if (w > wlar)
-    wincr = wincr1;
-  else
-    wincr = wincr2;
-
-  // find the integral of second term of hartley's form
-  // for the integral of the range for equal-length
-  // intervals using legendre quadrature.  limits of
-  // integration are from (w/2, 8).  two or three
-  // equal-length intervals are used.
-
-  // blb and bub are lower and upper limits of integration.
-
-  var blb = qsqz;
-  var binc = (bb - qsqz) / wincr;
-  var bub = blb + binc;
-  var einsum = 0.0;
-
-  // integrate over each interval
-
-  var cc1 = cc - 1.0;
-  for (var wi = 1; wi <= wincr; wi++) {
-    var elsum = 0.0;
-    var a = 0.5 * (bub + blb);
-
-    // legendre quadrature with order = nleg
-
-    var b = 0.5 * (bub - blb);
-
-    for (var jj = 1; jj <= nleg; jj++) {
-      var j, xx;
-      if (ihalf < jj) {
-        j = (nleg - jj) + 1;
-        xx = xleg[j-1];
-      } else {
-        j = jj;
-        xx = -xleg[j-1];
-      }
-      var c = b * xx;
-      var ac = a + c;
-
-      // if exp(-qexpo/2) < 9e-14,
-      // then doesn't contribute to integral
-
-      var qexpo = ac * ac;
-      if (qexpo > C3)
-        break;
-
-      var pplus = 2 * jStat.normal.cdf(ac, 0, 1, 1, 0);
-      var pminus= 2 * jStat.normal.cdf(ac, w, 1, 1, 0);
-
-      // if rinsum ^ (cc-1) < 9e-14,
-      // then doesn't contribute to integral
-
-      var rinsum = (pplus * 0.5) - (pminus * 0.5);
-      if (rinsum >= Math.exp(C1 / cc1)) {
-        rinsum = (aleg[j-1] * Math.exp(-(0.5 * qexpo))) * Math.pow(rinsum, cc1);
-        elsum += rinsum;
-      }
-    }
-    elsum *= (((2.0 * b) * cc) / Math.sqrt(2 * Math.PI));
-    einsum += elsum;
-    blb = bub;
-    bub += binc;
-  }
-
-  // if pr_w ^ rr < 9e-14, then return 0
-  pr_w += einsum;
-  if (pr_w <= Math.exp(C1 / rr))
-    return 0;
-
-  pr_w = Math.pow(pr_w, rr);
-  if (pr_w >= 1) // 1 was iMax was eps
-    return 1;
-  return pr_w;
-}
-
-function tukeyQinv(p, c, v) {
-  var p0 = 0.322232421088;
-  var q0 = 0.993484626060e-01;
-  var p1 = -1.0;
-  var q1 = 0.588581570495;
-  var p2 = -0.342242088547;
-  var q2 = 0.531103462366;
-  var p3 = -0.204231210125;
-  var q3 = 0.103537752850;
-  var p4 = -0.453642210148e-04;
-  var q4 = 0.38560700634e-02;
-  var c1 = 0.8832;
-  var c2 = 0.2368;
-  var c3 = 1.214;
-  var c4 = 1.208;
-  var c5 = 1.4142;
-  var vmax = 120.0;
-
-  var ps = 0.5 - 0.5 * p;
-  var yi = Math.sqrt(Math.log(1.0 / (ps * ps)));
-  var t = yi + (((( yi * p4 + p3) * yi + p2) * yi + p1) * yi + p0)
-     / (((( yi * q4 + q3) * yi + q2) * yi + q1) * yi + q0);
-  if (v < vmax) t += (t * t * t + t) / v / 4.0;
-  var q = c1 - c2 * t;
-  if (v < vmax) q += -c3 / v + c4 * t / v;
-  return t * (q * Math.log(c - 1.0) + c5);
-}
-
-jStat.extend(jStat.tukey, {
-  cdf: function cdf(q, nmeans, df) {
-    // Identical implementation as the R ptukey() function as of commit 68947
-    var rr = 1;
-    var cc = nmeans;
-
-    var nlegq = 16;
-    var ihalfq = 8;
-
-    var eps1 = -30.0;
-    var eps2 = 1.0e-14;
-    var dhaf  = 100.0;
-    var dquar = 800.0;
-    var deigh = 5000.0;
-    var dlarg = 25000.0;
-    var ulen1 = 1.0;
-    var ulen2 = 0.5;
-    var ulen3 = 0.25;
-    var ulen4 = 0.125;
-    var xlegq = [
-      0.989400934991649932596154173450,
-      0.944575023073232576077988415535,
-      0.865631202387831743880467897712,
-      0.755404408355003033895101194847,
-      0.617876244402643748446671764049,
-      0.458016777657227386342419442984,
-      0.281603550779258913230460501460,
-      0.950125098376374401853193354250e-1
-    ];
-    var alegq = [
-      0.271524594117540948517805724560e-1,
-      0.622535239386478928628438369944e-1,
-      0.951585116824927848099251076022e-1,
-      0.124628971255533872052476282192,
-      0.149595988816576732081501730547,
-      0.169156519395002538189312079030,
-      0.182603415044923588866763667969,
-      0.189450610455068496285396723208
-    ];
-
-    if (q <= 0)
-      return 0;
-
-    // df must be > 1
-    // there must be at least two values
-
-    if (df < 2 || rr < 1 || cc < 2) return NaN;
-
-    if (!Number.isFinite(q))
-      return 1;
-
-    if (df > dlarg)
-      return tukeyWprob(q, rr, cc);
-
-    // calculate leading constant
-
-    var f2 = df * 0.5;
-    var f2lf = ((f2 * Math.log(df)) - (df * Math.log(2))) - jStat.gammaln(f2);
-    var f21 = f2 - 1.0;
-
-    // integral is divided into unit, half-unit, quarter-unit, or
-    // eighth-unit length intervals depending on the value of the
-    // degrees of freedom.
-
-    var ff4 = df * 0.25;
-    var ulen;
-    if      (df <= dhaf)  ulen = ulen1;
-    else if (df <= dquar) ulen = ulen2;
-    else if (df <= deigh) ulen = ulen3;
-    else                  ulen = ulen4;
-
-    f2lf += Math.log(ulen);
-
-    // integrate over each subinterval
-
-    var ans = 0.0;
-
-    for (var i = 1; i <= 50; i++) {
-      var otsum = 0.0;
-
-      // legendre quadrature with order = nlegq
-      // nodes (stored in xlegq) are symmetric around zero.
-
-      var twa1 = (2 * i - 1) * ulen;
-
-      for (var jj = 1; jj <= nlegq; jj++) {
-        var j, t1;
-        if (ihalfq < jj) {
-          j = jj - ihalfq - 1;
-          t1 = (f2lf + (f21 * Math.log(twa1 + (xlegq[j] * ulen))))
-              - (((xlegq[j] * ulen) + twa1) * ff4);
-        } else {
-          j = jj - 1;
-          t1 = (f2lf + (f21 * Math.log(twa1 - (xlegq[j] * ulen))))
-              + (((xlegq[j] * ulen) - twa1) * ff4);
-        }
-
-        // if exp(t1) < 9e-14, then doesn't contribute to integral
-        var qsqz;
-        if (t1 >= eps1) {
-          if (ihalfq < jj) {
-            qsqz = q * Math.sqrt(((xlegq[j] * ulen) + twa1) * 0.5);
+            return jStat.hypgeom.pdf(N - m - n + k, N, N - m, N - n)
           } else {
-            qsqz = q * Math.sqrt(((-(xlegq[j] * ulen)) + twa1) * 0.5);
+            // Half or less of the population is sampled.
+
+            return jStat.hypgeom.pdf(n - k, N, N - m, n);
           }
 
-          // call wprob to find integral of range portion
+        } else if(n * 2 > N) {
+          // Half or less is successes.
 
-          var wprb = tukeyWprob(qsqz, rr, cc);
-          var rotsum = (wprb * alegq[j]) * Math.exp(t1);
-          otsum += rotsum;
+          return jStat.hypgeom.pdf(m - k, N, m, N - n);
+
+        } else if(m < n) {
+          // We want to have the number of things sampled to be less than the
+          // successes available. So swap the definitions of successful and sampled.
+          return jStat.hypgeom.pdf(k, N, n, m);
+        } else {
+          // If we get here, half or less of the population was sampled, half or
+          // less of it was successes, and we had fewer sampled things than
+          // successes. Now we can do this complicated iterative algorithm in an
+          // efficient way.
+
+          // The basic premise of the algorithm is that we partially normalize our
+          // intermediate product to keep it in a numerically good region, and then
+          // finish the normalization at the end.
+
+          // This variable holds the scaled probability of the current number of
+          // successes.
+          var scaledPDF = 1;
+
+          // This keeps track of how much we have normalized.
+          var samplesDone = 0;
+
+          for(var i = 0; i < k; i++) {
+            // For every possible number of successes up to that observed...
+
+            while(scaledPDF > 1 && samplesDone < n) {
+              // Intermediate result is growing too big. Apply some of the
+              // normalization to shrink everything.
+
+              scaledPDF *= 1 - (m / (N - samplesDone));
+
+              // Say we've normalized by this sample already.
+              samplesDone++;
+            }
+
+            // Work out the partially-normalized hypergeometric PDF for the next
+            // number of successes
+            scaledPDF *= (n - i) * (m - i) / ((i + 1) * (N - m - n + i + 1));
+          }
+
+          for(; samplesDone < n; samplesDone++) {
+            // Apply all the rest of the normalization
+            scaledPDF *= 1 - (m / (N - samplesDone));
+          }
+
+          // Bound answer sanely before returning.
+          return Math.min(1, Math.max(0, scaledPDF));
         }
-        // end legendre integral for interval i
-        // L200:
+      },
+
+      cdf: function cdf(x, N, m, n) {
+        // Hypergeometric CDF.
+
+        // This algorithm is due to Prof. Thomas S. Ferguson, <tom@math.ucla.edu>,
+        // and comes from his hypergeometric test calculator at
+        // <http://www.math.ucla.edu/~tom/distributions/Hypergeometric.html>.
+
+        // x = number of successes drawn
+        // N = population size
+        // m = number of successes in population
+        // n = number of items drawn from population
+
+        if(x < 0 || x < m - (N - n)) {
+          // It's impossible to have this few successes drawn or fewer.
+          return 0;
+        } else if(x >= n || x >= m) {
+          // We will always have this many successes or fewer.
+          return 1;
+        } else if (m * 2 > N) {
+          // More than half the population is successes.
+
+          if(n * 2 > N) {
+            // More than half the population is sampled.
+
+            return jStat.hypgeom.cdf(N - m - n + x, N, N - m, N - n)
+          } else {
+            // Half or less of the population is sampled.
+
+            return 1 - jStat.hypgeom.cdf(n - x - 1, N, N - m, n);
+          }
+
+        } else if(n * 2 > N) {
+          // Half or less is successes.
+
+          return 1 - jStat.hypgeom.cdf(m - x - 1, N, m, N - n);
+
+        } else if(m < n) {
+          // We want to have the number of things sampled to be less than the
+          // successes available. So swap the definitions of successful and sampled.
+          return jStat.hypgeom.cdf(x, N, n, m);
+        } else {
+          // If we get here, half or less of the population was sampled, half or
+          // less of it was successes, and we had fewer sampled things than
+          // successes. Now we can do this complicated iterative algorithm in an
+          // efficient way.
+
+          // The basic premise of the algorithm is that we partially normalize our
+          // intermediate sum to keep it in a numerically good region, and then
+          // finish the normalization at the end.
+
+          // Holds the intermediate, scaled total CDF.
+          var scaledCDF = 1;
+
+          // This variable holds the scaled probability of the current number of
+          // successes.
+          var scaledPDF = 1;
+
+          // This keeps track of how much we have normalized.
+          var samplesDone = 0;
+
+          for(var i = 0; i < x; i++) {
+            // For every possible number of successes up to that observed...
+
+            while(scaledCDF > 1 && samplesDone < n) {
+              // Intermediate result is growing too big. Apply some of the
+              // normalization to shrink everything.
+
+              var factor = 1 - (m / (N - samplesDone));
+
+              scaledPDF *= factor;
+              scaledCDF *= factor;
+
+              // Say we've normalized by this sample already.
+              samplesDone++;
+            }
+
+            // Work out the partially-normalized hypergeometric PDF for the next
+            // number of successes
+            scaledPDF *= (n - i) * (m - i) / ((i + 1) * (N - m - n + i + 1));
+
+            // Add to the CDF answer.
+            scaledCDF += scaledPDF;
+          }
+
+          for(; samplesDone < n; samplesDone++) {
+            // Apply all the rest of the normalization
+            scaledCDF *= 1 - (m / (N - samplesDone));
+          }
+
+          // Bound answer sanely before returning.
+          return Math.min(1, Math.max(0, scaledCDF));
+        }
+      }
+    });
+
+
+
+    // extend uniform function with static methods
+    jStat.extend(jStat.poisson, {
+      pdf: function pdf(k, l) {
+        if (l < 0 || (k % 1) !== 0 || k < 0) {
+          return 0;
+        }
+
+        return Math.pow(l, k) * Math.exp(-l) / jStat.factorial(k);
+      },
+
+      cdf: function cdf(x, l) {
+        var sumarr = [],
+        k = 0;
+        if (x < 0) return 0;
+        for (; k <= x; k++) {
+          sumarr.push(jStat.poisson.pdf(k, l));
+        }
+        return jStat.sum(sumarr);
+      },
+
+      mean : function(l) {
+        return l;
+      },
+
+      variance : function(l) {
+        return l;
+      },
+
+      sample: function sample(l) {
+        var p = 1, k = 0, L = Math.exp(-l);
+        do {
+          k++;
+          p *= Math.random();
+        } while (p > L);
+        return k - 1;
+      }
+    });
+
+    // extend triangular function with static methods
+    jStat.extend(jStat.triangular, {
+      pdf: function pdf(x, a, b, c) {
+        if (b <= a || c < a || c > b) {
+          return NaN;
+        } else {
+          if (x < a || x > b) {
+            return 0;
+          } else if (x < c) {
+              return (2 * (x - a)) / ((b - a) * (c - a));
+          } else if (x === c) {
+              return (2 / (b - a));
+          } else { // x > c
+              return (2 * (b - x)) / ((b - a) * (b - c));
+          }
+        }
+      },
+
+      cdf: function cdf(x, a, b, c) {
+        if (b <= a || c < a || c > b)
+          return NaN;
+        if (x <= a)
+          return 0;
+        else if (x >= b)
+          return 1;
+        if (x <= c)
+          return Math.pow(x - a, 2) / ((b - a) * (c - a));
+        else // x > c
+          return 1 - Math.pow(b - x, 2) / ((b - a) * (b - c));
+      },
+
+      inv: function inv(p, a, b, c) {
+        if (b <= a || c < a || c > b) {
+          return NaN;
+        } else {
+          if (p <= ((c - a) / (b - a))) {
+            return a + (b - a) * Math.sqrt(p * ((c - a) / (b - a)));
+          } else { // p > ((c - a) / (b - a))
+            return a + (b - a) * (1 - Math.sqrt((1 - p) * (1 - ((c - a) / (b - a)))));
+          }
+        }
+      },
+
+      mean: function mean(a, b, c) {
+        return (a + b + c) / 3;
+      },
+
+      median: function median(a, b, c) {
+        if (c <= (a + b) / 2) {
+          return b - Math.sqrt((b - a) * (b - c)) / Math.sqrt(2);
+        } else if (c > (a + b) / 2) {
+          return a + Math.sqrt((b - a) * (c - a)) / Math.sqrt(2);
+        }
+      },
+
+      mode: function mode(a, b, c) {
+        return c;
+      },
+
+      sample: function sample(a, b, c) {
+        var u = Math.random();
+        if (u < ((c - a) / (b - a)))
+          return a + Math.sqrt(u * (b - a) * (c - a))
+        return b - Math.sqrt((1 - u) * (b - a) * (b - c));
+      },
+
+      variance: function variance(a, b, c) {
+        return (a * a + b * b + c * c - a * b - a * c - b * c) / 18;
+      }
+    });
+
+
+    // extend arcsine function with static methods
+    jStat.extend(jStat.arcsine, {
+      pdf: function pdf(x, a, b) {
+        if (b <= a) return NaN;
+
+        return (x <= a || x >= b) ? 0 :
+          (2 / Math.PI) *
+            Math.pow(Math.pow(b - a, 2) -
+                      Math.pow(2 * x - a - b, 2), -0.5);
+      },
+
+      cdf: function cdf(x, a, b) {
+        if (x < a)
+          return 0;
+        else if (x < b)
+          return (2 / Math.PI) * Math.asin(Math.sqrt((x - a)/(b - a)));
+        return 1;
+      },
+
+      inv: function(p, a, b) {
+        return a + (0.5 - 0.5 * Math.cos(Math.PI * p)) * (b - a);
+      },
+
+      mean: function mean(a, b) {
+        if (b <= a) return NaN;
+        return (a + b) / 2;
+      },
+
+      median: function median(a, b) {
+        if (b <= a) return NaN;
+        return (a + b) / 2;
+      },
+
+      mode: function mode(a, b) {
+        throw new Error('mode is not yet implemented');
+      },
+
+      sample: function sample(a, b) {
+        return ((a + b) / 2) + ((b - a) / 2) *
+          Math.sin(2 * Math.PI * jStat.uniform.sample(0, 1));
+      },
+
+      variance: function variance(a, b) {
+        if (b <= a) return NaN;
+        return Math.pow(b - a, 2) / 8;
+      }
+    });
+
+
+    function laplaceSign(x) { return x / Math.abs(x); }
+
+    jStat.extend(jStat.laplace, {
+      pdf: function pdf(x, mu, b) {
+        return (b <= 0) ? 0 : (Math.exp(-Math.abs(x - mu) / b)) / (2 * b);
+      },
+
+      cdf: function cdf(x, mu, b) {
+        if (b <= 0) { return 0; }
+
+        if(x < mu) {
+          return 0.5 * Math.exp((x - mu) / b);
+        } else {
+          return 1 - 0.5 * Math.exp(- (x - mu) / b);
+        }
+      },
+
+      mean: function(mu, b) {
+        return mu;
+      },
+
+      median: function(mu, b) {
+        return mu;
+      },
+
+      mode: function(mu, b) {
+        return mu;
+      },
+
+      variance: function(mu, b) {
+        return 2 * b * b;
+      },
+
+      sample: function sample(mu, b) {
+        var u = Math.random() - 0.5;
+
+        return mu - (b * laplaceSign(u) * Math.log(1 - (2 * Math.abs(u))));
+      }
+    });
+
+    function tukeyWprob(w, rr, cc) {
+      var nleg = 12;
+      var ihalf = 6;
+
+      var C1 = -30;
+      var C2 = -50;
+      var C3 = 60;
+      var bb   = 8;
+      var wlar = 3;
+      var wincr1 = 2;
+      var wincr2 = 3;
+      var xleg = [
+        0.981560634246719250690549090149,
+        0.904117256370474856678465866119,
+        0.769902674194304687036893833213,
+        0.587317954286617447296702418941,
+        0.367831498998180193752691536644,
+        0.125233408511468915472441369464
+      ];
+      var aleg = [
+        0.047175336386511827194615961485,
+        0.106939325995318430960254718194,
+        0.160078328543346226334652529543,
+        0.203167426723065921749064455810,
+        0.233492536538354808760849898925,
+        0.249147045813402785000562436043
+      ];
+
+      var qsqz = w * 0.5;
+
+      // if w >= 16 then the integral lower bound (occurs for c=20)
+      // is 0.99999999999995 so return a value of 1.
+
+      if (qsqz >= bb)
+        return 1.0;
+
+      // find (f(w/2) - 1) ^ cc
+      // (first term in integral of hartley's form).
+
+      var pr_w = 2 * jStat.normal.cdf(qsqz, 0, 1, 1, 0) - 1; // erf(qsqz / M_SQRT2)
+      // if pr_w ^ cc < 2e-22 then set pr_w = 0
+      if (pr_w >= Math.exp(C2 / cc))
+        pr_w = Math.pow(pr_w, cc);
+      else
+        pr_w = 0.0;
+
+      // if w is large then the second component of the
+      // integral is small, so fewer intervals are needed.
+
+      var wincr;
+      if (w > wlar)
+        wincr = wincr1;
+      else
+        wincr = wincr2;
+
+      // find the integral of second term of hartley's form
+      // for the integral of the range for equal-length
+      // intervals using legendre quadrature.  limits of
+      // integration are from (w/2, 8).  two or three
+      // equal-length intervals are used.
+
+      // blb and bub are lower and upper limits of integration.
+
+      var blb = qsqz;
+      var binc = (bb - qsqz) / wincr;
+      var bub = blb + binc;
+      var einsum = 0.0;
+
+      // integrate over each interval
+
+      var cc1 = cc - 1.0;
+      for (var wi = 1; wi <= wincr; wi++) {
+        var elsum = 0.0;
+        var a = 0.5 * (bub + blb);
+
+        // legendre quadrature with order = nleg
+
+        var b = 0.5 * (bub - blb);
+
+        for (var jj = 1; jj <= nleg; jj++) {
+          var j, xx;
+          if (ihalf < jj) {
+            j = (nleg - jj) + 1;
+            xx = xleg[j-1];
+          } else {
+            j = jj;
+            xx = -xleg[j-1];
+          }
+          var c = b * xx;
+          var ac = a + c;
+
+          // if exp(-qexpo/2) < 9e-14,
+          // then doesn't contribute to integral
+
+          var qexpo = ac * ac;
+          if (qexpo > C3)
+            break;
+
+          var pplus = 2 * jStat.normal.cdf(ac, 0, 1, 1, 0);
+          var pminus= 2 * jStat.normal.cdf(ac, w, 1, 1, 0);
+
+          // if rinsum ^ (cc-1) < 9e-14,
+          // then doesn't contribute to integral
+
+          var rinsum = (pplus * 0.5) - (pminus * 0.5);
+          if (rinsum >= Math.exp(C1 / cc1)) {
+            rinsum = (aleg[j-1] * Math.exp(-(0.5 * qexpo))) * Math.pow(rinsum, cc1);
+            elsum += rinsum;
+          }
+        }
+        elsum *= (((2.0 * b) * cc) / Math.sqrt(2 * Math.PI));
+        einsum += elsum;
+        blb = bub;
+        bub += binc;
       }
 
-      // if integral for interval i < 1e-14, then stop.
-      // However, in order to avoid small area under left tail,
-      // at least  1 / ulen  intervals are calculated.
-      if (i * ulen >= 1.0 && otsum <= eps2)
-        break;
+      // if pr_w ^ rr < 9e-14, then return 0
+      pr_w += einsum;
+      if (pr_w <= Math.exp(C1 / rr))
+        return 0;
 
-      // end of interval i
-      // L330:
-
-      ans += otsum;
+      pr_w = Math.pow(pr_w, rr);
+      if (pr_w >= 1) // 1 was iMax was eps
+        return 1;
+      return pr_w;
     }
 
-    if (otsum > eps2) { // not converged
-      throw new Error('tukey.cdf failed to converge');
+    function tukeyQinv(p, c, v) {
+      var p0 = 0.322232421088;
+      var q0 = 0.993484626060e-01;
+      var p1 = -1.0;
+      var q1 = 0.588581570495;
+      var p2 = -0.342242088547;
+      var q2 = 0.531103462366;
+      var p3 = -0.204231210125;
+      var q3 = 0.103537752850;
+      var p4 = -0.453642210148e-04;
+      var q4 = 0.38560700634e-02;
+      var c1 = 0.8832;
+      var c2 = 0.2368;
+      var c3 = 1.214;
+      var c4 = 1.208;
+      var c5 = 1.4142;
+      var vmax = 120.0;
+
+      var ps = 0.5 - 0.5 * p;
+      var yi = Math.sqrt(Math.log(1.0 / (ps * ps)));
+      var t = yi + (((( yi * p4 + p3) * yi + p2) * yi + p1) * yi + p0)
+         / (((( yi * q4 + q3) * yi + q2) * yi + q1) * yi + q0);
+      if (v < vmax) t += (t * t * t + t) / v / 4.0;
+      var q = c1 - c2 * t;
+      if (v < vmax) q += -c3 / v + c4 * t / v;
+      return t * (q * Math.log(c - 1.0) + c5);
     }
-    if (ans > 1)
-      ans = 1;
-    return ans;
-  },
 
-  inv: function(p, nmeans, df) {
-    // Identical implementation as the R qtukey() function as of commit 68947
-    var rr = 1;
-    var cc = nmeans;
+    jStat.extend(jStat.tukey, {
+      cdf: function cdf(q, nmeans, df) {
+        // Identical implementation as the R ptukey() function as of commit 68947
+        var rr = 1;
+        var cc = nmeans;
 
-    var eps = 0.0001;
-    var maxiter = 50;
+        var nlegq = 16;
+        var ihalfq = 8;
 
-    // df must be > 1 ; there must be at least two values
-    if (df < 2 || rr < 1 || cc < 2) return NaN;
+        var eps1 = -30.0;
+        var eps2 = 1.0e-14;
+        var dhaf  = 100.0;
+        var dquar = 800.0;
+        var deigh = 5000.0;
+        var dlarg = 25000.0;
+        var ulen1 = 1.0;
+        var ulen2 = 0.5;
+        var ulen3 = 0.25;
+        var ulen4 = 0.125;
+        var xlegq = [
+          0.989400934991649932596154173450,
+          0.944575023073232576077988415535,
+          0.865631202387831743880467897712,
+          0.755404408355003033895101194847,
+          0.617876244402643748446671764049,
+          0.458016777657227386342419442984,
+          0.281603550779258913230460501460,
+          0.950125098376374401853193354250e-1
+        ];
+        var alegq = [
+          0.271524594117540948517805724560e-1,
+          0.622535239386478928628438369944e-1,
+          0.951585116824927848099251076022e-1,
+          0.124628971255533872052476282192,
+          0.149595988816576732081501730547,
+          0.169156519395002538189312079030,
+          0.182603415044923588866763667969,
+          0.189450610455068496285396723208
+        ];
 
-    if (p < 0 || p > 1) return NaN;
-    if (p === 0) return 0;
-    if (p === 1) return Infinity;
+        if (q <= 0)
+          return 0;
 
-    // Initial value
+        // df must be > 1
+        // there must be at least two values
 
-    var x0 = tukeyQinv(p, cc, df);
+        if (df < 2 || rr < 1 || cc < 2) return NaN;
 
-    // Find prob(value < x0)
+        if (!Number.isFinite(q))
+          return 1;
 
-    var valx0 = jStat.tukey.cdf(x0, nmeans, df) - p;
+        if (df > dlarg)
+          return tukeyWprob(q, rr, cc);
 
-    // Find the second iterate and prob(value < x1).
-    // If the first iterate has probability value
-    // exceeding p then second iterate is 1 less than
-    // first iterate; otherwise it is 1 greater.
+        // calculate leading constant
 
-    var x1;
-    if (valx0 > 0.0)
-      x1 = Math.max(0.0, x0 - 1.0);
-    else
-      x1 = x0 + 1.0;
-    var valx1 = jStat.tukey.cdf(x1, nmeans, df) - p;
+        var f2 = df * 0.5;
+        var f2lf = ((f2 * Math.log(df)) - (df * Math.log(2))) - jStat.gammaln(f2);
+        var f21 = f2 - 1.0;
 
-    // Find new iterate
+        // integral is divided into unit, half-unit, quarter-unit, or
+        // eighth-unit length intervals depending on the value of the
+        // degrees of freedom.
 
-    var ans;
-    for(var iter = 1; iter < maxiter; iter++) {
-      ans = x1 - ((valx1 * (x1 - x0)) / (valx1 - valx0));
-      valx0 = valx1;
+        var ff4 = df * 0.25;
+        var ulen;
+        if      (df <= dhaf)  ulen = ulen1;
+        else if (df <= dquar) ulen = ulen2;
+        else if (df <= deigh) ulen = ulen3;
+        else                  ulen = ulen4;
 
-      // New iterate must be >= 0
+        f2lf += Math.log(ulen);
 
-      x0 = x1;
-      if (ans < 0.0) {
-        ans = 0.0;
-        valx1 = -p;
-      }
-      // Find prob(value < new iterate)
+        // integrate over each subinterval
 
-      valx1 = jStat.tukey.cdf(ans, nmeans, df) - p;
-      x1 = ans;
+        var ans = 0.0;
 
-      // If the difference between two successive
-      // iterates is less than eps, stop
+        for (var i = 1; i <= 50; i++) {
+          var otsum = 0.0;
 
-      var xabs = Math.abs(x1 - x0);
-      if (xabs < eps)
+          // legendre quadrature with order = nlegq
+          // nodes (stored in xlegq) are symmetric around zero.
+
+          var twa1 = (2 * i - 1) * ulen;
+
+          for (var jj = 1; jj <= nlegq; jj++) {
+            var j, t1;
+            if (ihalfq < jj) {
+              j = jj - ihalfq - 1;
+              t1 = (f2lf + (f21 * Math.log(twa1 + (xlegq[j] * ulen))))
+                  - (((xlegq[j] * ulen) + twa1) * ff4);
+            } else {
+              j = jj - 1;
+              t1 = (f2lf + (f21 * Math.log(twa1 - (xlegq[j] * ulen))))
+                  + (((xlegq[j] * ulen) - twa1) * ff4);
+            }
+
+            // if exp(t1) < 9e-14, then doesn't contribute to integral
+            var qsqz;
+            if (t1 >= eps1) {
+              if (ihalfq < jj) {
+                qsqz = q * Math.sqrt(((xlegq[j] * ulen) + twa1) * 0.5);
+              } else {
+                qsqz = q * Math.sqrt(((-(xlegq[j] * ulen)) + twa1) * 0.5);
+              }
+
+              // call wprob to find integral of range portion
+
+              var wprb = tukeyWprob(qsqz, rr, cc);
+              var rotsum = (wprb * alegq[j]) * Math.exp(t1);
+              otsum += rotsum;
+            }
+            // end legendre integral for interval i
+            // L200:
+          }
+
+          // if integral for interval i < 1e-14, then stop.
+          // However, in order to avoid small area under left tail,
+          // at least  1 / ulen  intervals are calculated.
+          if (i * ulen >= 1.0 && otsum <= eps2)
+            break;
+
+          // end of interval i
+          // L330:
+
+          ans += otsum;
+        }
+
+        if (otsum > eps2) { // not converged
+          throw new Error('tukey.cdf failed to converge');
+        }
+        if (ans > 1)
+          ans = 1;
         return ans;
+      },
+
+      inv: function(p, nmeans, df) {
+        // Identical implementation as the R qtukey() function as of commit 68947
+        var rr = 1;
+        var cc = nmeans;
+
+        var eps = 0.0001;
+        var maxiter = 50;
+
+        // df must be > 1 ; there must be at least two values
+        if (df < 2 || rr < 1 || cc < 2) return NaN;
+
+        if (p < 0 || p > 1) return NaN;
+        if (p === 0) return 0;
+        if (p === 1) return Infinity;
+
+        // Initial value
+
+        var x0 = tukeyQinv(p, cc, df);
+
+        // Find prob(value < x0)
+
+        var valx0 = jStat.tukey.cdf(x0, nmeans, df) - p;
+
+        // Find the second iterate and prob(value < x1).
+        // If the first iterate has probability value
+        // exceeding p then second iterate is 1 less than
+        // first iterate; otherwise it is 1 greater.
+
+        var x1;
+        if (valx0 > 0.0)
+          x1 = Math.max(0.0, x0 - 1.0);
+        else
+          x1 = x0 + 1.0;
+        var valx1 = jStat.tukey.cdf(x1, nmeans, df) - p;
+
+        // Find new iterate
+
+        var ans;
+        for(var iter = 1; iter < maxiter; iter++) {
+          ans = x1 - ((valx1 * (x1 - x0)) / (valx1 - valx0));
+          valx0 = valx1;
+
+          // New iterate must be >= 0
+
+          x0 = x1;
+          if (ans < 0.0) {
+            ans = 0.0;
+            valx1 = -p;
+          }
+          // Find prob(value < new iterate)
+
+          valx1 = jStat.tukey.cdf(ans, nmeans, df) - p;
+          x1 = ans;
+
+          // If the difference between two successive
+          // iterates is less than eps, stop
+
+          var xabs = Math.abs(x1 - x0);
+          if (xabs < eps)
+            return ans;
+        }
+
+        throw new Error('tukey.inv failed to converge');
+      }
+    });
+
+    }(jStat, Math));
+    /* Provides functions for the solution of linear system of equations, integration, extrapolation,
+     * interpolation, eigenvalue problems, differential equations and PCA analysis. */
+
+    (function(jStat, Math) {
+
+    var push = Array.prototype.push;
+    var isArray = jStat.utils.isArray;
+
+    function isUsable(arg) {
+      return isArray(arg) || arg instanceof jStat;
     }
 
-    throw new Error('tukey.inv failed to converge');
-  }
-});
+    jStat.extend({
 
-}(jStat, Math));
-/* Provides functions for the solution of linear system of equations, integration, extrapolation,
- * interpolation, eigenvalue problems, differential equations and PCA analysis. */
+      // add a vector/matrix to a vector/matrix or scalar
+      add: function add(arr, arg) {
+        // check if arg is a vector or scalar
+        if (isUsable(arg)) {
+          if (!isUsable(arg[0])) arg = [ arg ];
+          return jStat.map(arr, function(value, row, col) {
+            return value + arg[row][col];
+          });
+        }
+        return jStat.map(arr, function(value) { return value + arg; });
+      },
 
-(function(jStat, Math) {
+      // subtract a vector or scalar from the vector
+      subtract: function subtract(arr, arg) {
+        // check if arg is a vector or scalar
+        if (isUsable(arg)) {
+          if (!isUsable(arg[0])) arg = [ arg ];
+          return jStat.map(arr, function(value, row, col) {
+            return value - arg[row][col] || 0;
+          });
+        }
+        return jStat.map(arr, function(value) { return value - arg; });
+      },
 
-var push = Array.prototype.push;
-var isArray = jStat.utils.isArray;
+      // matrix division
+      divide: function divide(arr, arg) {
+        if (isUsable(arg)) {
+          if (!isUsable(arg[0])) arg = [ arg ];
+          return jStat.multiply(arr, jStat.inv(arg));
+        }
+        return jStat.map(arr, function(value) { return value / arg; });
+      },
 
-function isUsable(arg) {
-  return isArray(arg) || arg instanceof jStat;
-}
+      // matrix multiplication
+      multiply: function multiply(arr, arg) {
+        var row, col, nrescols, sum, nrow, ncol, res, rescols;
+        // eg: arr = 2 arg = 3 -> 6 for res[0][0] statement closure
+        if (arr.length === undefined && arg.length === undefined) {
+          return arr * arg;
+        }
+        nrow = arr.length,
+        ncol = arr[0].length,
+        res = jStat.zeros(nrow, nrescols = (isUsable(arg)) ? arg[0].length : ncol),
+        rescols = 0;
+        if (isUsable(arg)) {
+          for (; rescols < nrescols; rescols++) {
+            for (row = 0; row < nrow; row++) {
+              sum = 0;
+              for (col = 0; col < ncol; col++)
+              sum += arr[row][col] * arg[col][rescols];
+              res[row][rescols] = sum;
+            }
+          }
+          return (nrow === 1 && rescols === 1) ? res[0][0] : res;
+        }
+        return jStat.map(arr, function(value) { return value * arg; });
+      },
 
-jStat.extend({
+      // outer([1,2,3],[4,5,6])
+      // ===
+      // [[1],[2],[3]] times [[4,5,6]]
+      // ->
+      // [[4,5,6],[8,10,12],[12,15,18]]
+      outer:function outer(A, B) {
+        return jStat.multiply(A.map(function(t){ return [t] }), [B]);
+      },
 
-  // add a vector/matrix to a vector/matrix or scalar
-  add: function add(arr, arg) {
-    // check if arg is a vector or scalar
-    if (isUsable(arg)) {
-      if (!isUsable(arg[0])) arg = [ arg ];
-      return jStat.map(arr, function(value, row, col) {
-        return value + arg[row][col];
-      });
-    }
-    return jStat.map(arr, function(value) { return value + arg; });
-  },
 
-  // subtract a vector or scalar from the vector
-  subtract: function subtract(arr, arg) {
-    // check if arg is a vector or scalar
-    if (isUsable(arg)) {
-      if (!isUsable(arg[0])) arg = [ arg ];
-      return jStat.map(arr, function(value, row, col) {
-        return value - arg[row][col] || 0;
-      });
-    }
-    return jStat.map(arr, function(value) { return value - arg; });
-  },
-
-  // matrix division
-  divide: function divide(arr, arg) {
-    if (isUsable(arg)) {
-      if (!isUsable(arg[0])) arg = [ arg ];
-      return jStat.multiply(arr, jStat.inv(arg));
-    }
-    return jStat.map(arr, function(value) { return value / arg; });
-  },
-
-  // matrix multiplication
-  multiply: function multiply(arr, arg) {
-    var row, col, nrescols, sum, nrow, ncol, res, rescols;
-    // eg: arr = 2 arg = 3 -> 6 for res[0][0] statement closure
-    if (arr.length === undefined && arg.length === undefined) {
-      return arr * arg;
-    }
-    nrow = arr.length, ncol = arr[0].length, res = jStat.zeros(nrow, nrescols = (isUsable(arg)) ? arg[0].length : ncol), rescols = 0;
-    if (isUsable(arg)) {
-      for (; rescols < nrescols; rescols++) {
-        for (row = 0; row < nrow; row++) {
+      // Returns the dot product of two matricies
+      dot: function dot(arr, arg) {
+        if (!isUsable(arr[0])) arr = [ arr ];
+        if (!isUsable(arg[0])) arg = [ arg ];
+        // convert column to row vector
+        var left = (arr[0].length === 1 && arr.length !== 1) ? jStat.transpose(arr) : arr,
+        right = (arg[0].length === 1 && arg.length !== 1) ? jStat.transpose(arg) : arg,
+        res = [],
+        row = 0,
+        nrow = left.length,
+        ncol = left[0].length,
+        sum, col;
+        for (; row < nrow; row++) {
+          res[row] = [];
           sum = 0;
           for (col = 0; col < ncol; col++)
-          sum += arr[row][col] * arg[col][rescols];
-          res[row][rescols] = sum;
+          sum += left[row][col] * right[row][col];
+          res[row] = sum;
         }
-      }
-      return (nrow === 1 && rescols === 1) ? res[0][0] : res;
-    }
-    return jStat.map(arr, function(value) { return value * arg; });
-  },
+        return (res.length === 1) ? res[0] : res;
+      },
 
-  // outer([1,2,3],[4,5,6])
-  // ===
-  // [[1],[2],[3]] times [[4,5,6]]
-  // ->
-  // [[4,5,6],[8,10,12],[12,15,18]]
-  outer:function outer(A, B) {
-    return jStat.multiply(A.map(function(t){ return [t] }), [B]);
-  },
+      // raise every element by a scalar
+      pow: function pow(arr, arg) {
+        return jStat.map(arr, function(value) { return Math.pow(value, arg); });
+      },
 
+      // exponentiate every element
+      exp: function exp(arr) {
+        return jStat.map(arr, function(value) { return Math.exp(value); });
+      },
 
-  // Returns the dot product of two matricies
-  dot: function dot(arr, arg) {
-    if (!isUsable(arr[0])) arr = [ arr ];
-    if (!isUsable(arg[0])) arg = [ arg ];
-    // convert column to row vector
-    var left = (arr[0].length === 1 && arr.length !== 1) ? jStat.transpose(arr) : arr,
-    right = (arg[0].length === 1 && arg.length !== 1) ? jStat.transpose(arg) : arg,
-    res = [],
-    row = 0,
-    nrow = left.length,
-    ncol = left[0].length,
-    sum, col;
-    for (; row < nrow; row++) {
-      res[row] = [];
-      sum = 0;
-      for (col = 0; col < ncol; col++)
-      sum += left[row][col] * right[row][col];
-      res[row] = sum;
-    }
-    return (res.length === 1) ? res[0] : res;
-  },
+      // generate the natural log of every element
+      log: function exp(arr) {
+        return jStat.map(arr, function(value) { return Math.log(value); });
+      },
 
-  // raise every element by a scalar
-  pow: function pow(arr, arg) {
-    return jStat.map(arr, function(value) { return Math.pow(value, arg); });
-  },
+      // generate the absolute values of the vector
+      abs: function abs(arr) {
+        return jStat.map(arr, function(value) { return Math.abs(value); });
+      },
 
-  // exponentiate every element
-  exp: function exp(arr) {
-    return jStat.map(arr, function(value) { return Math.exp(value); });
-  },
-
-  // generate the natural log of every element
-  log: function exp(arr) {
-    return jStat.map(arr, function(value) { return Math.log(value); });
-  },
-
-  // generate the absolute values of the vector
-  abs: function abs(arr) {
-    return jStat.map(arr, function(value) { return Math.abs(value); });
-  },
-
-  // computes the p-norm of the vector
-  // In the case that a matrix is passed, uses the first row as the vector
-  norm: function norm(arr, p) {
-    var nnorm = 0,
-    i = 0;
-    // check the p-value of the norm, and set for most common case
-    if (isNaN(p)) p = 2;
-    // check if multi-dimensional array, and make vector correction
-    if (isUsable(arr[0])) arr = arr[0];
-    // vector norm
-    for (; i < arr.length; i++) {
-      nnorm += Math.pow(Math.abs(arr[i]), p);
-    }
-    return Math.pow(nnorm, 1 / p);
-  },
-
-  // computes the angle between two vectors in rads
-  // In case a matrix is passed, this uses the first row as the vector
-  angle: function angle(arr, arg) {
-    return Math.acos(jStat.dot(arr, arg) / (jStat.norm(arr) * jStat.norm(arg)));
-  },
-
-  // augment one matrix by another
-  // Note: this function returns a matrix, not a jStat object
-  aug: function aug(a, b) {
-    var newarr = [];
-    for (var i = 0; i < a.length; i++) {
-      newarr.push(a[i].slice());
-    }
-    for (var i = 0; i < newarr.length; i++) {
-      push.apply(newarr[i], b[i]);
-    }
-    return newarr;
-  },
-
-  // The inv() function calculates the inverse of a matrix
-  // Create the inverse by augmenting the matrix by the identity matrix of the
-  // appropriate size, and then use G-J elimination on the augmented matrix.
-  inv: function inv(a) {
-    var rows = a.length;
-    var cols = a[0].length;
-    var b = jStat.identity(rows, cols);
-    var c = jStat.gauss_jordan(a, b);
-    var result = [];
-    var i = 0;
-    var j;
-
-    //We need to copy the inverse portion to a new matrix to rid G-J artifacts
-    for (; i < rows; i++) {
-      result[i] = [];
-      for (j = cols; j < c[0].length; j++)
-        result[i][j - cols] = c[i][j];
-    }
-    return result;
-  },
-
-  // calculate the determinant of a matrix
-  det: function det(a) {
-    var alen = a.length,
-    alend = alen * 2,
-    vals = new Array(alend),
-    rowshift = alen - 1,
-    colshift = alend - 1,
-    mrow = rowshift - alen + 1,
-    mcol = colshift,
-    i = 0,
-    result = 0,
-    j;
-    // check for special 2x2 case
-    if (alen === 2) {
-      return a[0][0] * a[1][1] - a[0][1] * a[1][0];
-    }
-    for (; i < alend; i++) {
-      vals[i] = 1;
-    }
-    for (var i = 0; i < alen; i++) {
-      for (j = 0; j < alen; j++) {
-        vals[(mrow < 0) ? mrow + alen : mrow ] *= a[i][j];
-        vals[(mcol < alen) ? mcol + alen : mcol ] *= a[i][j];
-        mrow++;
-        mcol--;
-      }
-      mrow = --rowshift - alen + 1;
-      mcol = --colshift;
-    }
-    for (var i = 0; i < alen; i++) {
-      result += vals[i];
-    }
-    for (; i < alend; i++) {
-      result -= vals[i];
-    }
-    return result;
-  },
-
-  gauss_elimination: function gauss_elimination(a, b) {
-    var i = 0,
-    j = 0,
-    n = a.length,
-    m = a[0].length,
-    factor = 1,
-    sum = 0,
-    x = [],
-    maug, pivot, temp, k;
-    a = jStat.aug(a, b);
-    maug = a[0].length;
-    for(var i = 0; i < n; i++) {
-      pivot = a[i][i];
-      j = i;
-      for (k = i + 1; k < m; k++) {
-        if (pivot < Math.abs(a[k][i])) {
-          pivot = a[k][i];
-          j = k;
+      // computes the p-norm of the vector
+      // In the case that a matrix is passed, uses the first row as the vector
+      norm: function norm(arr, p) {
+        var nnorm = 0,
+        i = 0;
+        // check the p-value of the norm, and set for most common case
+        if (isNaN(p)) p = 2;
+        // check if multi-dimensional array, and make vector correction
+        if (isUsable(arr[0])) arr = arr[0];
+        // vector norm
+        for (; i < arr.length; i++) {
+          nnorm += Math.pow(Math.abs(arr[i]), p);
         }
-      }
-      if (j != i) {
-        for(k = 0; k < maug; k++) {
-          temp = a[i][k];
-          a[i][k] = a[j][k];
-          a[j][k] = temp;
+        return Math.pow(nnorm, 1 / p);
+      },
+
+      // computes the angle between two vectors in rads
+      // In case a matrix is passed, this uses the first row as the vector
+      angle: function angle(arr, arg) {
+        return Math.acos(jStat.dot(arr, arg) / (jStat.norm(arr) * jStat.norm(arg)));
+      },
+
+      // augment one matrix by another
+      // Note: this function returns a matrix, not a jStat object
+      aug: function aug(a, b) {
+        var newarr = [];
+        for (var i = 0; i < a.length; i++) {
+          newarr.push(a[i].slice());
         }
-      }
-      for (j = i + 1; j < n; j++) {
-        factor = a[j][i] / a[i][i];
-        for(k = i; k < maug; k++) {
-          a[j][k] = a[j][k] - factor * a[i][k];
+        for (var i = 0; i < newarr.length; i++) {
+          push.apply(newarr[i], b[i]);
         }
-      }
-    }
-    for (var i = n - 1; i >= 0; i--) {
-      sum = 0;
-      for (j = i + 1; j<= n - 1; j++) {
-        sum = sum + x[j] * a[i][j];
-      }
-      x[i] =(a[i][maug - 1] - sum) / a[i][i];
-    }
-    return x;
-  },
+        return newarr;
+      },
 
-  gauss_jordan: function gauss_jordan(a, b) {
-    var m = jStat.aug(a, b),
-    h = m.length,
-    w = m[0].length;
-    var c = 0;
-    // find max pivot
-    for (var y = 0; y < h; y++) {
-      var maxrow = y;
-      for (var y2 = y+1; y2 < h; y2++) {
-        if (Math.abs(m[y2][y]) > Math.abs(m[maxrow][y]))
-          maxrow = y2;
-      }
-      var tmp = m[y];
-      m[y] = m[maxrow];
-      m[maxrow] = tmp;
-      for (var y2 = y+1; y2 < h; y2++) {
-        c = m[y2][y] / m[y][y];
-        for (var x = y; x < w; x++) {
-          m[y2][x] -= m[y][x] * c;
+      // The inv() function calculates the inverse of a matrix
+      // Create the inverse by augmenting the matrix by the identity matrix of the
+      // appropriate size, and then use G-J elimination on the augmented matrix.
+      inv: function inv(a) {
+        var rows = a.length;
+        var cols = a[0].length;
+        var b = jStat.identity(rows, cols);
+        var c = jStat.gauss_jordan(a, b);
+        var result = [];
+        var i = 0;
+        var j;
+
+        //We need to copy the inverse portion to a new matrix to rid G-J artifacts
+        for (; i < rows; i++) {
+          result[i] = [];
+          for (j = cols; j < c[0].length; j++)
+            result[i][j - cols] = c[i][j];
         }
-      }
-    }
-    // backsubstitute
-    for (var y = h-1; y >= 0; y--) {
-      c = m[y][y];
-      for (var y2 = 0; y2 < y; y2++) {
-        for (var x = w-1; x > y-1; x--) {
-          m[y2][x] -= m[y][x] * m[y2][y] / c;
+        return result;
+      },
+
+      // calculate the determinant of a matrix
+      det: function det(a) {
+        var alen = a.length,
+        alend = alen * 2,
+        vals = new Array(alend),
+        rowshift = alen - 1,
+        colshift = alend - 1,
+        mrow = rowshift - alen + 1,
+        mcol = colshift,
+        i = 0,
+        result = 0,
+        j;
+        // check for special 2x2 case
+        if (alen === 2) {
+          return a[0][0] * a[1][1] - a[0][1] * a[1][0];
         }
-      }
-      m[y][y] /= c;
-      for (var x = h; x < w; x++) {
-        m[y][x] /= c;
-      }
-    }
-    return m;
-  },
-
-  // solve equation
-  // Ax=b
-  // A is upper triangular matrix
-  // A=[[1,2,3],[0,4,5],[0,6,7]]
-  // b=[1,2,3]
-  // triaUpSolve(A,b) // -> [2.666,0.1666,1.666]
-  // if you use matrix style
-  // A=[[1,2,3],[0,4,5],[0,6,7]]
-  // b=[[1],[2],[3]]
-  // will return [[2.666],[0.1666],[1.666]]
-  triaUpSolve: function triaUpSolve(A, b) {
-    var size = A[0].length;
-    var x = jStat.zeros(1, size)[0];
-    var parts;
-    var matrix_mode = false;
-
-    if (b[0].length != undefined) {
-      b = b.map(function(i){ return i[0] });
-      matrix_mode = true;
-    }
-
-    jStat.arange(size - 1, -1, -1).forEach(function(i) {
-      parts = jStat.arange(i + 1, size).map(function(j) {
-        return x[j] * A[i][j];
-      });
-      x[i] = (b[i] - jStat.sum(parts)) / A[i][i];
-    });
-
-    if (matrix_mode)
-      return x.map(function(i){ return [i] });
-    return x;
-  },
-
-  triaLowSolve: function triaLowSolve(A, b) {
-    // like to triaUpSolve but A is lower triangular matrix
-    var size = A[0].length;
-    var x = jStat.zeros(1, size)[0];
-    var parts;
-
-    var matrix_mode=false;
-    if (b[0].length != undefined) {
-      b = b.map(function(i){ return i[0] });
-      matrix_mode = true;
-    }
-
-    jStat.arange(size).forEach(function(i) {
-      parts = jStat.arange(i).map(function(j) {
-        return A[i][j] * x[j];
-      });
-      x[i] = (b[i] - jStat.sum(parts)) / A[i][i];
-    });
-
-    if (matrix_mode)
-      return x.map(function(i){ return [i] });
-    return x;
-  },
-
-
-  // A -> [L,U]
-  // A=LU
-  // L is lower triangular matrix
-  // U is upper triangular matrix
-  lu: function lu(A) {
-    var size = A.length;
-    //var L=jStat.diagonal(jStat.ones(1,size)[0]);
-    var L = jStat.identity(size);
-    var R = jStat.zeros(A.length, A[0].length);
-    var parts;
-    jStat.arange(size).forEach(function(t) {
-      R[0][t] = A[0][t];
-    });
-    jStat.arange(1, size).forEach(function(l) {
-      jStat.arange(l).forEach(function(i) {
-        parts = jStat.arange(i).map(function(jj) {
-          return L[l][jj] * R[jj][i];
-        });
-        L[l][i] = (A[l][i] - jStat.sum(parts)) / R[i][i];
-      });
-      jStat.arange(l, size).forEach(function(j) {
-        parts = jStat.arange(l).map(function(jj) {
-          return L[l][jj] * R[jj][j];
-        });
-        R[l][j] = A[i][j] - jStat.sum(parts);
-      });
-    });
-    return [L, R];
-  },
-
-  // A -> T
-  // A=TT'
-  // T is lower triangular matrix
-  cholesky: function cholesky(A) {
-    var size = A.length;
-    var T = jStat.zeros(A.length, A[0].length);
-    var parts;
-    jStat.arange(size).forEach(function(i) {
-      parts = jStat.arange(i).map(function(t) {
-        return Math.pow(T[i][t],2);
-      });
-      T[i][i] = Math.sqrt(A[i][i] - jStat.sum(parts));
-      jStat.arange(i + 1, size).forEach(function(j) {
-        parts = jStat.arange(i).map(function(t) {
-          return T[i][t] * T[j][t];
-        });
-        T[j][i] = (A[i][j] - jStat.sum(parts)) / T[i][i];
-      });
-    });
-    return T;
-  },
-
-
-  gauss_jacobi: function gauss_jacobi(a, b, x, r) {
-    var i = 0;
-    var j = 0;
-    var n = a.length;
-    var l = [];
-    var u = [];
-    var d = [];
-    var xv, c, h, xk;
-    for (; i < n; i++) {
-      l[i] = [];
-      u[i] = [];
-      d[i] = [];
-      for (j = 0; j < n; j++) {
-        if (i > j) {
-          l[i][j] = a[i][j];
-          u[i][j] = d[i][j] = 0;
-        } else if (i < j) {
-          u[i][j] = a[i][j];
-          l[i][j] = d[i][j] = 0;
-        } else {
-          d[i][j] = a[i][j];
-          l[i][j] = u[i][j] = 0;
+        for (; i < alend; i++) {
+          vals[i] = 1;
         }
-      }
-    }
-    h = jStat.multiply(jStat.multiply(jStat.inv(d), jStat.add(l, u)), -1);
-    c = jStat.multiply(jStat.inv(d), b);
-    xv = x;
-    xk = jStat.add(jStat.multiply(h, x), c);
-    i = 2;
-    while (Math.abs(jStat.norm(jStat.subtract(xk,xv))) > r) {
-      xv = xk;
-      xk = jStat.add(jStat.multiply(h, xv), c);
-      i++;
-    }
-    return xk;
-  },
-
-  gauss_seidel: function gauss_seidel(a, b, x, r) {
-    var i = 0;
-    var n = a.length;
-    var l = [];
-    var u = [];
-    var d = [];
-    var j, xv, c, h, xk;
-    for (; i < n; i++) {
-      l[i] = [];
-      u[i] = [];
-      d[i] = [];
-      for (j = 0; j < n; j++) {
-        if (i > j) {
-          l[i][j] = a[i][j];
-          u[i][j] = d[i][j] = 0;
-        } else if (i < j) {
-          u[i][j] = a[i][j];
-          l[i][j] = d[i][j] = 0;
-        } else {
-          d[i][j] = a[i][j];
-          l[i][j] = u[i][j] = 0;
+        for (var i = 0; i < alen; i++) {
+          for (j = 0; j < alen; j++) {
+            vals[(mrow < 0) ? mrow + alen : mrow ] *= a[i][j];
+            vals[(mcol < alen) ? mcol + alen : mcol ] *= a[i][j];
+            mrow++;
+            mcol--;
+          }
+          mrow = --rowshift - alen + 1;
+          mcol = --colshift;
         }
-      }
-    }
-    h = jStat.multiply(jStat.multiply(jStat.inv(jStat.add(d, l)), u), -1);
-    c = jStat.multiply(jStat.inv(jStat.add(d, l)), b);
-    xv = x;
-    xk = jStat.add(jStat.multiply(h, x), c);
-    i = 2;
-    while (Math.abs(jStat.norm(jStat.subtract(xk, xv))) > r) {
-      xv = xk;
-      xk = jStat.add(jStat.multiply(h, xv), c);
-      i = i + 1;
-    }
-    return xk;
-  },
-
-  SOR: function SOR(a, b, x, r, w) {
-    var i = 0;
-    var n = a.length;
-    var l = [];
-    var u = [];
-    var d = [];
-    var j, xv, c, h, xk;
-    for (; i < n; i++) {
-      l[i] = [];
-      u[i] = [];
-      d[i] = [];
-      for (j = 0; j < n; j++) {
-        if (i > j) {
-          l[i][j] = a[i][j];
-          u[i][j] = d[i][j] = 0;
-        } else if (i < j) {
-          u[i][j] = a[i][j];
-          l[i][j] = d[i][j] = 0;
-        } else {
-          d[i][j] = a[i][j];
-          l[i][j] = u[i][j] = 0;
+        for (var i = 0; i < alen; i++) {
+          result += vals[i];
         }
-      }
-    }
-    h = jStat.multiply(jStat.inv(jStat.add(d, jStat.multiply(l, w))),
-                       jStat.subtract(jStat.multiply(d, 1 - w),
-                                      jStat.multiply(u, w)));
-    c = jStat.multiply(jStat.multiply(jStat.inv(jStat.add(d,
-        jStat.multiply(l, w))), b), w);
-    xv = x;
-    xk = jStat.add(jStat.multiply(h, x), c);
-    i = 2;
-    while (Math.abs(jStat.norm(jStat.subtract(xk, xv))) > r) {
-      xv = xk;
-      xk = jStat.add(jStat.multiply(h, xv), c);
-      i++;
-    }
-    return xk;
-  },
-
-  householder: function householder(a) {
-    var m = a.length;
-    var n = a[0].length;
-    var i = 0;
-    var w = [];
-    var p = [];
-    var alpha, r, k, j, factor;
-    for (; i < m - 1; i++) {
-      alpha = 0;
-      for (j = i + 1; j < n; j++)
-      alpha += (a[j][i] * a[j][i]);
-      factor = (a[i + 1][i] > 0) ? -1 : 1;
-      alpha = factor * Math.sqrt(alpha);
-      r = Math.sqrt((((alpha * alpha) - a[i + 1][i] * alpha) / 2));
-      w = jStat.zeros(m, 1);
-      w[i + 1][0] = (a[i + 1][i] - alpha) / (2 * r);
-      for (k = i + 2; k < m; k++) w[k][0] = a[k][i] / (2 * r);
-      p = jStat.subtract(jStat.identity(m, n),
-          jStat.multiply(jStat.multiply(w, jStat.transpose(w)), 2));
-      a = jStat.multiply(p, jStat.multiply(a, p));
-    }
-    return a;
-  },
-
-  // A -> [Q,R]
-  // Q is orthogonal matrix
-  // R is upper triangular
-  QR: (function() {
-    // x -> Q
-    // find a orthogonal matrix Q st.
-    // Qx=y
-    // y is [||x||,0,0,...]
-
-    // quick ref
-    var sum   = jStat.sum;
-    var range = jStat.arange;
-
-    function qr2(x) {
-      // quick impletation
-      // https://www.stat.wisc.edu/~larget/math496/qr.html
-
-      var n = x.length;
-      var p = x[0].length;
-
-      x = jStat.copy(x);
-      r = jStat.zeros(p, p);
-
-      var i,j,k;
-      for(j = 0; j < p; j++){
-        r[j][j] = Math.sqrt(sum(range(n).map(function(i){
-          return x[i][j] * x[i][j];
-        })));
-        for(i = 0; i < n; i++){
-          x[i][j] = x[i][j] / r[j][j];
+        for (; i < alend; i++) {
+          result -= vals[i];
         }
-        for(k = j+1; k < p; k++){
-          r[j][k] = sum(range(n).map(function(i){
-            return x[i][j] * x[i][k];
-          }));
-          for(i = 0; i < n; i++){
-            x[i][k] = x[i][k] - x[i][j]*r[j][k];
+        return result;
+      },
+
+      gauss_elimination: function gauss_elimination(a, b) {
+        var i = 0,
+        j = 0,
+        n = a.length,
+        m = a[0].length,
+        factor = 1,
+        sum = 0,
+        x = [],
+        maug, pivot, temp, k;
+        a = jStat.aug(a, b);
+        maug = a[0].length;
+        for(var i = 0; i < n; i++) {
+          pivot = a[i][i];
+          j = i;
+          for (k = i + 1; k < m; k++) {
+            if (pivot < Math.abs(a[k][i])) {
+              pivot = a[k][i];
+              j = k;
+            }
+          }
+          if (j != i) {
+            for(k = 0; k < maug; k++) {
+              temp = a[i][k];
+              a[i][k] = a[j][k];
+              a[j][k] = temp;
+            }
+          }
+          for (j = i + 1; j < n; j++) {
+            factor = a[j][i] / a[i][i];
+            for(k = i; k < maug; k++) {
+              a[j][k] = a[j][k] - factor * a[i][k];
+            }
           }
         }
-      }
-      return [x, r];
-    }
+        for (var i = n - 1; i >= 0; i--) {
+          sum = 0;
+          for (j = i + 1; j<= n - 1; j++) {
+            sum = sum + x[j] * a[i][j];
+          }
+          x[i] =(a[i][maug - 1] - sum) / a[i][i];
+        }
+        return x;
+      },
 
-    return qr2;
-  }()),
+      gauss_jordan: function gauss_jordan(a, b) {
+        var m = jStat.aug(a, b),
+        h = m.length,
+        w = m[0].length;
+        var c = 0;
+        // find max pivot
+        for (var y = 0; y < h; y++) {
+          var maxrow = y;
+          for (var y2 = y+1; y2 < h; y2++) {
+            if (Math.abs(m[y2][y]) > Math.abs(m[maxrow][y]))
+              maxrow = y2;
+          }
+          var tmp = m[y];
+          m[y] = m[maxrow];
+          m[maxrow] = tmp;
+          for (var y2 = y+1; y2 < h; y2++) {
+            c = m[y2][y] / m[y][y];
+            for (var x = y; x < w; x++) {
+              m[y2][x] -= m[y][x] * c;
+            }
+          }
+        }
+        // backsubstitute
+        for (var y = h-1; y >= 0; y--) {
+          c = m[y][y];
+          for (var y2 = 0; y2 < y; y2++) {
+            for (var x = w-1; x > y-1; x--) {
+              m[y2][x] -= m[y][x] * m[y2][y] / c;
+            }
+          }
+          m[y][y] /= c;
+          for (var x = h; x < w; x++) {
+            m[y][x] /= c;
+          }
+        }
+        return m;
+      },
 
-  lstsq: (function(A, b) {
-    // solve least squard problem for Ax=b as QR decomposition way if b is
-    // [[b1],[b2],[b3]] form will return [[x1],[x2],[x3]] array form solution
-    // else b is [b1,b2,b3] form will return [x1,x2,x3] array form solution
-    function R_I(A) {
-      A = jStat.copy(A);
-      var size = A.length;
-      var I = jStat.identity(size);
-      jStat.arange(size - 1, -1, -1).forEach(function(i) {
-        jStat.sliceAssign(
-            I, { row: i }, jStat.divide(jStat.slice(I, { row: i }), A[i][i]));
-        jStat.sliceAssign(
-            A, { row: i }, jStat.divide(jStat.slice(A, { row: i }), A[i][i]));
-        jStat.arange(i).forEach(function(j) {
-          var c = jStat.multiply(A[j][i], -1);
-          var Aj = jStat.slice(A, { row: j });
-          var cAi = jStat.multiply(jStat.slice(A, { row: i }), c);
-          jStat.sliceAssign(A, { row: j }, jStat.add(Aj, cAi));
-          var Ij = jStat.slice(I, { row: j });
-          var cIi = jStat.multiply(jStat.slice(I, { row: i }), c);
-          jStat.sliceAssign(I, { row: j }, jStat.add(Ij, cIi));
+      // solve equation
+      // Ax=b
+      // A is upper triangular matrix
+      // A=[[1,2,3],[0,4,5],[0,6,7]]
+      // b=[1,2,3]
+      // triaUpSolve(A,b) // -> [2.666,0.1666,1.666]
+      // if you use matrix style
+      // A=[[1,2,3],[0,4,5],[0,6,7]]
+      // b=[[1],[2],[3]]
+      // will return [[2.666],[0.1666],[1.666]]
+      triaUpSolve: function triaUpSolve(A, b) {
+        var size = A[0].length;
+        var x = jStat.zeros(1, size)[0];
+        var parts;
+        var matrix_mode = false;
+
+        if (b[0].length != undefined) {
+          b = b.map(function(i){ return i[0] });
+          matrix_mode = true;
+        }
+
+        jStat.arange(size - 1, -1, -1).forEach(function(i) {
+          parts = jStat.arange(i + 1, size).map(function(j) {
+            return x[j] * A[i][j];
+          });
+          x[i] = (b[i] - jStat.sum(parts)) / A[i][i];
         });
-      });
-      return I;
-    }
 
-    function qr_solve(A, b){
-      var array_mode = false;
-      if (b[0].length === undefined) {
-        // [c1,c2,c3] mode
-        b = b.map(function(x){ return [x] });
-        array_mode = true;
-      }
-      var QR = jStat.QR(A);
-      var Q = QR[0];
-      var R = QR[1];
-      var attrs = A[0].length;
-      var Q1 = jStat.slice(Q,{col:{end:attrs}});
-      var R1 = jStat.slice(R,{row:{end:attrs}});
-      var RI = R_I(R1);
-	  var Q2 = jStat.transpose(Q1);
+        if (matrix_mode)
+          return x.map(function(i){ return [i] });
+        return x;
+      },
 
-	  if(Q2[0].length === undefined){
-		  Q2 = [Q2]; // The confusing jStat.multifly implementation threat nature process again.
-	  }
+      triaLowSolve: function triaLowSolve(A, b) {
+        // like to triaUpSolve but A is lower triangular matrix
+        var size = A[0].length;
+        var x = jStat.zeros(1, size)[0];
+        var parts;
 
-      var x = jStat.multiply(jStat.multiply(RI, Q2), b);
+        var matrix_mode=false;
+        if (b[0].length != undefined) {
+          b = b.map(function(i){ return i[0] });
+          matrix_mode = true;
+        }
 
-	  if(x.length === undefined){
-		  x = [[x]]; // The confusing jStat.multifly implementation threat nature process again.
-	  }
+        jStat.arange(size).forEach(function(i) {
+          parts = jStat.arange(i).map(function(j) {
+            return A[i][j] * x[j];
+          });
+          x[i] = (b[i] - jStat.sum(parts)) / A[i][i];
+        });
+
+        if (matrix_mode)
+          return x.map(function(i){ return [i] });
+        return x;
+      },
 
 
-      if (array_mode)
-        return x.map(function(i){ return i[0] });
-      return x;
-    }
+      // A -> [L,U]
+      // A=LU
+      // L is lower triangular matrix
+      // U is upper triangular matrix
+      lu: function lu(A) {
+        var size = A.length;
+        //var L=jStat.diagonal(jStat.ones(1,size)[0]);
+        var L = jStat.identity(size);
+        var R = jStat.zeros(A.length, A[0].length);
+        var parts;
+        jStat.arange(size).forEach(function(t) {
+          R[0][t] = A[0][t];
+        });
+        jStat.arange(1, size).forEach(function(l) {
+          jStat.arange(l).forEach(function(i) {
+            parts = jStat.arange(i).map(function(jj) {
+              return L[l][jj] * R[jj][i];
+            });
+            L[l][i] = (A[l][i] - jStat.sum(parts)) / R[i][i];
+          });
+          jStat.arange(l, size).forEach(function(j) {
+            parts = jStat.arange(l).map(function(jj) {
+              return L[l][jj] * R[jj][j];
+            });
+            R[l][j] = A[i][j] - jStat.sum(parts);
+          });
+        });
+        return [L, R];
+      },
 
-    return qr_solve;
-  }()),
+      // A -> T
+      // A=TT'
+      // T is lower triangular matrix
+      cholesky: function cholesky(A) {
+        var size = A.length;
+        var T = jStat.zeros(A.length, A[0].length);
+        var parts;
+        jStat.arange(size).forEach(function(i) {
+          parts = jStat.arange(i).map(function(t) {
+            return Math.pow(T[i][t],2);
+          });
+          T[i][i] = Math.sqrt(A[i][i] - jStat.sum(parts));
+          jStat.arange(i + 1, size).forEach(function(j) {
+            parts = jStat.arange(i).map(function(t) {
+              return T[i][t] * T[j][t];
+            });
+            T[j][i] = (A[i][j] - jStat.sum(parts)) / T[i][i];
+          });
+        });
+        return T;
+      },
 
-  jacobi: function jacobi(a) {
-    var condition = 1;
-    var n = a.length;
-    var e = jStat.identity(n, n);
-    var ev = [];
-    var b, i, j, p, q, maxim, theta, s;
-    // condition === 1 only if tolerance is not reached
-    while (condition === 1) {
-      maxim = a[0][1];
-      p = 0;
-      q = 1;
-      for (var i = 0; i < n; i++) {
+
+      gauss_jacobi: function gauss_jacobi(a, b, x, r) {
+        var i = 0;
+        var j = 0;
+        var n = a.length;
+        var l = [];
+        var u = [];
+        var d = [];
+        var xv, c, h, xk;
+        for (; i < n; i++) {
+          l[i] = [];
+          u[i] = [];
+          d[i] = [];
+          for (j = 0; j < n; j++) {
+            if (i > j) {
+              l[i][j] = a[i][j];
+              u[i][j] = d[i][j] = 0;
+            } else if (i < j) {
+              u[i][j] = a[i][j];
+              l[i][j] = d[i][j] = 0;
+            } else {
+              d[i][j] = a[i][j];
+              l[i][j] = u[i][j] = 0;
+            }
+          }
+        }
+        h = jStat.multiply(jStat.multiply(jStat.inv(d), jStat.add(l, u)), -1);
+        c = jStat.multiply(jStat.inv(d), b);
+        xv = x;
+        xk = jStat.add(jStat.multiply(h, x), c);
+        i = 2;
+        while (Math.abs(jStat.norm(jStat.subtract(xk,xv))) > r) {
+          xv = xk;
+          xk = jStat.add(jStat.multiply(h, xv), c);
+          i++;
+        }
+        return xk;
+      },
+
+      gauss_seidel: function gauss_seidel(a, b, x, r) {
+        var i = 0;
+        var n = a.length;
+        var l = [];
+        var u = [];
+        var d = [];
+        var j, xv, c, h, xk;
+        for (; i < n; i++) {
+          l[i] = [];
+          u[i] = [];
+          d[i] = [];
+          for (j = 0; j < n; j++) {
+            if (i > j) {
+              l[i][j] = a[i][j];
+              u[i][j] = d[i][j] = 0;
+            } else if (i < j) {
+              u[i][j] = a[i][j];
+              l[i][j] = d[i][j] = 0;
+            } else {
+              d[i][j] = a[i][j];
+              l[i][j] = u[i][j] = 0;
+            }
+          }
+        }
+        h = jStat.multiply(jStat.multiply(jStat.inv(jStat.add(d, l)), u), -1);
+        c = jStat.multiply(jStat.inv(jStat.add(d, l)), b);
+        xv = x;
+        xk = jStat.add(jStat.multiply(h, x), c);
+        i = 2;
+        while (Math.abs(jStat.norm(jStat.subtract(xk, xv))) > r) {
+          xv = xk;
+          xk = jStat.add(jStat.multiply(h, xv), c);
+          i = i + 1;
+        }
+        return xk;
+      },
+
+      SOR: function SOR(a, b, x, r, w) {
+        var i = 0;
+        var n = a.length;
+        var l = [];
+        var u = [];
+        var d = [];
+        var j, xv, c, h, xk;
+        for (; i < n; i++) {
+          l[i] = [];
+          u[i] = [];
+          d[i] = [];
+          for (j = 0; j < n; j++) {
+            if (i > j) {
+              l[i][j] = a[i][j];
+              u[i][j] = d[i][j] = 0;
+            } else if (i < j) {
+              u[i][j] = a[i][j];
+              l[i][j] = d[i][j] = 0;
+            } else {
+              d[i][j] = a[i][j];
+              l[i][j] = u[i][j] = 0;
+            }
+          }
+        }
+        h = jStat.multiply(jStat.inv(jStat.add(d, jStat.multiply(l, w))),
+                           jStat.subtract(jStat.multiply(d, 1 - w),
+                                          jStat.multiply(u, w)));
+        c = jStat.multiply(jStat.multiply(jStat.inv(jStat.add(d,
+            jStat.multiply(l, w))), b), w);
+        xv = x;
+        xk = jStat.add(jStat.multiply(h, x), c);
+        i = 2;
+        while (Math.abs(jStat.norm(jStat.subtract(xk, xv))) > r) {
+          xv = xk;
+          xk = jStat.add(jStat.multiply(h, xv), c);
+          i++;
+        }
+        return xk;
+      },
+
+      householder: function householder(a) {
+        var m = a.length;
+        var n = a[0].length;
+        var i = 0;
+        var w = [];
+        var p = [];
+        var alpha, r, k, j, factor;
+        for (; i < m - 1; i++) {
+          alpha = 0;
+          for (j = i + 1; j < n; j++)
+          alpha += (a[j][i] * a[j][i]);
+          factor = (a[i + 1][i] > 0) ? -1 : 1;
+          alpha = factor * Math.sqrt(alpha);
+          r = Math.sqrt((((alpha * alpha) - a[i + 1][i] * alpha) / 2));
+          w = jStat.zeros(m, 1);
+          w[i + 1][0] = (a[i + 1][i] - alpha) / (2 * r);
+          for (k = i + 2; k < m; k++) w[k][0] = a[k][i] / (2 * r);
+          p = jStat.subtract(jStat.identity(m, n),
+              jStat.multiply(jStat.multiply(w, jStat.transpose(w)), 2));
+          a = jStat.multiply(p, jStat.multiply(a, p));
+        }
+        return a;
+      },
+
+      // A -> [Q,R]
+      // Q is orthogonal matrix
+      // R is upper triangular
+      QR: (function() {
+        // x -> Q
+        // find a orthogonal matrix Q st.
+        // Qx=y
+        // y is [||x||,0,0,...]
+
+        // quick ref
+        var sum   = jStat.sum;
+        var range = jStat.arange;
+
+        function qr2(x) {
+          // quick impletation
+          // https://www.stat.wisc.edu/~larget/math496/qr.html
+
+          var n = x.length;
+          var p = x[0].length;
+
+          x = jStat.copy(x);
+          r = jStat.zeros(p, p);
+
+          var i,j,k;
+          for(j = 0; j < p; j++){
+            r[j][j] = Math.sqrt(sum(range(n).map(function(i){
+              return x[i][j] * x[i][j];
+            })));
+            for(i = 0; i < n; i++){
+              x[i][j] = x[i][j] / r[j][j];
+            }
+            for(k = j+1; k < p; k++){
+              r[j][k] = sum(range(n).map(function(i){
+                return x[i][j] * x[i][k];
+              }));
+              for(i = 0; i < n; i++){
+                x[i][k] = x[i][k] - x[i][j]*r[j][k];
+              }
+            }
+          }
+          return [x, r];
+        }
+
+        return qr2;
+      }()),
+
+      lstsq: (function(A, b) {
+        // solve least squard problem for Ax=b as QR decomposition way if b is
+        // [[b1],[b2],[b3]] form will return [[x1],[x2],[x3]] array form solution
+        // else b is [b1,b2,b3] form will return [x1,x2,x3] array form solution
+        function R_I(A) {
+          A = jStat.copy(A);
+          var size = A.length;
+          var I = jStat.identity(size);
+          jStat.arange(size - 1, -1, -1).forEach(function(i) {
+            jStat.sliceAssign(
+                I, { row: i }, jStat.divide(jStat.slice(I, { row: i }), A[i][i]));
+            jStat.sliceAssign(
+                A, { row: i }, jStat.divide(jStat.slice(A, { row: i }), A[i][i]));
+            jStat.arange(i).forEach(function(j) {
+              var c = jStat.multiply(A[j][i], -1);
+              var Aj = jStat.slice(A, { row: j });
+              var cAi = jStat.multiply(jStat.slice(A, { row: i }), c);
+              jStat.sliceAssign(A, { row: j }, jStat.add(Aj, cAi));
+              var Ij = jStat.slice(I, { row: j });
+              var cIi = jStat.multiply(jStat.slice(I, { row: i }), c);
+              jStat.sliceAssign(I, { row: j }, jStat.add(Ij, cIi));
+            });
+          });
+          return I;
+        }
+
+        function qr_solve(A, b){
+          var array_mode = false;
+          if (b[0].length === undefined) {
+            // [c1,c2,c3] mode
+            b = b.map(function(x){ return [x] });
+            array_mode = true;
+          }
+          var QR = jStat.QR(A);
+          var Q = QR[0];
+          var R = QR[1];
+          var attrs = A[0].length;
+          var Q1 = jStat.slice(Q,{col:{end:attrs}});
+          var R1 = jStat.slice(R,{row:{end:attrs}});
+          var RI = R_I(R1);
+    	  var Q2 = jStat.transpose(Q1);
+
+    	  if(Q2[0].length === undefined){
+    		  Q2 = [Q2]; // The confusing jStat.multifly implementation threat nature process again.
+    	  }
+
+          var x = jStat.multiply(jStat.multiply(RI, Q2), b);
+
+    	  if(x.length === undefined){
+    		  x = [[x]]; // The confusing jStat.multifly implementation threat nature process again.
+    	  }
+
+
+          if (array_mode)
+            return x.map(function(i){ return i[0] });
+          return x;
+        }
+
+        return qr_solve;
+      }()),
+
+      jacobi: function jacobi(a) {
+        var condition = 1;
+        var n = a.length;
+        var e = jStat.identity(n, n);
+        var ev = [];
+        var b, i, j, p, q, maxim, theta, s;
+        // condition === 1 only if tolerance is not reached
+        while (condition === 1) {
+          maxim = a[0][1];
+          p = 0;
+          q = 1;
+          for (var i = 0; i < n; i++) {
+            for (j = 0; j < n; j++) {
+              if (i != j) {
+                if (maxim < Math.abs(a[i][j])) {
+                  maxim = Math.abs(a[i][j]);
+                  p = i;
+                  q = j;
+                }
+              }
+            }
+          }
+          if (a[p][p] === a[q][q])
+            theta = (a[p][q] > 0) ? Math.PI / 4 : -Math.PI / 4;
+          else
+            theta = Math.atan(2 * a[p][q] / (a[p][p] - a[q][q])) / 2;
+          s = jStat.identity(n, n);
+          s[p][p] = Math.cos(theta);
+          s[p][q] = -Math.sin(theta);
+          s[q][p] = Math.sin(theta);
+          s[q][q] = Math.cos(theta);
+          // eigen vector matrix
+          e = jStat.multiply(e, s);
+          b = jStat.multiply(jStat.multiply(jStat.inv(s), a), s);
+          a = b;
+          condition = 0;
+          for (var i = 1; i < n; i++) {
+            for (j = 1; j < n; j++) {
+              if (i != j && Math.abs(a[i][j]) > 0.001) {
+                condition = 1;
+              }
+            }
+          }
+        }
+        for (var i = 0; i < n; i++) ev.push(a[i][i]);
+        //returns both the eigenvalue and eigenmatrix
+        return [e, ev];
+      },
+
+      rungekutta: function rungekutta(f, h, p, t_j, u_j, order) {
+        var k1, k2, u_j1, k3, k4;
+        if (order === 2) {
+          while (t_j <= p) {
+            k1 = h * f(t_j, u_j);
+            k2 = h * f(t_j + h, u_j + k1);
+            u_j1 = u_j + (k1 + k2) / 2;
+            u_j = u_j1;
+            t_j = t_j + h;
+          }
+        }
+        if (order === 4) {
+          while (t_j <= p) {
+            k1 = h * f(t_j, u_j);
+            k2 = h * f(t_j + h / 2, u_j + k1 / 2);
+            k3 = h * f(t_j + h / 2, u_j + k2 / 2);
+            k4 = h * f(t_j +h, u_j + k3);
+            u_j1 = u_j + (k1 + 2 * k2 + 2 * k3 + k4) / 6;
+            u_j = u_j1;
+            t_j = t_j + h;
+          }
+        }
+        return u_j;
+      },
+
+      romberg: function romberg(f, a, b, order) {
+        var i = 0;
+        var h = (b - a) / 2;
+        var x = [];
+        var h1 = [];
+        var g = [];
+        var m, a1, j, k, I;
+        while (i < order / 2) {
+          I = f(a);
+          for (j = a, k = 0; j <= b; j = j + h, k++) x[k] = j;
+          m = x.length;
+          for (j = 1; j < m - 1; j++) {
+            I += (((j % 2) !== 0) ? 4 : 2) * f(x[j]);
+          }
+          I = (h / 3) * (I + f(b));
+          g[i] = I;
+          h /= 2;
+          i++;
+        }
+        a1 = g.length;
+        m = 1;
+        while (a1 !== 1) {
+          for (j = 0; j < a1 - 1; j++)
+          h1[j] = ((Math.pow(4, m)) * g[j + 1] - g[j]) / (Math.pow(4, m) - 1);
+          a1 = h1.length;
+          g = h1;
+          h1 = [];
+          m++;
+        }
+        return g;
+      },
+
+      richardson: function richardson(X, f, x, h) {
+        function pos(X, x) {
+          var i = 0;
+          var n = X.length;
+          var p;
+          for (; i < n; i++)
+            if (X[i] === x) p = i;
+          return p;
+        }
+        var n = X.length,
+        h_min = Math.abs(x - X[pos(X, x) + 1]),
+        i = 0,
+        g = [],
+        h1 = [],
+        y1, y2, m, a, j;
+        while (h >= h_min) {
+          y1 = pos(X, x + h);
+          y2 = pos(X, x);
+          g[i] = (f[y1] - 2 * f[y2] + f[2 * y2 - y1]) / (h * h);
+          h /= 2;
+          i++;
+        }
+        a = g.length;
+        m = 1;
+        while (a != 1) {
+          for (j = 0; j < a - 1; j++)
+          h1[j] = ((Math.pow(4, m)) * g[j + 1] - g[j]) / (Math.pow(4, m) - 1);
+          a = h1.length;
+          g = h1;
+          h1 = [];
+          m++;
+        }
+        return g;
+      },
+
+      simpson: function simpson(f, a, b, n) {
+        var h = (b - a) / n;
+        var I = f(a);
+        var x = [];
+        var j = a;
+        var k = 0;
+        var i = 1;
+        var m;
+        for (; j <= b; j = j + h, k++)
+          x[k] = j;
+        m = x.length;
+        for (; i < m - 1; i++) {
+          I += ((i % 2 !== 0) ? 4 : 2) * f(x[i]);
+        }
+        return (h / 3) * (I + f(b));
+      },
+
+      hermite: function hermite(X, F, dF, value) {
+        var n = X.length;
+        var p = 0;
+        var i = 0;
+        var l = [];
+        var dl = [];
+        var A = [];
+        var B = [];
+        var j;
+        for (; i < n; i++) {
+          l[i] = 1;
+          for (j = 0; j < n; j++) {
+            if (i != j) l[i] *= (value - X[j]) / (X[i] - X[j]);
+          }
+          dl[i] = 0;
+          for (j = 0; j < n; j++) {
+            if (i != j) dl[i] += 1 / (X [i] - X[j]);
+          }
+          A[i] = (1 - 2 * (value - X[i]) * dl[i]) * (l[i] * l[i]);
+          B[i] = (value - X[i]) * (l[i] * l[i]);
+          p += (A[i] * F[i] + B[i] * dF[i]);
+        }
+        return p;
+      },
+
+      lagrange: function lagrange(X, F, value) {
+        var p = 0;
+        var i = 0;
+        var j, l;
+        var n = X.length;
+        for (; i < n; i++) {
+          l = F[i];
+          for (j = 0; j < n; j++) {
+            // calculating the lagrange polynomial L_i
+            if (i != j) l *= (value - X[j]) / (X[i] - X[j]);
+          }
+          // adding the lagrange polynomials found above
+          p += l;
+        }
+        return p;
+      },
+
+      cubic_spline: function cubic_spline(X, F, value) {
+        var n = X.length;
+        var i = 0, j;
+        var A = [];
+        var B = [];
+        var alpha = [];
+        var c = [];
+        var h = [];
+        var b = [];
+        var d = [];
+        for (; i < n - 1; i++)
+          h[i] = X[i + 1] - X[i];
+        alpha[0] = 0;
+        for (var i = 1; i < n - 1; i++) {
+          alpha[i] = (3 / h[i]) * (F[i + 1] - F[i]) -
+              (3 / h[i-1]) * (F[i] - F[i-1]);
+        }
+        for (var i = 1; i < n - 1; i++) {
+          A[i] = [];
+          B[i] = [];
+          A[i][i-1] = h[i-1];
+          A[i][i] = 2 * (h[i - 1] + h[i]);
+          A[i][i+1] = h[i];
+          B[i][0] = alpha[i];
+        }
+        c = jStat.multiply(jStat.inv(A), B);
+        for (j = 0; j < n - 1; j++) {
+          b[j] = (F[j + 1] - F[j]) / h[j] - h[j] * (c[j + 1][0] + 2 * c[j][0]) / 3;
+          d[j] = (c[j + 1][0] - c[j][0]) / (3 * h[j]);
+        }
         for (j = 0; j < n; j++) {
-          if (i != j) {
-            if (maxim < Math.abs(a[i][j])) {
-              maxim = Math.abs(a[i][j]);
-              p = i;
-              q = j;
+          if (X[j] > value) break;
+        }
+        j -= 1;
+        return F[j] + (value - X[j]) * b[j] + jStat.sq(value-X[j]) *
+            c[j] + (value - X[j]) * jStat.sq(value - X[j]) * d[j];
+      },
+
+      gauss_quadrature: function gauss_quadrature() {
+        throw new Error('gauss_quadrature not yet implemented');
+      },
+
+      PCA: function PCA(X) {
+        var m = X.length;
+        var n = X[0].length;
+        var i = 0;
+        var j, temp1;
+        var u = [];
+        var D = [];
+        var result = [];
+        var temp2 = [];
+        var Y = [];
+        var Bt = [];
+        var B = [];
+        var C = [];
+        var V = [];
+        var Vt = [];
+        for (var i = 0; i < m; i++) {
+          u[i] = jStat.sum(X[i]) / n;
+        }
+        for (var i = 0; i < n; i++) {
+          B[i] = [];
+          for(j = 0; j < m; j++) {
+            B[i][j] = X[j][i] - u[j];
+          }
+        }
+        B = jStat.transpose(B);
+        for (var i = 0; i < m; i++) {
+          C[i] = [];
+          for (j = 0; j < m; j++) {
+            C[i][j] = (jStat.dot([B[i]], [B[j]])) / (n - 1);
+          }
+        }
+        result = jStat.jacobi(C);
+        V = result[0];
+        D = result[1];
+        Vt = jStat.transpose(V);
+        for (var i = 0; i < D.length; i++) {
+          for (j = i; j < D.length; j++) {
+            if(D[i] < D[j])  {
+              temp1 = D[i];
+              D[i] = D[j];
+              D[j] = temp1;
+              temp2 = Vt[i];
+              Vt[i] = Vt[j];
+              Vt[j] = temp2;
             }
           }
         }
-      }
-      if (a[p][p] === a[q][q])
-        theta = (a[p][q] > 0) ? Math.PI / 4 : -Math.PI / 4;
-      else
-        theta = Math.atan(2 * a[p][q] / (a[p][p] - a[q][q])) / 2;
-      s = jStat.identity(n, n);
-      s[p][p] = Math.cos(theta);
-      s[p][q] = -Math.sin(theta);
-      s[q][p] = Math.sin(theta);
-      s[q][q] = Math.cos(theta);
-      // eigen vector matrix
-      e = jStat.multiply(e, s);
-      b = jStat.multiply(jStat.multiply(jStat.inv(s), a), s);
-      a = b;
-      condition = 0;
-      for (var i = 1; i < n; i++) {
-        for (j = 1; j < n; j++) {
-          if (i != j && Math.abs(a[i][j]) > 0.001) {
-            condition = 1;
+        Bt = jStat.transpose(B);
+        for (var i = 0; i < m; i++) {
+          Y[i] = [];
+          for (j = 0; j < Bt.length; j++) {
+            Y[i][j] = jStat.dot([Vt[i]], [Bt[j]]);
           }
         }
+        return [X, D, Vt, Y];
       }
-    }
-    for (var i = 0; i < n; i++) ev.push(a[i][i]);
-    //returns both the eigenvalue and eigenmatrix
-    return [e, ev];
-  },
+    });
 
-  rungekutta: function rungekutta(f, h, p, t_j, u_j, order) {
-    var k1, k2, u_j1, k3, k4;
-    if (order === 2) {
-      while (t_j <= p) {
-        k1 = h * f(t_j, u_j);
-        k2 = h * f(t_j + h, u_j + k1);
-        u_j1 = u_j + (k1 + k2) / 2;
-        u_j = u_j1;
-        t_j = t_j + h;
-      }
-    }
-    if (order === 4) {
-      while (t_j <= p) {
-        k1 = h * f(t_j, u_j);
-        k2 = h * f(t_j + h / 2, u_j + k1 / 2);
-        k3 = h * f(t_j + h / 2, u_j + k2 / 2);
-        k4 = h * f(t_j +h, u_j + k3);
-        u_j1 = u_j + (k1 + 2 * k2 + 2 * k3 + k4) / 6;
-        u_j = u_j1;
-        t_j = t_j + h;
-      }
-    }
-    return u_j;
-  },
+    // extend jStat.fn with methods that require one argument
+    (function(funcs) {
+      for (var i = 0; i < funcs.length; i++) (function(passfunc) {
+        jStat.fn[passfunc] = function(arg, func) {
+          var tmpthis = this;
+          // check for callback
+          if (func) {
+            setTimeout(function() {
+              func.call(tmpthis, jStat.fn[passfunc].call(tmpthis, arg));
+            }, 15);
+            return this;
+          }
+          if (typeof jStat[passfunc](this, arg) === 'number')
+            return jStat[passfunc](this, arg);
+          else
+            return jStat(jStat[passfunc](this, arg));
+        };
+      }(funcs[i]));
+    }('add divide multiply subtract dot pow exp log abs norm angle'.split(' ')));
 
-  romberg: function romberg(f, a, b, order) {
-    var i = 0;
-    var h = (b - a) / 2;
-    var x = [];
-    var h1 = [];
-    var g = [];
-    var m, a1, j, k, I;
-    while (i < order / 2) {
-      I = f(a);
-      for (j = a, k = 0; j <= b; j = j + h, k++) x[k] = j;
-      m = x.length;
-      for (j = 1; j < m - 1; j++) {
-        I += (((j % 2) !== 0) ? 4 : 2) * f(x[j]);
-      }
-      I = (h / 3) * (I + f(b));
-      g[i] = I;
-      h /= 2;
-      i++;
-    }
-    a1 = g.length;
-    m = 1;
-    while (a1 !== 1) {
-      for (j = 0; j < a1 - 1; j++)
-      h1[j] = ((Math.pow(4, m)) * g[j + 1] - g[j]) / (Math.pow(4, m) - 1);
-      a1 = h1.length;
-      g = h1;
-      h1 = [];
-      m++;
-    }
-    return g;
-  },
+    }(jStat, Math));
+    (function(jStat, Math) {
 
-  richardson: function richardson(X, f, x, h) {
-    function pos(X, x) {
-      var i = 0;
-      var n = X.length;
-      var p;
-      for (; i < n; i++)
-        if (X[i] === x) p = i;
-      return p;
-    }
-    var n = X.length,
-    h_min = Math.abs(x - X[pos(X, x) + 1]),
-    i = 0,
-    g = [],
-    h1 = [],
-    y1, y2, m, a, j;
-    while (h >= h_min) {
-      y1 = pos(X, x + h);
-      y2 = pos(X, x);
-      g[i] = (f[y1] - 2 * f[y2] + f[2 * y2 - y1]) / (h * h);
-      h /= 2;
-      i++;
-    }
-    a = g.length;
-    m = 1;
-    while (a != 1) {
-      for (j = 0; j < a - 1; j++)
-      h1[j] = ((Math.pow(4, m)) * g[j + 1] - g[j]) / (Math.pow(4, m) - 1);
-      a = h1.length;
-      g = h1;
-      h1 = [];
-      m++;
-    }
-    return g;
-  },
+    var slice = [].slice;
+    var isNumber = jStat.utils.isNumber;
+    var isArray = jStat.utils.isArray;
 
-  simpson: function simpson(f, a, b, n) {
-    var h = (b - a) / n;
-    var I = f(a);
-    var x = [];
-    var j = a;
-    var k = 0;
-    var i = 1;
-    var m;
-    for (; j <= b; j = j + h, k++)
-      x[k] = j;
-    m = x.length;
-    for (; i < m - 1; i++) {
-      I += ((i % 2 !== 0) ? 4 : 2) * f(x[i]);
-    }
-    return (h / 3) * (I + f(b));
-  },
-
-  hermite: function hermite(X, F, dF, value) {
-    var n = X.length;
-    var p = 0;
-    var i = 0;
-    var l = [];
-    var dl = [];
-    var A = [];
-    var B = [];
-    var j;
-    for (; i < n; i++) {
-      l[i] = 1;
-      for (j = 0; j < n; j++) {
-        if (i != j) l[i] *= (value - X[j]) / (X[i] - X[j]);
-      }
-      dl[i] = 0;
-      for (j = 0; j < n; j++) {
-        if (i != j) dl[i] += 1 / (X [i] - X[j]);
-      }
-      A[i] = (1 - 2 * (value - X[i]) * dl[i]) * (l[i] * l[i]);
-      B[i] = (value - X[i]) * (l[i] * l[i]);
-      p += (A[i] * F[i] + B[i] * dF[i]);
-    }
-    return p;
-  },
-
-  lagrange: function lagrange(X, F, value) {
-    var p = 0;
-    var i = 0;
-    var j, l;
-    var n = X.length;
-    for (; i < n; i++) {
-      l = F[i];
-      for (j = 0; j < n; j++) {
-        // calculating the lagrange polynomial L_i
-        if (i != j) l *= (value - X[j]) / (X[i] - X[j]);
-      }
-      // adding the lagrange polynomials found above
-      p += l;
-    }
-    return p;
-  },
-
-  cubic_spline: function cubic_spline(X, F, value) {
-    var n = X.length;
-    var i = 0, j;
-    var A = [];
-    var B = [];
-    var alpha = [];
-    var c = [];
-    var h = [];
-    var b = [];
-    var d = [];
-    for (; i < n - 1; i++)
-      h[i] = X[i + 1] - X[i];
-    alpha[0] = 0;
-    for (var i = 1; i < n - 1; i++) {
-      alpha[i] = (3 / h[i]) * (F[i + 1] - F[i]) -
-          (3 / h[i-1]) * (F[i] - F[i-1]);
-    }
-    for (var i = 1; i < n - 1; i++) {
-      A[i] = [];
-      B[i] = [];
-      A[i][i-1] = h[i-1];
-      A[i][i] = 2 * (h[i - 1] + h[i]);
-      A[i][i+1] = h[i];
-      B[i][0] = alpha[i];
-    }
-    c = jStat.multiply(jStat.inv(A), B);
-    for (j = 0; j < n - 1; j++) {
-      b[j] = (F[j + 1] - F[j]) / h[j] - h[j] * (c[j + 1][0] + 2 * c[j][0]) / 3;
-      d[j] = (c[j + 1][0] - c[j][0]) / (3 * h[j]);
-    }
-    for (j = 0; j < n; j++) {
-      if (X[j] > value) break;
-    }
-    j -= 1;
-    return F[j] + (value - X[j]) * b[j] + jStat.sq(value-X[j]) *
-        c[j] + (value - X[j]) * jStat.sq(value - X[j]) * d[j];
-  },
-
-  gauss_quadrature: function gauss_quadrature() {
-    throw new Error('gauss_quadrature not yet implemented');
-  },
-
-  PCA: function PCA(X) {
-    var m = X.length;
-    var n = X[0].length;
-    var i = 0;
-    var j, temp1;
-    var u = [];
-    var D = [];
-    var result = [];
-    var temp2 = [];
-    var Y = [];
-    var Bt = [];
-    var B = [];
-    var C = [];
-    var V = [];
-    var Vt = [];
-    for (var i = 0; i < m; i++) {
-      u[i] = jStat.sum(X[i]) / n;
-    }
-    for (var i = 0; i < n; i++) {
-      B[i] = [];
-      for(j = 0; j < m; j++) {
-        B[i][j] = X[j][i] - u[j];
-      }
-    }
-    B = jStat.transpose(B);
-    for (var i = 0; i < m; i++) {
-      C[i] = [];
-      for (j = 0; j < m; j++) {
-        C[i][j] = (jStat.dot([B[i]], [B[j]])) / (n - 1);
-      }
-    }
-    result = jStat.jacobi(C);
-    V = result[0];
-    D = result[1];
-    Vt = jStat.transpose(V);
-    for (var i = 0; i < D.length; i++) {
-      for (j = i; j < D.length; j++) {
-        if(D[i] < D[j])  {
-          temp1 = D[i];
-          D[i] = D[j];
-          D[j] = temp1;
-          temp2 = Vt[i];
-          Vt[i] = Vt[j];
-          Vt[j] = temp2;
+    // flag==true denotes use of sample standard deviation
+    // Z Statistics
+    jStat.extend({
+      // 2 different parameter lists:
+      // (value, mean, sd)
+      // (value, array, flag)
+      zscore: function zscore() {
+        var args = slice.call(arguments);
+        if (isNumber(args[1])) {
+          return (args[0] - args[1]) / args[2];
         }
-      }
-    }
-    Bt = jStat.transpose(B);
-    for (var i = 0; i < m; i++) {
-      Y[i] = [];
-      for (j = 0; j < Bt.length; j++) {
-        Y[i][j] = jStat.dot([Vt[i]], [Bt[j]]);
-      }
-    }
-    return [X, D, Vt, Y];
-  }
-});
+        return (args[0] - jStat.mean(args[1])) / jStat.stdev(args[1], args[2]);
+      },
 
-// extend jStat.fn with methods that require one argument
-(function(funcs) {
-  for (var i = 0; i < funcs.length; i++) (function(passfunc) {
-    jStat.fn[passfunc] = function(arg, func) {
-      var tmpthis = this;
-      // check for callback
-      if (func) {
-        setTimeout(function() {
-          func.call(tmpthis, jStat.fn[passfunc].call(tmpthis, arg));
-        }, 15);
-        return this;
-      }
-      if (typeof jStat[passfunc](this, arg) === 'number')
-        return jStat[passfunc](this, arg);
-      else
-        return jStat(jStat[passfunc](this, arg));
-    };
-  }(funcs[i]));
-}('add divide multiply subtract dot pow exp log abs norm angle'.split(' ')));
-
-}(jStat, Math));
-(function(jStat, Math) {
-
-var slice = [].slice;
-var isNumber = jStat.utils.isNumber;
-var isArray = jStat.utils.isArray;
-
-// flag==true denotes use of sample standard deviation
-// Z Statistics
-jStat.extend({
-  // 2 different parameter lists:
-  // (value, mean, sd)
-  // (value, array, flag)
-  zscore: function zscore() {
-    var args = slice.call(arguments);
-    if (isNumber(args[1])) {
-      return (args[0] - args[1]) / args[2];
-    }
-    return (args[0] - jStat.mean(args[1])) / jStat.stdev(args[1], args[2]);
-  },
-
-  // 3 different paramter lists:
-  // (value, mean, sd, sides)
-  // (zscore, sides)
-  // (value, array, sides, flag)
-  ztest: function ztest() {
-    var args = slice.call(arguments);
-    var z;
-    if (isArray(args[1])) {
+      // 3 different paramter lists:
+      // (value, mean, sd, sides)
+      // (zscore, sides)
       // (value, array, sides, flag)
-      z = jStat.zscore(args[0],args[1],args[3]);
-      return (args[2] === 1) ?
-        (jStat.normal.cdf(-Math.abs(z), 0, 1)) :
-        (jStat.normal.cdf(-Math.abs(z), 0, 1)*2);
-    } else {
-      if (args.length > 2) {
-        // (value, mean, sd, sides)
-        z = jStat.zscore(args[0],args[1],args[2]);
-        return (args[3] === 1) ?
-          (jStat.normal.cdf(-Math.abs(z),0,1)) :
-          (jStat.normal.cdf(-Math.abs(z),0,1)* 2);
-      } else {
-        // (zscore, sides)
-        z = args[0];
-        return (args[1] === 1) ?
-          (jStat.normal.cdf(-Math.abs(z),0,1)) :
-          (jStat.normal.cdf(-Math.abs(z),0,1)*2);
-      }
-    }
-  }
-});
-
-jStat.extend(jStat.fn, {
-  zscore: function zscore(value, flag) {
-    return (value - this.mean()) / this.stdev(flag);
-  },
-
-  ztest: function ztest(value, sides, flag) {
-    var zscore = Math.abs(this.zscore(value, flag));
-    return (sides === 1) ?
-      (jStat.normal.cdf(-zscore, 0, 1)) :
-      (jStat.normal.cdf(-zscore, 0, 1) * 2);
-  }
-});
-
-// T Statistics
-jStat.extend({
-  // 2 parameter lists
-  // (value, mean, sd, n)
-  // (value, array)
-  tscore: function tscore() {
-    var args = slice.call(arguments);
-    return (args.length === 4) ?
-      ((args[0] - args[1]) / (args[2] / Math.sqrt(args[3]))) :
-      ((args[0] - jStat.mean(args[1])) /
-       (jStat.stdev(args[1], true) / Math.sqrt(args[1].length)));
-  },
-
-  // 3 different paramter lists:
-  // (value, mean, sd, n, sides)
-  // (tscore, n, sides)
-  // (value, array, sides)
-  ttest: function ttest() {
-    var args = slice.call(arguments);
-    var tscore;
-    if (args.length === 5) {
-      tscore = Math.abs(jStat.tscore(args[0], args[1], args[2], args[3]));
-      return (args[4] === 1) ?
-        (jStat.studentt.cdf(-tscore, args[3]-1)) :
-        (jStat.studentt.cdf(-tscore, args[3]-1)*2);
-    }
-    if (isNumber(args[1])) {
-      tscore = Math.abs(args[0]);
-      return (args[2] == 1) ?
-        (jStat.studentt.cdf(-tscore, args[1]-1)) :
-        (jStat.studentt.cdf(-tscore, args[1]-1) * 2);
-    }
-    tscore = Math.abs(jStat.tscore(args[0], args[1]));
-    return (args[2] == 1) ?
-      (jStat.studentt.cdf(-tscore, args[1].length-1)) :
-      (jStat.studentt.cdf(-tscore, args[1].length-1) * 2);
-  }
-});
-
-jStat.extend(jStat.fn, {
-  tscore: function tscore(value) {
-    return (value - this.mean()) / (this.stdev(true) / Math.sqrt(this.cols()));
-  },
-
-  ttest: function ttest(value, sides) {
-    return (sides === 1) ?
-      (1 - jStat.studentt.cdf(Math.abs(this.tscore(value)), this.cols()-1)) :
-      (jStat.studentt.cdf(-Math.abs(this.tscore(value)), this.cols()-1)*2);
-  }
-});
-
-// F Statistics
-jStat.extend({
-  // Paramter list is as follows:
-  // (array1, array2, array3, ...)
-  // or it is an array of arrays
-  // array of arrays conversion
-  anovafscore: function anovafscore() {
-    var args = slice.call(arguments),
-    expVar, sample, sampMean, sampSampMean, tmpargs, unexpVar, i, j;
-    if (args.length === 1) {
-      tmpargs = new Array(args[0].length);
-      for (var i = 0; i < args[0].length; i++) {
-        tmpargs[i] = args[0][i];
-      }
-      args = tmpargs;
-    }
-    // 2 sample case
-    if (args.length === 2) {
-      return jStat.variance(args[0]) / jStat.variance(args[1]);
-    }
-    // Builds sample array
-    sample = new Array();
-    for (var i = 0; i < args.length; i++) {
-      sample = sample.concat(args[i]);
-    }
-    sampMean = jStat.mean(sample);
-    // Computes the explained variance
-    expVar = 0;
-    for (var i = 0; i < args.length; i++) {
-      expVar = expVar + args[i].length * Math.pow(jStat.mean(args[i]) - sampMean, 2);
-    }
-    expVar /= (args.length - 1);
-    // Computes unexplained variance
-    unexpVar = 0;
-    for (var i = 0; i < args.length; i++) {
-      sampSampMean = jStat.mean(args[i]);
-      for (j = 0; j < args[i].length; j++) {
-        unexpVar += Math.pow(args[i][j] - sampSampMean, 2);
-      }
-    }
-    unexpVar /= (sample.length - args.length);
-    return expVar / unexpVar;
-  },
-
-  // 2 different paramter setups
-  // (array1, array2, array3, ...)
-  // (anovafscore, df1, df2)
-  anovaftest: function anovaftest() {
-    var args = slice.call(arguments),
-    df1, df2, n, i;
-    if (isNumber(args[0])) {
-      return 1 - jStat.centralF.cdf(args[0], args[1], args[2]);
-    }
-    anovafscore = jStat.anovafscore(args);
-    df1 = args.length - 1;
-    n = 0;
-    for (var i = 0; i < args.length; i++) {
-      n = n + args[i].length;
-    }
-    df2 = n - df1 - 1;
-    return 1 - jStat.centralF.cdf(anovafscore, df1, df2);
-  },
-
-  ftest: function ftest(fscore, df1, df2) {
-    return 1 - jStat.centralF.cdf(fscore, df1, df2);
-  }
-});
-
-jStat.extend(jStat.fn, {
-  anovafscore: function anovafscore() {
-    return jStat.anovafscore(this.toArray());
-  },
-
-  anovaftes: function anovaftes() {
-    var n = 0;
-    var i;
-    for (var i = 0; i < this.length; i++) {
-      n = n + this[i].length;
-    }
-    return jStat.ftest(this.anovafscore(), this.length - 1, n - this.length);
-  }
-});
-
-// Tukey's range test
-jStat.extend({
-  // 2 parameter lists
-  // (mean1, mean2, n1, n2, sd)
-  // (array1, array2, sd)
-  qscore: function qscore() {
-    var args = slice.call(arguments);
-    var mean1, mean2, n1, n2, sd;
-    if (isNumber(args[0])) {
-        mean1 = args[0];
-        mean2 = args[1];
-        n1 = args[2];
-        n2 = args[3];
-        sd = args[4];
-    } else {
-        mean1 = jStat.mean(args[0]);
-        mean2 = jStat.mean(args[1]);
-        n1 = args[0].length;
-        n2 = args[1].length;
-        sd = args[2];
-    }
-    return Math.abs(mean1 - mean2) / (sd * Math.sqrt((1 / n1 + 1 / n2) / 2));
-  },
-
-  // 3 different parameter lists:
-  // (qscore, n, k)
-  // (mean1, mean2, n1, n2, sd, n, k)
-  // (array1, array2, sd, n, k)
-  qtest: function qtest() {
-    var args = slice.call(arguments);
-
-    var qscore;
-    if (args.length === 3) {
-      qscore = args[0];
-      args = args.slice(1);
-    } else if (args.length === 7) {
-      qscore = jStat.qscore(args[0], args[1], args[2], args[3], args[4]);
-      args = args.slice(5);
-    } else {
-      qscore = jStat.qscore(args[0], args[1], args[2]);
-      args = args.slice(3);
-    }
-
-    var n = args[0];
-    var k = args[1];
-
-    return 1 - jStat.tukey.cdf(qscore, k, n - k);
-  },
-
-  tukeyhsd: function tukeyhsd(arrays) {
-    var sd = jStat.pooledstdev(arrays);
-    var means = arrays.map(function (arr) {return jStat.mean(arr);});
-    var n = arrays.reduce(function (n, arr) {return n + arr.length;}, 0);
-
-    var results = [];
-    for (var i = 0; i < arrays.length; ++i) {
-        for (var j = i + 1; j < arrays.length; ++j) {
-            var p = jStat.qtest(means[i], means[j], arrays[i].length, arrays[j].length, sd, n, arrays.length);
-            results.push([[i, j], p]);
-        }
-    }
-
-    return results;
-  }
-});
-
-// Error Bounds
-jStat.extend({
-  // 2 different parameter setups
-  // (value, alpha, sd, n)
-  // (value, alpha, array)
-  normalci: function normalci() {
-    var args = slice.call(arguments),
-    ans = new Array(2),
-    change;
-    if (args.length === 4) {
-      change = Math.abs(jStat.normal.inv(args[1] / 2, 0, 1) *
-                        args[2] / Math.sqrt(args[3]));
-    } else {
-      change = Math.abs(jStat.normal.inv(args[1] / 2, 0, 1) *
-                        jStat.stdev(args[2]) / Math.sqrt(args[2].length));
-    }
-    ans[0] = args[0] - change;
-    ans[1] = args[0] + change;
-    return ans;
-  },
-
-  // 2 different parameter setups
-  // (value, alpha, sd, n)
-  // (value, alpha, array)
-  tci: function tci() {
-    var args = slice.call(arguments),
-    ans = new Array(2),
-    change;
-    if (args.length === 4) {
-      change = Math.abs(jStat.studentt.inv(args[1] / 2, args[3] - 1) *
-                        args[2] / Math.sqrt(args[3]));
-    } else {
-      change = Math.abs(jStat.studentt.inv(args[1] / 2, args[2].length - 1) *
-                        jStat.stdev(args[2], true) / Math.sqrt(args[2].length));
-    }
-    ans[0] = args[0] - change;
-    ans[1] = args[0] + change;
-    return ans;
-  },
-
-  significant: function significant(pvalue, alpha) {
-    return pvalue < alpha;
-  }
-});
-
-jStat.extend(jStat.fn, {
-  normalci: function normalci(value, alpha) {
-    return jStat.normalci(value, alpha, this.toArray());
-  },
-
-  tci: function tci(value, alpha) {
-    return jStat.tci(value, alpha, this.toArray());
-  }
-});
-
-// internal method for calculating the z-score for a difference of proportions test
-function differenceOfProportions(p1, n1, p2, n2) {
-  if (p1 > 1 || p2 > 1 || p1 <= 0 || p2 <= 0) {
-    throw new Error("Proportions should be greater than 0 and less than 1")
-  }
-  var pooled = (p1 * n1 + p2 * n2) / (n1 + n2);
-  var se = Math.sqrt(pooled * (1 - pooled) * ((1/n1) + (1/n2)));
-  return (p1 - p2) / se;
-}
-
-// Difference of Proportions
-jStat.extend(jStat.fn, {
-  oneSidedDifferenceOfProportions: function oneSidedDifferenceOfProportions(p1, n1, p2, n2) {
-    var z = differenceOfProportions(p1, n1, p2, n2);
-    return jStat.ztest(z, 1);
-  },
-
-  twoSidedDifferenceOfProportions: function twoSidedDifferenceOfProportions(p1, n1, p2, n2) {
-    var z = differenceOfProportions(p1, n1, p2, n2);
-    return jStat.ztest(z, 2);
-  }
-});
-
-}(jStat, Math));
-jStat.models = (function(){
-
-  function sub_regress(endog, exog) {
-    return ols(endog, exog);
-  }
-
-  function sub_regress(exog) {
-    var var_count = exog[0].length;
-    var modelList = jStat.arange(var_count).map(function(endog_index) {
-      var exog_index =
-          jStat.arange(var_count).filter(function(i){return i!==endog_index});
-      return ols(jStat.col(exog, endog_index).map(function(x){ return x[0] }),
-                 jStat.col(exog, exog_index))
-    });
-    return modelList;
-  }
-
-  // do OLS model regress
-  // exog have include const columns ,it will not generate it .In fact, exog is
-  // "design matrix" look at
-  //https://en.wikipedia.org/wiki/Design_matrix
-  function ols(endog, exog) {
-    var nobs = endog.length;
-    var df_model = exog[0].length - 1;
-    var df_resid = nobs-df_model - 1;
-    var coef = jStat.lstsq(exog, endog);
-    var predict =
-        jStat.multiply(exog, coef.map(function(x) { return [x] }))
-            .map(function(p) { return p[0] });
-    var resid = jStat.subtract(endog, predict);
-    var ybar = jStat.mean(endog);
-    // constant cause problem
-    // var SST = jStat.sum(endog.map(function(y) {
-    //   return Math.pow(y-ybar,2);
-    // }));
-    var SSE = jStat.sum(predict.map(function(f) {
-      return Math.pow(f - ybar, 2);
-    }));
-    var SSR = jStat.sum(endog.map(function(y, i) {
-      return Math.pow(y - predict[i], 2);
-    }));
-    var SST = SSE + SSR;
-    var R2 = (SSE / SST);
-    return {
-        exog:exog,
-        endog:endog,
-        nobs:nobs,
-        df_model:df_model,
-        df_resid:df_resid,
-        coef:coef,
-        predict:predict,
-        resid:resid,
-        ybar:ybar,
-        SST:SST,
-        SSE:SSE,
-        SSR:SSR,
-        R2:R2
-    };
-  }
-
-  // H0: b_I=0
-  // H1: b_I!=0
-  function t_test(model) {
-    var subModelList = sub_regress(model.exog);
-    //var sigmaHat=jStat.stdev(model.resid);
-    var sigmaHat = Math.sqrt(model.SSR / (model.df_resid));
-    var seBetaHat = subModelList.map(function(mod) {
-      var SST = mod.SST;
-      var R2 = mod.R2;
-      return sigmaHat / Math.sqrt(SST * (1 - R2));
-    });
-    var tStatistic = model.coef.map(function(coef, i) {
-      return (coef - 0) / seBetaHat[i];
-    });
-    var pValue = tStatistic.map(function(t) {
-      var leftppf = jStat.studentt.cdf(t, model.df_resid);
-      return (leftppf > 0.5 ? 1 - leftppf : leftppf) * 2;
-    });
-    var c = jStat.studentt.inv(0.975, model.df_resid);
-    var interval95 = model.coef.map(function(coef, i) {
-      var d = c * seBetaHat[i];
-      return [coef - d, coef + d];
-    });
-    return {
-        se: seBetaHat,
-        t: tStatistic,
-        p: pValue,
-        sigmaHat: sigmaHat,
-        interval95: interval95
-    };
-  }
-
-  function F_test(model) {
-    var F_statistic =
-        (model.R2 / model.df_model) / ((1 - model.R2) / model.df_resid);
-    var fcdf = function(x, n1, n2) {
-      return jStat.beta.cdf(x / (n2 / n1 + x), n1 / 2, n2 / 2)
-    };
-    var pvalue = 1 - fcdf(F_statistic, model.df_model, model.df_resid);
-    return { F_statistic: F_statistic, pvalue: pvalue };
-  }
-
-  function ols_wrap(endog, exog) {
-    var model = ols(endog,exog);
-    var ttest = t_test(model);
-    var ftest = F_test(model);
-    // Provide the Wherry / Ezekiel / McNemar / Cohen Adjusted R^2
-    // Which matches the 'adjusted R^2' provided by R's lm package
-    var adjust_R2 =
-        1 - (1 - model.R2) * ((model.nobs - 1) / (model.df_resid));
-    model.t = ttest;
-    model.f = ftest;
-    model.adjust_R2 = adjust_R2;
-    return model;
-  }
-
-  return { ols: ols_wrap };
-})();
-  // Make it compatible with previous version.
-  jStat.jStat = jStat;
-
-  return jStat;
-});
-});
-
-// SOLVING FOR POWER
-function solveforpower_Gtest ({total_sample_size, base_rate, effect_size, alpha, alternative, mu}) {
-    var sample_size = total_sample_size/2;
-
-    var mean_base = base_rate;
-    var mean_var = base_rate * (1+effect_size);
-
-    var mean_diff = mean_var - mean_base;
-    var delta = mean_diff - mu;
-
-    var variance = mean_base * (1-mean_base) + mean_var * (1-mean_var);
-    var z = jstat.normal.inv(1-alpha/2, 0, 1);
-    var mean = delta*Math.sqrt(sample_size/variance);
-
-    var power;
-    if (alternative == 'lower') {
-        power = jstat.normal.cdf(jstat.normal.inv(alpha, 0, 1), mean, 1);
-    } else if (alternative == 'greater') {
-        power = 1-jstat.normal.cdf(jstat.normal.inv(1-alpha, 0, 1), mean, 1);
-    } else {
-        power = 1 - (jstat.normal.cdf(z, mean, 1) -
-            jstat.normal.cdf(-z, mean, 1));
-    }
-
-    return power
-}
-
-function solveforpower_Ttest({total_sample_size, base_rate, sd_rate, effect_size, alpha, alternative, mu}) {
-    var sample_size = total_sample_size/2;
-
-    var mean_base = base_rate;
-    var mean_var = base_rate * (1+effect_size);
-
-    var mean_diff = mean_var - mean_base;
-    var delta = mean_diff - mu;
-
-    var variance = 2*sd_rate**2;
-    var z = jstat.normal.inv(1-alpha/2, 0, 1);
-    var mean = delta*Math.sqrt(sample_size/variance);
-
-    var power;
-    if (alternative == 'lower') {
-        power = jstat.normal.cdf(jstat.normal.inv(alpha, 0, 1), mean, 1);
-    } else if (alternative == 'greater') {
-	power = 1-jstat.normal.cdf(jstat.normal.inv(1-alpha, 0, 1), mean, 1);
-    } else {
-        power = 1 - (jstat.normal.cdf(z, mean, 1) -
-            jstat.normal.cdf(-z, mean, 1));
-   }
-
-    return power
-}
-
-
-function is_valid_input(data) {
-    var { base_rate, effect_size, alternative, opts, mu } = data;
-    var change = effect_size*base_rate;
-    if (typeof(mu) != 'undefined') {
-        if (alternative == 'greater' && mu >= change) {
-            return false;
-        }
-        if (alternative == 'lower' && mu <= change) {
-            return false;
-        }
-     }
-
-     if (opts && opts.type == 'relative') {
-        if (alternative == 'greater' && opts.threshold >= effect_size) {
-            return false;
-        }
-        if (alternative == 'lower' && opts.threshold <= effect_size) {
-            return false;
-        }
-     }
-
-     if (opts && opts.type == 'absolutePerDay' && opts.calculating == 'days') {
-        if (alternative == 'greater' && opts.threshold/opts.visitors_per_day >= change) {
-            return false;
-        }
-        if (alternative == 'lower' && opts.threshold/opts.visitors_per_day <= change) {
-            return false;
-        }
-     }
-
-     return true;
-}
-
-// SOLVING FOR SAMPLE SIZE
-function solve_quadratic_for_sample({mean_diff, Z, days, threshold, variance}) {
-    var a = mean_diff;
-    if (a == 0) {
-        return threshold*Math.sqrt(days)/(2*Math.sqrt(variance)*Z)
-    }
-
-    var b = Math.sqrt(variance)*Z/Math.sqrt(days);
-    var c = -threshold/2;
-
-    var det = b**2 - 4*a*c;
-    if (det < 0) {
-      return NaN;
-    }
-
-    var sol_h = (-b + Math.sqrt(det)) / (2*a);
-    var sol_l = (-b - Math.sqrt(det)) / (2*a);
-
-    return sol_h >= 0 ? sol_h : sol_l;
-}
-
-function solveforsample_Ttest(data){
-    var { base_rate, sd_rate, effect_size, alpha, beta, alternative, mu, opts } = data;
-    if (!is_valid_input(data)) {
-       return NaN;
-    }
-    var mean_base = base_rate;
-    var mean_var = base_rate * (1+effect_size);
-
-    var variance = 2*sd_rate**2;
-    var mean_diff = mean_var - mean_base;
-
-    var multiplier;
-    var sample_one_group;
-    if (opts && opts.type == 'absolutePerDay') {
-        if (opts.calculating == 'visitorsPerDay') {
-            var Z;
-            if (alternative == "greater") {
-                Z = jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1);
-            } else if (alternative == "lower") {
-                Z = jstat.normal.inv(1-beta, 0, 1) - jstat.normal.inv(alpha, 0, 1);
-            } else {
-                Z = jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1);
-            }
-            var sqrt_visitors_per_day = solve_quadratic_for_sample({mean_diff: mean_diff, Z: Z,
-                days: opts.days, threshold: opts.threshold, variance: variance});
-            sample_one_group = opts.days*sqrt_visitors_per_day**2;
+      ztest: function ztest() {
+        var args = slice.call(arguments);
+        var z;
+        if (isArray(args[1])) {
+          // (value, array, sides, flag)
+          z = jStat.zscore(args[0],args[1],args[3]);
+          return (args[2] === 1) ?
+            (jStat.normal.cdf(-Math.abs(z), 0, 1)) :
+            (jStat.normal.cdf(-Math.abs(z), 0, 1)*2);
         } else {
-            multiplier = variance/(mean_diff*Math.sqrt(opts.visitors_per_day/2) - opts.threshold/(Math.sqrt(2*opts.visitors_per_day)))**2;
-            var days;
+          if (args.length > 2) {
+            // (value, mean, sd, sides)
+            z = jStat.zscore(args[0],args[1],args[2]);
+            return (args[3] === 1) ?
+              (jStat.normal.cdf(-Math.abs(z),0,1)) :
+              (jStat.normal.cdf(-Math.abs(z),0,1)* 2);
+          } else {
+            // (zscore, sides)
+            z = args[0];
+            return (args[1] === 1) ?
+              (jStat.normal.cdf(-Math.abs(z),0,1)) :
+              (jStat.normal.cdf(-Math.abs(z),0,1)*2);
+          }
+        }
+      }
+    });
+
+    jStat.extend(jStat.fn, {
+      zscore: function zscore(value, flag) {
+        return (value - this.mean()) / this.stdev(flag);
+      },
+
+      ztest: function ztest(value, sides, flag) {
+        var zscore = Math.abs(this.zscore(value, flag));
+        return (sides === 1) ?
+          (jStat.normal.cdf(-zscore, 0, 1)) :
+          (jStat.normal.cdf(-zscore, 0, 1) * 2);
+      }
+    });
+
+    // T Statistics
+    jStat.extend({
+      // 2 parameter lists
+      // (value, mean, sd, n)
+      // (value, array)
+      tscore: function tscore() {
+        var args = slice.call(arguments);
+        return (args.length === 4) ?
+          ((args[0] - args[1]) / (args[2] / Math.sqrt(args[3]))) :
+          ((args[0] - jStat.mean(args[1])) /
+           (jStat.stdev(args[1], true) / Math.sqrt(args[1].length)));
+      },
+
+      // 3 different paramter lists:
+      // (value, mean, sd, n, sides)
+      // (tscore, n, sides)
+      // (value, array, sides)
+      ttest: function ttest() {
+        var args = slice.call(arguments);
+        var tscore;
+        if (args.length === 5) {
+          tscore = Math.abs(jStat.tscore(args[0], args[1], args[2], args[3]));
+          return (args[4] === 1) ?
+            (jStat.studentt.cdf(-tscore, args[3]-1)) :
+            (jStat.studentt.cdf(-tscore, args[3]-1)*2);
+        }
+        if (isNumber(args[1])) {
+          tscore = Math.abs(args[0]);
+          return (args[2] == 1) ?
+            (jStat.studentt.cdf(-tscore, args[1]-1)) :
+            (jStat.studentt.cdf(-tscore, args[1]-1) * 2);
+        }
+        tscore = Math.abs(jStat.tscore(args[0], args[1]));
+        return (args[2] == 1) ?
+          (jStat.studentt.cdf(-tscore, args[1].length-1)) :
+          (jStat.studentt.cdf(-tscore, args[1].length-1) * 2);
+      }
+    });
+
+    jStat.extend(jStat.fn, {
+      tscore: function tscore(value) {
+        return (value - this.mean()) / (this.stdev(true) / Math.sqrt(this.cols()));
+      },
+
+      ttest: function ttest(value, sides) {
+        return (sides === 1) ?
+          (1 - jStat.studentt.cdf(Math.abs(this.tscore(value)), this.cols()-1)) :
+          (jStat.studentt.cdf(-Math.abs(this.tscore(value)), this.cols()-1)*2);
+      }
+    });
+
+    // F Statistics
+    jStat.extend({
+      // Paramter list is as follows:
+      // (array1, array2, array3, ...)
+      // or it is an array of arrays
+      // array of arrays conversion
+      anovafscore: function anovafscore() {
+        var args = slice.call(arguments),
+        expVar, sample, sampMean, sampSampMean, tmpargs, unexpVar, i, j;
+        if (args.length === 1) {
+          tmpargs = new Array(args[0].length);
+          for (var i = 0; i < args[0].length; i++) {
+            tmpargs[i] = args[0][i];
+          }
+          args = tmpargs;
+        }
+        // 2 sample case
+        if (args.length === 2) {
+          return jStat.variance(args[0]) / jStat.variance(args[1]);
+        }
+        // Builds sample array
+        sample = new Array();
+        for (var i = 0; i < args.length; i++) {
+          sample = sample.concat(args[i]);
+        }
+        sampMean = jStat.mean(sample);
+        // Computes the explained variance
+        expVar = 0;
+        for (var i = 0; i < args.length; i++) {
+          expVar = expVar + args[i].length * Math.pow(jStat.mean(args[i]) - sampMean, 2);
+        }
+        expVar /= (args.length - 1);
+        // Computes unexplained variance
+        unexpVar = 0;
+        for (var i = 0; i < args.length; i++) {
+          sampSampMean = jStat.mean(args[i]);
+          for (j = 0; j < args[i].length; j++) {
+            unexpVar += Math.pow(args[i][j] - sampSampMean, 2);
+          }
+        }
+        unexpVar /= (sample.length - args.length);
+        return expVar / unexpVar;
+      },
+
+      // 2 different paramter setups
+      // (array1, array2, array3, ...)
+      // (anovafscore, df1, df2)
+      anovaftest: function anovaftest() {
+        var args = slice.call(arguments),
+        df1, df2, n, i;
+        if (isNumber(args[0])) {
+          return 1 - jStat.centralF.cdf(args[0], args[1], args[2]);
+        }
+        anovafscore = jStat.anovafscore(args);
+        df1 = args.length - 1;
+        n = 0;
+        for (var i = 0; i < args.length; i++) {
+          n = n + args[i].length;
+        }
+        df2 = n - df1 - 1;
+        return 1 - jStat.centralF.cdf(anovafscore, df1, df2);
+      },
+
+      ftest: function ftest(fscore, df1, df2) {
+        return 1 - jStat.centralF.cdf(fscore, df1, df2);
+      }
+    });
+
+    jStat.extend(jStat.fn, {
+      anovafscore: function anovafscore() {
+        return jStat.anovafscore(this.toArray());
+      },
+
+      anovaftes: function anovaftes() {
+        var n = 0;
+        var i;
+        for (var i = 0; i < this.length; i++) {
+          n = n + this[i].length;
+        }
+        return jStat.ftest(this.anovafscore(), this.length - 1, n - this.length);
+      }
+    });
+
+    // Tukey's range test
+    jStat.extend({
+      // 2 parameter lists
+      // (mean1, mean2, n1, n2, sd)
+      // (array1, array2, sd)
+      qscore: function qscore() {
+        var args = slice.call(arguments);
+        var mean1, mean2, n1, n2, sd;
+        if (isNumber(args[0])) {
+            mean1 = args[0];
+            mean2 = args[1];
+            n1 = args[2];
+            n2 = args[3];
+            sd = args[4];
+        } else {
+            mean1 = jStat.mean(args[0]);
+            mean2 = jStat.mean(args[1]);
+            n1 = args[0].length;
+            n2 = args[1].length;
+            sd = args[2];
+        }
+        return Math.abs(mean1 - mean2) / (sd * Math.sqrt((1 / n1 + 1 / n2) / 2));
+      },
+
+      // 3 different parameter lists:
+      // (qscore, n, k)
+      // (mean1, mean2, n1, n2, sd, n, k)
+      // (array1, array2, sd, n, k)
+      qtest: function qtest() {
+        var args = slice.call(arguments);
+
+        var qscore;
+        if (args.length === 3) {
+          qscore = args[0];
+          args = args.slice(1);
+        } else if (args.length === 7) {
+          qscore = jStat.qscore(args[0], args[1], args[2], args[3], args[4]);
+          args = args.slice(5);
+        } else {
+          qscore = jStat.qscore(args[0], args[1], args[2]);
+          args = args.slice(3);
+        }
+
+        var n = args[0];
+        var k = args[1];
+
+        return 1 - jStat.tukey.cdf(qscore, k, n - k);
+      },
+
+      tukeyhsd: function tukeyhsd(arrays) {
+        var sd = jStat.pooledstdev(arrays);
+        var means = arrays.map(function (arr) {return jStat.mean(arr);});
+        var n = arrays.reduce(function (n, arr) {return n + arr.length;}, 0);
+
+        var results = [];
+        for (var i = 0; i < arrays.length; ++i) {
+            for (var j = i + 1; j < arrays.length; ++j) {
+                var p = jStat.qtest(means[i], means[j], arrays[i].length, arrays[j].length, sd, n, arrays.length);
+                results.push([[i, j], p]);
+            }
+        }
+
+        return results;
+      }
+    });
+
+    // Error Bounds
+    jStat.extend({
+      // 2 different parameter setups
+      // (value, alpha, sd, n)
+      // (value, alpha, array)
+      normalci: function normalci() {
+        var args = slice.call(arguments),
+        ans = new Array(2),
+        change;
+        if (args.length === 4) {
+          change = Math.abs(jStat.normal.inv(args[1] / 2, 0, 1) *
+                            args[2] / Math.sqrt(args[3]));
+        } else {
+          change = Math.abs(jStat.normal.inv(args[1] / 2, 0, 1) *
+                            jStat.stdev(args[2]) / Math.sqrt(args[2].length));
+        }
+        ans[0] = args[0] - change;
+        ans[1] = args[0] + change;
+        return ans;
+      },
+
+      // 2 different parameter setups
+      // (value, alpha, sd, n)
+      // (value, alpha, array)
+      tci: function tci() {
+        var args = slice.call(arguments),
+        ans = new Array(2),
+        change;
+        if (args.length === 4) {
+          change = Math.abs(jStat.studentt.inv(args[1] / 2, args[3] - 1) *
+                            args[2] / Math.sqrt(args[3]));
+        } else {
+          change = Math.abs(jStat.studentt.inv(args[1] / 2, args[2].length - 1) *
+                            jStat.stdev(args[2], true) / Math.sqrt(args[2].length));
+        }
+        ans[0] = args[0] - change;
+        ans[1] = args[0] + change;
+        return ans;
+      },
+
+      significant: function significant(pvalue, alpha) {
+        return pvalue < alpha;
+      }
+    });
+
+    jStat.extend(jStat.fn, {
+      normalci: function normalci(value, alpha) {
+        return jStat.normalci(value, alpha, this.toArray());
+      },
+
+      tci: function tci(value, alpha) {
+        return jStat.tci(value, alpha, this.toArray());
+      }
+    });
+
+    // internal method for calculating the z-score for a difference of proportions test
+    function differenceOfProportions(p1, n1, p2, n2) {
+      if (p1 > 1 || p2 > 1 || p1 <= 0 || p2 <= 0) {
+        throw new Error("Proportions should be greater than 0 and less than 1")
+      }
+      var pooled = (p1 * n1 + p2 * n2) / (n1 + n2);
+      var se = Math.sqrt(pooled * (1 - pooled) * ((1/n1) + (1/n2)));
+      return (p1 - p2) / se;
+    }
+
+    // Difference of Proportions
+    jStat.extend(jStat.fn, {
+      oneSidedDifferenceOfProportions: function oneSidedDifferenceOfProportions(p1, n1, p2, n2) {
+        var z = differenceOfProportions(p1, n1, p2, n2);
+        return jStat.ztest(z, 1);
+      },
+
+      twoSidedDifferenceOfProportions: function twoSidedDifferenceOfProportions(p1, n1, p2, n2) {
+        var z = differenceOfProportions(p1, n1, p2, n2);
+        return jStat.ztest(z, 2);
+      }
+    });
+
+    }(jStat, Math));
+    jStat.models = (function(){
+
+      function sub_regress(endog, exog) {
+        return ols(endog, exog);
+      }
+
+      function sub_regress(exog) {
+        var var_count = exog[0].length;
+        var modelList = jStat.arange(var_count).map(function(endog_index) {
+          var exog_index =
+              jStat.arange(var_count).filter(function(i){return i!==endog_index});
+          return ols(jStat.col(exog, endog_index).map(function(x){ return x[0] }),
+                     jStat.col(exog, exog_index))
+        });
+        return modelList;
+      }
+
+      // do OLS model regress
+      // exog have include const columns ,it will not generate it .In fact, exog is
+      // "design matrix" look at
+      //https://en.wikipedia.org/wiki/Design_matrix
+      function ols(endog, exog) {
+        var nobs = endog.length;
+        var df_model = exog[0].length - 1;
+        var df_resid = nobs-df_model - 1;
+        var coef = jStat.lstsq(exog, endog);
+        var predict =
+            jStat.multiply(exog, coef.map(function(x) { return [x] }))
+                .map(function(p) { return p[0] });
+        var resid = jStat.subtract(endog, predict);
+        var ybar = jStat.mean(endog);
+        // constant cause problem
+        // var SST = jStat.sum(endog.map(function(y) {
+        //   return Math.pow(y-ybar,2);
+        // }));
+        var SSE = jStat.sum(predict.map(function(f) {
+          return Math.pow(f - ybar, 2);
+        }));
+        var SSR = jStat.sum(endog.map(function(y, i) {
+          return Math.pow(y - predict[i], 2);
+        }));
+        var SST = SSE + SSR;
+        var R2 = (SSE / SST);
+        return {
+            exog:exog,
+            endog:endog,
+            nobs:nobs,
+            df_model:df_model,
+            df_resid:df_resid,
+            coef:coef,
+            predict:predict,
+            resid:resid,
+            ybar:ybar,
+            SST:SST,
+            SSE:SSE,
+            SSR:SSR,
+            R2:R2
+        };
+      }
+
+      // H0: b_I=0
+      // H1: b_I!=0
+      function t_test(model) {
+        var subModelList = sub_regress(model.exog);
+        //var sigmaHat=jStat.stdev(model.resid);
+        var sigmaHat = Math.sqrt(model.SSR / (model.df_resid));
+        var seBetaHat = subModelList.map(function(mod) {
+          var SST = mod.SST;
+          var R2 = mod.R2;
+          return sigmaHat / Math.sqrt(SST * (1 - R2));
+        });
+        var tStatistic = model.coef.map(function(coef, i) {
+          return (coef - 0) / seBetaHat[i];
+        });
+        var pValue = tStatistic.map(function(t) {
+          var leftppf = jStat.studentt.cdf(t, model.df_resid);
+          return (leftppf > 0.5 ? 1 - leftppf : leftppf) * 2;
+        });
+        var c = jStat.studentt.inv(0.975, model.df_resid);
+        var interval95 = model.coef.map(function(coef, i) {
+          var d = c * seBetaHat[i];
+          return [coef - d, coef + d];
+        });
+        return {
+            se: seBetaHat,
+            t: tStatistic,
+            p: pValue,
+            sigmaHat: sigmaHat,
+            interval95: interval95
+        };
+      }
+
+      function F_test(model) {
+        var F_statistic =
+            (model.R2 / model.df_model) / ((1 - model.R2) / model.df_resid);
+        var fcdf = function(x, n1, n2) {
+          return jStat.beta.cdf(x / (n2 / n1 + x), n1 / 2, n2 / 2)
+        };
+        var pvalue = 1 - fcdf(F_statistic, model.df_model, model.df_resid);
+        return { F_statistic: F_statistic, pvalue: pvalue };
+      }
+
+      function ols_wrap(endog, exog) {
+        var model = ols(endog,exog);
+        var ttest = t_test(model);
+        var ftest = F_test(model);
+        // Provide the Wherry / Ezekiel / McNemar / Cohen Adjusted R^2
+        // Which matches the 'adjusted R^2' provided by R's lm package
+        var adjust_R2 =
+            1 - (1 - model.R2) * ((model.nobs - 1) / (model.df_resid));
+        model.t = ttest;
+        model.f = ftest;
+        model.adjust_R2 = adjust_R2;
+        return model;
+      }
+
+      return { ols: ols_wrap };
+    })();
+      // Make it compatible with previous version.
+      jStat.jStat = jStat;
+
+      return jStat;
+    });
+    });
+
+    function get_alpha_sidaks_correction(alpha, variants) {
+        if (variants == 1) {
+            return alpha;
+        }
+
+        return 1 - (Math.pow(1-alpha, 1/variants));
+    }
+
+    // SOLVING FOR POWER
+    function solveforpower_Gtest(data) {
+        var { base_rate, effect_size } = data;
+        var mean_var = base_rate*(1+effect_size);
+        data.variance = base_rate*(1-base_rate) + mean_var*(1-mean_var);
+
+        return solve_for_power(data);
+    }
+
+    function solveforpower_Ttest(data) {
+        var { sd_rate } = data;
+        data.variance = 2*sd_rate**2;
+
+        return solve_for_power(data);
+    }
+
+    function solve_for_power(data) {
+        var {total_sample_size, base_rate, variance, effect_size, alpha, variants, alternative, mu} = data;
+        var sample_size = total_sample_size / (1 + variants);
+
+        var mean_base = base_rate;
+        var mean_var = base_rate * (1+effect_size);
+
+        var mean_diff = mean_var - mean_base;
+        var delta = mean_diff - mu;
+
+        var z = jstat.normal.inv(1-alpha/2, 0, 1);
+        var mean = delta*Math.sqrt(sample_size/variance);
+
+        var power;
+        if (alternative == 'lower') {
+            power = jstat.normal.cdf(jstat.normal.inv(alpha, 0, 1), mean, 1);
+        } else if (alternative == 'greater') {
+            power = 1-jstat.normal.cdf(jstat.normal.inv(1-alpha, 0, 1), mean, 1);
+        } else {
+            power = 1 - (jstat.normal.cdf(z, mean, 1) - jstat.normal.cdf(-z, mean, 1));
+       }
+
+        return power;
+    }
+
+
+    function is_valid_input(data) {
+        var { base_rate, effect_size, alternative, opts, mu } = data;
+        var change = effect_size*base_rate;
+        if (typeof(mu) != 'undefined') {
+            if (alternative == 'greater' && mu >= change) {
+                return false;
+            }
+            if (alternative == 'lower' && mu <= change) {
+                return false;
+            }
+         }
+
+         if (opts && opts.type == 'relative') {
+            if (alternative == 'greater' && opts.threshold >= effect_size) {
+                return false;
+            }
+            if (alternative == 'lower' && opts.threshold <= effect_size) {
+                return false;
+            }
+         }
+
+         if (opts && opts.type == 'absolutePerDay' && opts.calculating == 'days') {
+            if (alternative == 'greater' && opts.threshold/opts.visitors_per_day >= change) {
+                return false;
+            }
+            if (alternative == 'lower' && opts.threshold/opts.visitors_per_day <= change) {
+                return false;
+            }
+         }
+
+         return true;
+    }
+
+    // SOLVING FOR SAMPLE SIZE
+    function solve_quadratic_for_sample({mean_diff, Z, days, threshold, variance}) {
+        var a = mean_diff;
+        if (a == 0) {
+            return threshold*Math.sqrt(days)/(2*Math.sqrt(variance)*Z)
+        }
+
+        var b = Math.sqrt(variance)*Z/Math.sqrt(days);
+        var c = -threshold/2;
+
+        var det = b**2 - 4*a*c;
+        if (det < 0) {
+          return NaN;
+        }
+
+        var sol_h = (-b + Math.sqrt(det)) / (2*a);
+        var sol_l = (-b - Math.sqrt(det)) / (2*a);
+
+        return sol_h >= 0 ? sol_h : sol_l;
+    }
+
+    function solveforsample_Ttest(data){
+        var { sd_rate } = data;
+        data.variance = 2*sd_rate**2;
+        return sample_size_calculation(data);
+    }
+
+    function solveforsample_Gtest(data){
+        var { base_rate, effect_size } = data;
+        var mean_var = base_rate*(1+effect_size);
+        data.variance = base_rate*(1-base_rate) + mean_var*(1-mean_var);
+
+        return sample_size_calculation(data);
+    }
+
+    function sample_size_calculation(data) {
+        var { base_rate, variance, effect_size, alpha, beta, variants, alternative, mu, opts } = data;
+
+        if (!is_valid_input(data)) {
+            return NaN;
+        }
+
+        var mean_base = base_rate;
+        var mean_var = base_rate*(1+effect_size);
+        var mean_diff = mean_var - mean_base;
+
+        var multiplier;
+        var sample_one_group;
+        if (opts && opts.type == 'absolutePerDay') {
+            if (opts.calculating == 'visitorsPerDay') {
+                var Z;
+                if (alternative == "greater") {
+                    Z = jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1);
+                } else if (alternative == "lower") {
+                    Z = jstat.normal.inv(1-beta, 0, 1) - jstat.normal.inv(alpha, 0, 1);
+                } else {
+                    Z = jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1);
+                }
+                var sqrt_visitors_per_day = solve_quadratic_for_sample({mean_diff: mean_diff, Z: Z,
+                    days: opts.days, threshold: opts.threshold, variance: variance});
+                sample_one_group = opts.days*sqrt_visitors_per_day**2;
+            } else {
+                multiplier = variance/(mean_diff*Math.sqrt(opts.visitors_per_day/2) - opts.threshold/(Math.sqrt(2*opts.visitors_per_day)))**2;
+                var days;
+                if (alternative == "greater" || alternative == "lower") {
+                    days = multiplier * (jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1))**2;
+                } else {
+                    days = multiplier * (jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1))**2;
+                }
+                sample_one_group = days*opts.visitors_per_day/2;
+            }
+        } else {
+            multiplier = variance/(mu - mean_diff)**2;
+
             if (alternative == "greater" || alternative == "lower") {
-                days = multiplier * (jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1))**2;
+                sample_one_group = multiplier * (jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1))**2;
             } else {
-                days = multiplier * (jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1))**2;
+                sample_one_group = multiplier * (jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1))**2;
             }
-            sample_one_group = days*opts.visitors_per_day/2;
         }
-    } else {
-        multiplier = variance/(mu - mean_diff)**2;
 
+        return (1+variants)*Math.ceil(sample_one_group);
+    }
+
+
+
+    // SOLVING FOR EFFECT SIZE
+    function solveforeffectsize_Ttest({total_sample_size, base_rate, sd_rate, alpha, beta, variants, alternative, mu}){
+        var sample_size = total_sample_size / (1 + variants);
+        var variance = 2*sd_rate**2;
+
+        var z = jstat.normal.inv(1-beta, 0, 1);
+        var multiplier = Math.sqrt(variance/sample_size);
+        var effect_size;
+        if (alternative == "greater") {
+            effect_size = mu + (z - jstat.normal.inv(alpha, 0, 1)) * multiplier;
+        } else if (alternative == "lower") {
+            effect_size = mu - (z - jstat.normal.inv(alpha, 0, 1)) * multiplier;
+        } else {
+            var delta = (z + jstat.normal.inv(1-alpha/2, 0, 1) )* multiplier;
+            effect_size = mu + delta;
+        }
+
+        return effect_size/base_rate;
+    }
+
+    function solve_quadratic(Z, sample_size, control_rate, mu) {
+        var a = (Z**2 + sample_size) * control_rate**2;
+        var b = -(Z**2) * control_rate - 2 * (control_rate + mu) * sample_size * control_rate;
+        var c = sample_size * (control_rate + mu)**2 - Z**2 * control_rate * (1-control_rate);
+
+        var det = b**2 - 4*a*c;
+        if (det < 0) {
+          return [NaN, NaN];
+        }
+
+        var sol_h = (-b + Math.sqrt(det)) / (2*a);
+        var sol_l = (-b - Math.sqrt(det)) / (2*a);
+
+        return [sol_h, sol_l];
+    }
+
+    function solveforeffectsize_Gtest({total_sample_size, base_rate, alpha, beta, variants, alternative, mu}){
+        var sample_size = total_sample_size / (1 + variants);
+
+        var rel_effect_size;
+        var Z;
+        var solutions;
         if (alternative == "greater" || alternative == "lower") {
-            sample_one_group = multiplier * (jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1))**2;
-        } else {
-            sample_one_group = multiplier * (jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1))**2;
-        }
-    }
-
-    return 2*Math.ceil(sample_one_group);
-}
-
-function solveforsample_Gtest(data){
-    var { base_rate, effect_size, alpha, beta, alternative, mu, opts } = data;
-    if (!is_valid_input(data)) {
-       return NaN;
-    }
-    var mean_base = base_rate;
-    var mean_var = base_rate*(1+effect_size);
-
-    var variance = mean_base*(1-mean_base) + mean_var*(1-mean_var);
-
-    var mean_diff = mean_var - mean_base;
-
-    var multiplier;
-    var sample_one_group;
-    if (opts && opts.type == 'absolutePerDay') {
-        if (opts.calculating == 'visitorsPerDay') {
-            var Z;
-            if (alternative == "greater") {
-                Z = jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1);
-            } else if (alternative == "lower") {
-                Z = jstat.normal.inv(1-beta, 0, 1) - jstat.normal.inv(alpha, 0, 1);
+            Z = jstat.normal.inv(beta, 0, 1) + jstat.normal.inv(alpha, 0, 1);
+            solutions = solve_quadratic(Z, sample_size, base_rate, mu);
+            if (alternative == 'greater') {
+                rel_effect_size = solutions[0] - 1;
             } else {
-                Z = jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1);
+                rel_effect_size = solutions[1] - 1;
             }
-            var sqrt_visitors_per_day = solve_quadratic_for_sample({mean_diff: mean_diff, Z: Z,
-                days: opts.days, threshold: opts.threshold, variance: variance});
-            sample_one_group = opts.days*sqrt_visitors_per_day**2;
         } else {
-            multiplier = variance/(mean_diff*Math.sqrt(opts.visitors_per_day/2) - opts.threshold/(Math.sqrt(2*opts.visitors_per_day)))**2;
-            var days;
-            if (alternative == "greater" || alternative == "lower") {
-                days = multiplier * (jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1))**2;
-            } else {
-                days = multiplier * (jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1))**2;
-            }
-            sample_one_group = days*opts.visitors_per_day/2;
-        }
-    } else {
-        multiplier = variance/(mu - mean_diff)**2;
-
-        if (alternative == "greater" || alternative == "lower") {
-            sample_one_group = multiplier * (jstat.normal.inv(beta, 0, 1) - jstat.normal.inv(1-alpha, 0, 1))**2;
-        } else {
-            sample_one_group = multiplier * (jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1))**2;
-        }
-    }
-
-    return 2*Math.ceil(sample_one_group);
-}
-
-
-
-// SOLVING FOR EFFECT SIZE
-function solveforeffectsize_Ttest({total_sample_size, base_rate, sd_rate, alpha, beta, alternative, mu}){
-    var sample_size = total_sample_size/2;
-    var variance = 2*sd_rate**2;
-
-    var z = jstat.normal.inv(1-beta, 0, 1);
-    var multiplier = Math.sqrt(variance/sample_size);
-    var effect_size;
-    if (alternative == "greater") {
-        effect_size = mu + (z - jstat.normal.inv(alpha, 0, 1)) * multiplier;
-    } else if (alternative == "lower") {
-        effect_size = mu - (z - jstat.normal.inv(alpha, 0, 1)) * multiplier;
-    } else {
-        var delta = (z + jstat.normal.inv(1-alpha/2, 0, 1) )* multiplier;
-        effect_size = mu + delta;
-    }
-
-    return effect_size/base_rate;
-}
-
-function solve_quadratic(Z, sample_size, control_rate, mu) {
-    var a = (Z**2 + sample_size) * control_rate**2;
-    var b = -(Z**2) * control_rate - 2 * (control_rate + mu) * sample_size * control_rate;
-    var c = sample_size * (control_rate + mu)**2 - Z**2 * control_rate * (1-control_rate);
-
-    var det = b**2 - 4*a*c;
-    if (det < 0) {
-      return [NaN, NaN];
-    }
-
-    var sol_h = (-b + Math.sqrt(det)) / (2*a);
-    var sol_l = (-b - Math.sqrt(det)) / (2*a);
-
-    return [sol_h, sol_l];
-}
-
-function solveforeffectsize_Gtest({total_sample_size, base_rate, alpha, beta, alternative, mu}){
-    var sample_size = total_sample_size / 2;
-
-    var rel_effect_size;
-    var Z;
-    var solutions;
-    if (alternative == "greater" || alternative == "lower") {
-        Z = jstat.normal.inv(beta, 0, 1) + jstat.normal.inv(alpha, 0, 1);
-        solutions = solve_quadratic(Z, sample_size, base_rate, mu);
-        if (alternative == 'greater') {
+            Z = jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1);
+            solutions = solve_quadratic(Z, sample_size, base_rate, mu);
             rel_effect_size = solutions[0] - 1;
-        } else {
-            rel_effect_size = solutions[1] - 1;
         }
-    } else {
-        Z = jstat.normal.inv(1-beta, 0, 1) + jstat.normal.inv(1-alpha/2, 0, 1);
-        solutions = solve_quadratic(Z, sample_size, base_rate, mu);
-        rel_effect_size = solutions[0] - 1;
+
+        return rel_effect_size;
     }
 
-    return rel_effect_size;
-}
 
-
-function get_visitors_with_goals({total_sample_size, base_rate}){
-    return total_sample_size * base_rate;
-}
-
-function get_base_rate({total_sample_size, visitors_with_goals}){
-    return visitors_with_goals / total_sample_size;
-}
-
-function get_absolute_impact_in_metric_hash({base_rate, effect_size}) {
-    let value = base_rate * effect_size;
-    return {
-        value,
-        min: base_rate - value,
-        max: base_rate + value
+    function get_visitors_with_goals({total_sample_size, base_rate}){
+        return total_sample_size * base_rate;
     }
-}
 
-function get_relative_impact_from_absolute({base_rate, absolute_effect_size}) {
-    return ((base_rate + absolute_effect_size) / base_rate) - 1
-}
-
-function get_absolute_impact_in_visitors({total_sample_size, base_rate, effect_size}) {
-    let absoluteImpactInMetric = get_absolute_impact_in_metric_hash({base_rate, effect_size}).value;
-    return absoluteImpactInMetric * total_sample_size
-}
-
-function get_relative_impact_from_visitors({total_sample_size, base_rate, visitors}) {
-    let absoluteImpactInMetric = visitors / total_sample_size;
-
-    return get_relative_impact_from_absolute({
-        base_rate,
-        absolute_effect_size: absoluteImpactInMetric
-    })
-}
-
-function get_mu_from_relative_difference ({threshold, base_rate}) {
-    return threshold*base_rate;
-}
-
-function get_mu_from_absolute_per_day ({threshold, visitors_per_day}) {
-    return threshold/visitors_per_day;
-}
-
-function get_alternative ({type}) {
-    let alternative = 'two-sided';
-    if (type == 'noninferiority') {
-        alternative = 'greater';
+    function get_base_rate({total_sample_size, visitors_with_goals}){
+        return visitors_with_goals / total_sample_size;
     }
-    return alternative;
-}
 
-var statFormulas = {
-    gTest: {
-        power: solveforpower_Gtest,
-        sample: solveforsample_Gtest,
-        impact: solveforeffectsize_Gtest
-    },
-    tTest: {
-        power: solveforpower_Ttest,
-        sample: solveforsample_Ttest,
-        impact: solveforeffectsize_Ttest
-    },
-    getVisitorsWithGoals: get_visitors_with_goals,
-    getBaseRate: get_base_rate,
-    getAbsoluteImpactInMetricHash: get_absolute_impact_in_metric_hash,
-    getAbsoluteImpactInVisitors: get_absolute_impact_in_visitors,
-    getRelativeImpactFromAbsolute: get_relative_impact_from_absolute,
-    getRelativeImpactFromVisitors: get_relative_impact_from_visitors,
-    getMuFromRelativeDifference: get_mu_from_relative_difference,
-    getMuFromAbsolutePerDay: get_mu_from_absolute_per_day,
-    getAlternative: get_alternative,
-};
-
-var _incrementalTrials = {
-    getGraphYTicks () {
-        let impact = isNaN(this.impact) ? 0 : this.impact,
-            arr = [impact/1.50, impact/1.25, impact, impact*1.25, impact*1.50];
-
-        return arr
-    },
-    getGraphYTicksFormatted (y) {
-        let sample = this.sample,
-            base = this.base,
-
-            result = statFormulas.getAbsoluteImpactInVisitors({
-                total_sample_size: this.$store.getters.extractValue('sample', sample),
-                base_rate: this.$store.getters.extractValue('base', base),
-                effect_size: this.$store.getters.extractValue('impact', y)
-            });
-
-        return this.$store.getters.displayValue('impactByVisitors', result);
-    },
-    updateClonedValues (clonedObj, value) {
-        clonedObj.effect_size = this.$store.getters.extractValue('impact', value);
-
-        return clonedObj;
-    },
-    getCurrentYValue () {
-        return this.impact
-    },
-    getGraphXTicksFormatted (x) {
-        let { displayValue } = this,
-            result = x / this.runtime;
-
-        result = displayValue('impactByVisitors', result);
-        if (result >= 1000) {
-            result = window.parseInt(result / 1000) + 'k';
+    function get_absolute_impact_in_metric_hash({base_rate, effect_size}) {
+        let value = base_rate * effect_size;
+        return {
+            value,
+            min: base_rate - value,
+            max: base_rate + value
         }
-
-        return result
-    },
-    getGraphXValueForClonedValues (clonedValues) {
-        let {total_sample_size, base_rate, effect_size} = clonedValues,
-
-            impactByVisitor = statFormulas.getAbsoluteImpactInVisitors({
-                total_sample_size,
-                base_rate,
-                effect_size,
-            });
-
-        return this.$store.getters.displayValue('impactByVisitors', impactByVisitor);
     }
-};
 
-var _incrementalTrialsPerDay = {
-    getGraphYTicks () {
-        let impact = isNaN(this.impact) ? 0 : this.impact,
-            arr = [impact/1.50, impact/1.25, impact, impact*1.25, impact*1.50];
-
-        return arr
-    },
-    getGraphYTicksFormatted (y) {
-        let sample = this.sample,
-            base = this.base,
-
-            result = statFormulas.getAbsoluteImpactInVisitors({
-                total_sample_size: this.$store.getters.extractValue('sample', sample / this.runtime),
-                base_rate: this.$store.getters.extractValue('base', base),
-                effect_size: this.$store.getters.extractValue('impact', y)
-            });
-
-        if (isNaN(result)) {
-            result = 0;
-        }
-
-        return this.$store.getters.displayValue('impactByVisitors', result);
-    },
-    updateClonedValues (clonedObj, value) {
-        clonedObj.effect_size = this.$store.getters.extractValue('impact', value);
-
-        return clonedObj;
-    },
-    getCurrentYValue () {
-        return this.impact
-    },
-    getGraphXTicksFormatted (x) {
-        let { displayValue } = this,
-            result = x / this.runtime;
-
-        result = displayValue('impactByVisitors', result);
-        if (result >= 1000) {
-            result = window.parseInt(result / 1000) + 'k';
-        }
-
-        return result
-    },
-    getGraphXValueForClonedValues (clonedValues) {
-        let {total_sample_size, base_rate, effect_size} = clonedValues,
-
-            impactByVisitor = statFormulas.getAbsoluteImpactInVisitors({
-                total_sample_size,
-                base_rate,
-                effect_size,
-            });
-
-        return this.$store.getters.displayValue('impactByVisitors', impactByVisitor);
+    function get_relative_impact_from_absolute({base_rate, absolute_effect_size}) {
+        return ((base_rate + absolute_effect_size) / base_rate) - 1
     }
-};
 
-var _days = {
-    getGraphXTicksFormatted (x) {
-        let samplePerDay = this.sample / this.runtime,
-            result = x / samplePerDay;
-        result = this.$store.getters.displayValue('sample', result);
-        if (result >= 1000) {
-            result = window.parseInt(result / 1000) + 'k';
-        }
-
-        return result
-    },
-    getGraphXValueForClonedValues (clonedValues) {
-        let graphX = 'sample';
-        return this.$store.getters.displayValue(graphX, (this.math[graphX](clonedValues)));
+    function get_absolute_impact_in_visitors({total_sample_size, base_rate, effect_size}) {
+        let absoluteImpactInMetric = get_absolute_impact_in_metric_hash({base_rate, effect_size}).value;
+        return absoluteImpactInMetric * total_sample_size
     }
-};
 
-var _sample = {
-    getGraphXTicksFormatted (x) {
-        let result = x;
+    function get_relative_impact_from_visitors({total_sample_size, base_rate, visitors}) {
+        let absoluteImpactInMetric = visitors / total_sample_size;
 
-        result = this.$store.getters.displayValue('sample', result);
-        if (result >= 1000) {
-            result = window.parseInt(result / 1000) + 'k';
-        }
-
-        return result
+        return get_relative_impact_from_absolute({
+            base_rate,
+            absolute_effect_size: absoluteImpactInMetric
+        })
     }
-};
 
-var _samplePerDay = {
-    getGraphXTicksFormatted (x) {
-        let result = x / this.runtime;
-        result = this.$store.getters.displayValue('sample', result);
-        if (result >= 1000) {
-            result = window.parseInt(result / 1000) + 'k';
-        }
-
-        return result
-    },
-    getGraphXValueForClonedValues (clonedValues) {
-        let graphX = 'sample';
-        return this.$store.getters.displayValue(graphX, (this.math[graphX](clonedValues)));
+    function get_mu_from_relative_difference ({threshold, base_rate}) {
+        return threshold*base_rate;
     }
-};
 
-var _power = {
-    getGraphYTicks () {
-        let arr = [10, 25, 50, 75, 100];
-        return arr
-    },
-    getGraphYTicksFormatted (y) {
-        return `${y}%`
-    },
-    updateClonedValues (clonedObj, value) {
-        clonedObj.beta = 1 - this.$store.getters.extractValue('power', value);
-
-        return clonedObj;
-    },
-    getCurrentYValue () {
-        return this.power
-    },
-    getGraphXTicksFormatted () {
-        // not needed yet
-    },
-};
-
-var _threshold = {
-    getGraphYTicks () {
-        let threshold = isNaN(this.$store.state.nonInferiority.threshold) ? 0 : this.$store.state.nonInferiority.threshold,
-            arr = [threshold/1.50, threshold/1.25, threshold, threshold*1.25, threshold*1.50];
-        return arr
-    },
-    getGraphYTicksFormatted (y) {
-        let num = window.parseFloat(y);
-        if ((num % 1) !== 0) {
-            num = num.toFixed(2);
-        }
-
-        if (isNaN(num)) {
-            num = 0;
-        }
-
-        const suffix = this.$store.state.nonInferiority.selected == 'relative' ? '%' : '';
-
-        return `${num}${suffix}`
-    },
-    getCurrentYValue () {
-        return this.$store.state.nonInferiority.threshold
-    },
-    updateClonedValues (clonedObj, value) {
-        let { getters, state } = this.$store,
-            { customMu, customOpts, customAlternative, customThresholdCorrectedValue } = getters;
-
-        const thresholdCorrectedValue = customThresholdCorrectedValue({
-            threshold: value,
-            selected: state.nonInferiority.selected
-        });
-
-        const mu = customMu({
-            runtime: getters.runtime,
-            thresholdCorrectedValue: thresholdCorrectedValue,
-            visitors_per_day: getters.visitorsPerDay,
-            base_rate: getters.extractValue('base'),
-        });
-
-        const opts = customOpts({
-            selected: state.nonInferiority.selected,
-            lockedField: getters.lockedField,
-            thresholdCorrectedValue: thresholdCorrectedValue,
-            runtime: getters.runtime,
-            visitorsPerDay: getters.visitorsPerDay,
-        });
-
-        const alternative = customAlternative({ type: 'noninferiority' });
-
-        Object.assign(clonedObj, {
-            mu,
-            opts,
-            alternative
-        });
-
-        return clonedObj;
-    },
-};
-
-// name convention is the name used to set the graphY and graphX with a underscore before it
-
-var defaultConfig = {
-    getGraphYTicks () {
-        throw Error (`getGraphYTicks not defined for ${this.graphY}`)
-    },
-    getGraphYTicksFormatted () {
-        throw Error (`getGraphYTicksFormatted not defined for ${this.graphY}`)
-    },
-    getGraphYDataSet ({amount}) {
-        let yTicks = this.getGraphYTicks(),
-            curYValue = this.getCurrentYValue(),
-            firstTick = yTicks[0],
-            lastTick = yTicks[yTicks.length - 1],
-            ratio = (lastTick - firstTick) / amount,
-            result = Array.from(new Array(amount));
-
-        result = result.map((cur, i, arr) => {
-            let value = firstTick + ratio * i;
-            return value
-        });
-
-        // add the current value in case it isn't there
-        result.push(curYValue);
-
-        // sort current value
-        result.sort((a,b) => { return a - b});
-
-        // remove duplicates
-        result = [...new Set(result)];
-
-        return result
-    },
-    updateClonedValues () {
-        throw Error (`updateClonedValues not defined for ${this.graphY}`)
-    },
-    getCurrentYValue () {
-        throw Error (`getCurrentYValue not defined for ${this.graphY}`)
-    },
-    getGraphXTicksFormatted () {
-        throw Error (`getGraphXTicksFormatted not defined for ${this.graphY}`)
-    },
-    getGraphXValueForClonedValues (clonedValues) {
-        if (!this.math[this.graphX]) {
-            throw Error (`getGraphXValueForClonedValues didn't find math formula for ${this.graphX}`)
-        }
-        return this.$store.getters.displayValue(this.graphX, (this.math[this.graphX](clonedValues)));
+    function get_mu_from_absolute_per_day ({threshold, visitors_per_day}) {
+        return threshold/visitors_per_day;
     }
-};
 
+    function get_alternative ({type}) {
+        let alternative = 'two-sided';
+        if (type == 'noninferiority') {
+            alternative = 'greater';
+        }
+        return alternative;
+    }
 
+    var statFormulas = {
+        gTest: {
+            power: solveforpower_Gtest,
+            sample: solveforsample_Gtest,
+            impact: solveforeffectsize_Gtest
+        },
+        tTest: {
+            power: solveforpower_Ttest,
+            sample: solveforsample_Ttest,
+            impact: solveforeffectsize_Ttest
+        },
+        getVisitorsWithGoals: get_visitors_with_goals,
+        getBaseRate: get_base_rate,
+        getAbsoluteImpactInMetricHash: get_absolute_impact_in_metric_hash,
+        getAbsoluteImpactInVisitors: get_absolute_impact_in_visitors,
+        getRelativeImpactFromAbsolute: get_relative_impact_from_absolute,
+        getRelativeImpactFromVisitors: get_relative_impact_from_visitors,
+        getMuFromRelativeDifference: get_mu_from_relative_difference,
+        getMuFromAbsolutePerDay: get_mu_from_absolute_per_day,
+        getAlternative: get_alternative,
+        getCorrectedAlpha: get_alpha_sidaks_correction,
+    };
 
-var graphDataMixin = {
-    beforeCreate () {
-        // register configurations for metric params
-        // this is done to agregate different pieces of configuration that need to work in harmony
-        // for the svg graph
-        Object.assign(this, {
-            _sample:                    Object.assign({}, defaultConfig, _sample),
-            _samplePerDay:              Object.assign({}, defaultConfig, _samplePerDay),
-            _impact:                    Object.assign({}, defaultConfig, _impact),
-            _incrementalTrials:         Object.assign({}, defaultConfig, _incrementalTrials),
-            _power:                     Object.assign({}, defaultConfig, _power),
-            _incrementalTrialsPerDay:   Object.assign({}, defaultConfig, _incrementalTrialsPerDay),
-            _days:                      Object.assign({}, defaultConfig, _days),
-            _threshold:                 Object.assign({}, defaultConfig, _threshold),
-        });
-    },
-    methods: {
+    var _incrementalTrials = {
         getGraphYTicks () {
-            return this._getGraphY().getGraphYTicks.apply(this, []);
+            let impact = isNaN(this.impact) ? 0 : this.impact,
+                arr = [impact/1.50, impact/1.25, impact, impact*1.25, impact*1.50];
+
+            return arr
         },
-        getGraphYTicksFormatted () {
-            return this._getGraphY().getGraphYTicksFormatted.apply(this, [...arguments]);
+        getGraphYTicksFormatted (y) {
+            let sample = this.sample,
+                base = this.base,
+
+                result = statFormulas.getAbsoluteImpactInVisitors({
+                    total_sample_size: this.$store.getters.extractValue('sample', sample),
+                    base_rate: this.$store.getters.extractValue('base', base),
+                    effect_size: this.$store.getters.extractValue('impact', y)
+                });
+
+            return this.$store.getters.displayValue('impactByVisitors', result);
         },
-        getGraphYDataSet () {
-            return this._getGraphY().getGraphYDataSet.apply(this, [...arguments]);
-        },
-        updateClonedValues () {
-            return this._getGraphY().updateClonedValues.apply(this, [...arguments]);
+        updateClonedValues (clonedObj, value) {
+            clonedObj.effect_size = this.$store.getters.extractValue('impact', value);
+
+            return clonedObj;
         },
         getCurrentYValue () {
-            return this._getGraphY().getCurrentYValue.apply(this, [...arguments]);
+            return this.impact
         },
-        getGraphXValueForClonedValues () {
-            return this._getGraphX().getGraphXValueForClonedValues.apply(this, [...arguments]);
+        getGraphXTicksFormatted (x) {
+            let { displayValue } = this,
+                result = x / this.runtime;
+
+            result = displayValue('impactByVisitors', result);
+            if (result >= 1000) {
+                result = window.parseInt(result / 1000) + 'k';
+            }
+
+            return result
+        },
+        getGraphXValueForClonedValues (clonedValues) {
+            let {total_sample_size, base_rate, effect_size} = clonedValues,
+
+                impactByVisitor = statFormulas.getAbsoluteImpactInVisitors({
+                    total_sample_size,
+                    base_rate,
+                    effect_size,
+                });
+
+            return this.$store.getters.displayValue('impactByVisitors', impactByVisitor);
+        }
+    };
+
+    var _incrementalTrialsPerDay = {
+        getGraphYTicks () {
+            let impact = isNaN(this.impact) ? 0 : this.impact,
+                arr = [impact/1.50, impact/1.25, impact, impact*1.25, impact*1.50];
+
+            return arr
+        },
+        getGraphYTicksFormatted (y) {
+            let sample = this.sample,
+                base = this.base,
+
+                result = statFormulas.getAbsoluteImpactInVisitors({
+                    total_sample_size: this.$store.getters.extractValue('sample', sample / this.runtime),
+                    base_rate: this.$store.getters.extractValue('base', base),
+                    effect_size: this.$store.getters.extractValue('impact', y)
+                });
+
+            if (isNaN(result)) {
+                result = 0;
+            }
+
+            return this.$store.getters.displayValue('impactByVisitors', result);
+        },
+        updateClonedValues (clonedObj, value) {
+            clonedObj.effect_size = this.$store.getters.extractValue('impact', value);
+
+            return clonedObj;
+        },
+        getCurrentYValue () {
+            return this.impact
+        },
+        getGraphXTicksFormatted (x) {
+            let { displayValue } = this,
+                result = x / this.runtime;
+
+            result = displayValue('impactByVisitors', result);
+            if (result >= 1000) {
+                result = window.parseInt(result / 1000) + 'k';
+            }
+
+            return result
+        },
+        getGraphXValueForClonedValues (clonedValues) {
+            let {total_sample_size, base_rate, effect_size} = clonedValues,
+
+                impactByVisitor = statFormulas.getAbsoluteImpactInVisitors({
+                    total_sample_size,
+                    base_rate,
+                    effect_size,
+                });
+
+            return this.$store.getters.displayValue('impactByVisitors', impactByVisitor);
+        }
+    };
+
+    var _days = {
+        getGraphXTicksFormatted (x) {
+            let samplePerDay = this.sample / this.runtime,
+                result = x / samplePerDay;
+            result = this.$store.getters.displayValue('sample', result);
+            if (result >= 1000) {
+                result = window.parseInt(result / 1000) + 'k';
+            }
+
+            return result
+        },
+        getGraphXValueForClonedValues (clonedValues) {
+            let graphX = 'sample';
+            return this.$store.getters.displayValue(graphX, (this.math[graphX](clonedValues)));
+        }
+    };
+
+    var _sample = {
+        getGraphXTicksFormatted (x) {
+            let result = x;
+
+            result = this.$store.getters.displayValue('sample', result);
+            if (result >= 1000) {
+                result = window.parseInt(result / 1000) + 'k';
+            }
+
+            return result
+        }
+    };
+
+    var _samplePerDay = {
+        getGraphXTicksFormatted (x) {
+            let result = x / this.runtime;
+            result = this.$store.getters.displayValue('sample', result);
+            if (result >= 1000) {
+                result = window.parseInt(result / 1000) + 'k';
+            }
+
+            return result
+        },
+        getGraphXValueForClonedValues (clonedValues) {
+            let graphX = 'sample';
+            return this.$store.getters.displayValue(graphX, (this.math[graphX](clonedValues)));
+        }
+    };
+
+    var _power = {
+        getGraphYTicks () {
+            let arr = [10, 25, 50, 75, 100];
+            return arr
+        },
+        getGraphYTicksFormatted (y) {
+            return `${y}%`
+        },
+        updateClonedValues (clonedObj, value) {
+            clonedObj.beta = 1 - this.$store.getters.extractValue('power', value);
+
+            return clonedObj;
+        },
+        getCurrentYValue () {
+            return this.power
         },
         getGraphXTicksFormatted () {
-            return this._getGraphX().getGraphXTicksFormatted.apply(this, [...arguments]);
+            // not needed yet
         },
-        _getGraphX () {
-            let graphX = this[`_${this.graphX}`];
+    };
 
-            if (!graphX) {
-                throw Error (`_${this.graphX} is not registered`);
+    var _threshold = {
+        getGraphYTicks () {
+            let threshold = isNaN(this.$store.state.nonInferiority.threshold) ? 0 : this.$store.state.nonInferiority.threshold,
+                arr = [threshold/1.50, threshold/1.25, threshold, threshold*1.25, threshold*1.50];
+            return arr
+        },
+        getGraphYTicksFormatted (y) {
+            let num = window.parseFloat(y);
+            if ((num % 1) !== 0) {
+                num = num.toFixed(2);
             }
 
-            return graphX
-        },
-        _getGraphY () {
-            let graphY = this[`_${this.graphY}`];
-
-            if (!graphY) {
-                throw Error (`_${this.graphY} is not registered`);
+            if (isNaN(num)) {
+                num = 0;
             }
 
-            return graphY
+            const suffix = this.$store.state.nonInferiority.selected == 'relative' ? '%' : '';
+
+            return `${num}${suffix}`
+        },
+        getCurrentYValue () {
+            return this.$store.state.nonInferiority.threshold
+        },
+        updateClonedValues (clonedObj, value) {
+            let { getters, state } = this.$store,
+                { customMu, customOpts, customAlternative, customThresholdCorrectedValue } = getters;
+
+            const thresholdCorrectedValue = customThresholdCorrectedValue({
+                threshold: value,
+                selected: state.nonInferiority.selected
+            });
+
+            const mu = customMu({
+                runtime: getters.runtime,
+                thresholdCorrectedValue: thresholdCorrectedValue,
+                visitors_per_day: getters.visitorsPerDay,
+                base_rate: getters.extractValue('base'),
+            });
+
+            const opts = customOpts({
+                selected: state.nonInferiority.selected,
+                lockedField: getters.lockedField,
+                thresholdCorrectedValue: thresholdCorrectedValue,
+                runtime: getters.runtime,
+                visitorsPerDay: getters.visitorsPerDay,
+            });
+
+            const alternative = customAlternative({ type: 'noninferiority' });
+
+            Object.assign(clonedObj, {
+                mu,
+                opts,
+                alternative
+            });
+
+            return clonedObj;
+        },
+    };
+
+    // name convention is the name used to set the graphY and graphX with a underscore before it
+
+
+    var defaultConfig = {
+        getGraphYTicks () {
+            throw Error (`getGraphYTicks not defined for ${this.graphY}`)
+        },
+        getGraphYTicksFormatted () {
+            throw Error (`getGraphYTicksFormatted not defined for ${this.graphY}`)
+        },
+        getGraphYDataSet ({amount}) {
+            let yTicks = this.getGraphYTicks(),
+                curYValue = this.getCurrentYValue(),
+                firstTick = yTicks[0],
+                lastTick = yTicks[yTicks.length - 1],
+                ratio = (lastTick - firstTick) / amount,
+                result = Array.from(new Array(amount));
+
+            result = result.map((cur, i, arr) => {
+                let value = firstTick + ratio * i;
+                return value
+            });
+
+            // add the current value in case it isn't there
+            result.push(curYValue);
+
+            // sort current value
+            result.sort((a,b) => { return a - b});
+
+            // remove duplicates
+            result = [...new Set(result)];
+
+            return result
+        },
+        updateClonedValues () {
+            throw Error (`updateClonedValues not defined for ${this.graphY}`)
+        },
+        getCurrentYValue () {
+            throw Error (`getCurrentYValue not defined for ${this.graphY}`)
+        },
+        getGraphXTicksFormatted () {
+            throw Error (`getGraphXTicksFormatted not defined for ${this.graphY}`)
+        },
+        getGraphXValueForClonedValues (clonedValues) {
+            if (!this.math[this.graphX]) {
+                throw Error (`getGraphXValueForClonedValues didn't find math formula for ${this.graphX}`)
+            }
+            return this.$store.getters.displayValue(this.graphX, (this.math[this.graphX](clonedValues)));
         }
-    }
-};
+    };
 
-var svgGraphTabItem = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphTypeSynced),expression:"graphTypeSynced"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph"},domProps:{"value":_vm.value,"checked":_vm._q(_vm.graphTypeSynced,_vm.value)},on:{"change":function($event){_vm.graphTypeSynced=_vm.value;}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:_vm.spanClass},[_vm._v(_vm._s(_vm.graphName))])])},staticRenderFns: [],
-    props: ['graphType', 'graphX', 'graphY', 'getMetricDisplayName'],
-    data () {
-        return {
-        }
-    },
-    computed: {
-        graphName () {
-            const graphXDisplay = this.getMetricDisplayName(this.graphX);
-            const graphYDisplay = this.getMetricDisplayName(this.graphY);
-            return `${graphYDisplay} / ${graphXDisplay}`
+
+
+    var graphDataMixin = {
+        beforeCreate () {
+            // register configurations for metric params
+            // this is done to agregate different pieces of configuration that need to work in harmony
+            // for the svg graph
+            Object.assign(this, {
+                _sample:                    Object.assign({}, defaultConfig, _sample),
+                _samplePerDay:              Object.assign({}, defaultConfig, _samplePerDay),
+                _impact:                    Object.assign({}, defaultConfig, _impact),
+                _incrementalTrials:         Object.assign({}, defaultConfig, _incrementalTrials),
+                _power:                     Object.assign({}, defaultConfig, _power),
+                _incrementalTrialsPerDay:   Object.assign({}, defaultConfig, _incrementalTrialsPerDay),
+                _days:                      Object.assign({}, defaultConfig, _days),
+                _threshold:                 Object.assign({}, defaultConfig, _threshold),
+            });
         },
-        value () {
-            return `${this.graphX}-${this.graphY}`
-        },
-        spanClass () {
-            return {
-                'pc-graph-radio-selected': this.graphType == this.value
-            }
-        },
-        graphTypeSynced: {
-            get () {
-                return this.graphType
+        methods: {
+            getGraphYTicks () {
+                return this._getGraphY().getGraphYTicks.apply(this, []);
             },
-            set (newValue) {
-                this.$emit('update:graphType', newValue);
+            getGraphYTicksFormatted () {
+                return this._getGraphY().getGraphYTicksFormatted.apply(this, [...arguments]);
+            },
+            getGraphYDataSet () {
+                return this._getGraphY().getGraphYDataSet.apply(this, [...arguments]);
+            },
+            updateClonedValues () {
+                return this._getGraphY().updateClonedValues.apply(this, [...arguments]);
+            },
+            getCurrentYValue () {
+                return this._getGraphY().getCurrentYValue.apply(this, [...arguments]);
+            },
+            getGraphXValueForClonedValues () {
+                return this._getGraphX().getGraphXValueForClonedValues.apply(this, [...arguments]);
+            },
+            getGraphXTicksFormatted () {
+                return this._getGraphX().getGraphXTicksFormatted.apply(this, [...arguments]);
+            },
+            _getGraphX () {
+                let graphX = this[`_${this.graphX}`];
+
+                if (!graphX) {
+                    throw Error (`_${this.graphX} is not registered`);
+                }
+
+                return graphX
+            },
+            _getGraphY () {
+                let graphY = this[`_${this.graphY}`];
+
+                if (!graphY) {
+                    throw Error (`_${this.graphY} is not registered`);
+                }
+
+                return graphY
             }
         }
-    }
-};
+    };
 
-/*global c3*/
-/*eslint no-undef: "error"*/
+    var svgGraphTabItem = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('label',{staticClass:"pc-graph-radio-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.graphTypeSynced),expression:"graphTypeSynced"}],staticClass:"pc-graph-radio-input",attrs:{"type":"radio","name":"graph"},domProps:{"value":_vm.value,"checked":_vm._q(_vm.graphTypeSynced,_vm.value)},on:{"change":function($event){_vm.graphTypeSynced=_vm.value;}}}),_vm._v(" "),_c('span',{staticClass:"pc-graph-radio-text",class:_vm.spanClass},[_vm._v(_vm._s(_vm.graphName))])])},staticRenderFns: [],
+        props: ['graphType', 'graphX', 'graphY', 'getMetricDisplayName'],
+        data () {
+            return {
+            }
+        },
+        computed: {
+            graphName () {
+                const graphXDisplay = this.getMetricDisplayName(this.graphX);
+                const graphYDisplay = this.getMetricDisplayName(this.graphY);
+                return `${graphYDisplay} / ${graphXDisplay}`
+            },
+            value () {
+                return `${this.graphX}-${this.graphY}`
+            },
+            spanClass () {
+                return {
+                    'pc-graph-radio-selected': this.graphType == this.value
+                }
+            },
+            graphTypeSynced: {
+                get () {
+                    return this.graphType
+                },
+                set (newValue) {
+                    this.$emit('update:graphType', newValue);
+                }
+            }
+        }
+    };
 
-let dataDefault = [
-        ['x', 0, 0, 0, 0, 0, 0],
-        ['Sample', 0, 0, 0, 0, 0],
-        ['Current', null, null, 50]
-    ];
+    let dataDefault = [
+            ['x', 0, 0, 0, 0, 0, 0],
+            ['Sample', 0, 0, 0, 0, 0],
+            ['Current', null, null, 50]
+        ];
 
-let style = document.createElement('style');
+    let style = document.createElement('style');
 
-style.innerHTML = `
+    style.innerHTML = `
     .pc-graph .c3-axis-y-label {
         pointer-events: none;
     }
@@ -5450,207 +5408,207 @@ style.innerHTML = `
     }
 `;
 
-document.querySelector('head').appendChild(style);
+    document.querySelector('head').appendChild(style);
 
 
 
-var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--graph"},[_c('div',{staticClass:"pc-graph-controls"},_vm._l((_vm.graphList),function(graph){return _c('svgGraphTabItem',{key:graph.graphX + '-' + graph.graphY,attrs:{"graphX":graph.graphX,"graphY":graph.graphY,"getMetricDisplayName":_vm.getMetricDisplayName,"graphType":_vm.graphType},on:{"update:graphType":function($event){_vm.graphType=$event;}}})})),_vm._v(" "),_c('div',{ref:"pc-graph-size",staticClass:"pc-graph"},[_c('div',{ref:"pc-graph-wrapper",style:(_vm.style)},[_c('div',{ref:"pc-graph"})])])])},staticRenderFns: [],
-    mixins: [graphDataMixin],
-    props: [],
-    data () {
-        return {
-            width: 100,
-            height: 100,
-            data:  this.dataDefault,
-            graphType: this.getDefaultGraphOption() // x, y
-            // graphX: 'sample' // computed
-            // graphY: 'power' // computed
-        }
-    },
-    computed: {
-        style () {
-            let { width, height } = this;
-
+    var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--graph"},[_c('div',{staticClass:"pc-graph-controls"},_vm._l((_vm.graphList),function(graph){return _c('svgGraphTabItem',{key:graph.graphX + '-' + graph.graphY,attrs:{"graphX":graph.graphX,"graphY":graph.graphY,"getMetricDisplayName":_vm.getMetricDisplayName,"graphType":_vm.graphType},on:{"update:graphType":function($event){_vm.graphType=$event;},"update:graph-type":function($event){_vm.graphType=$event;}}})}),1),_vm._v(" "),_c('div',{ref:"pc-graph-size",staticClass:"pc-graph"},[_c('div',{ref:"pc-graph-wrapper",style:(_vm.style)},[_c('div',{ref:"pc-graph"})])])])},staticRenderFns: [],
+        mixins: [graphDataMixin],
+        props: [],
+        data () {
             return {
-                width: `${width}px`,
-                height: `${height}px`
+                width: 100,
+                height: 100,
+                data:  this.dataDefault,
+                graphType: this.getDefaultGraphOption() // x, y
+                // graphX: 'sample' // computed
+                // graphY: 'power' // computed
             }
         },
-        graphX () {
-            // 'sample'
-            return this.graphType.split('-')[0]
-        },
-        graphY () {
-            // 'power'
-            return this.graphType.split('-')[1]
-        },
-        math () {
-            return this.$store.getters.formulaToSolveProp
-        },
-        isNonInferiorityEnabled () {
-            return this.$store.state.nonInferiority.enabled
-        },
-        sample () {
-            return this.$store.state.attributes.sample
-        },
-        impact () {
-            return this.$store.state.attributes.impact
-        },
-        power () {
-            return this.$store.state.attributes.power
-        },
-        base () {
-            return this.$store.state.attributes.base
-        },
-        falsePosRate () {
-            return this.$store.state.attributes.falsePosRate
-        },
-        sdRate () {
-            return this.$store.state.attributes.sdRate
-        },
-        runtime () {
-            return this.$store.state.attributes.runtime
-        },
-        graphList() {
+        computed: {
+            style () {
+                let { width, height } = this;
 
-            let list = [
-                {
-                    name: 'days-incrementalTrialsPerDay',
-                    cond: !this.isNonInferiorityEnabled
-                },
-                {
-                    name: 'samplePerDay-incrementalTrials',
-                    cond: !this.isNonInferiorityEnabled
-                },
-                {
-                    name: 'sample-impact',
-                    cond: !this.isNonInferiorityEnabled
-                },
-                {
-                    name: 'sample-threshold',
-                    cond: this.isNonInferiorityEnabled
-                },
-                {
-                    name: 'sample-power',
-                    cond: true
-                },
-                {
-                    name: 'samplePerDay-power',
-                    cond: true
-                },
-                {
-                    name: 'impact-power',
-                    cond: !this.isNonInferiorityEnabled
-                },
-            ];
+                return {
+                    width: `${width}px`,
+                    height: `${height}px`
+                }
+            },
+            graphX () {
+                // 'sample'
+                return this.graphType.split('-')[0]
+            },
+            graphY () {
+                // 'power'
+                return this.graphType.split('-')[1]
+            },
+            math () {
+                return this.$store.getters.formulaToSolveProp
+            },
+            isNonInferiorityEnabled () {
+                return this.$store.state.nonInferiority.enabled
+            },
+            sample () {
+                return this.$store.state.attributes.sample
+            },
+            impact () {
+                return this.$store.state.attributes.impact
+            },
+            power () {
+                return this.$store.state.attributes.power
+            },
+            base () {
+                return this.$store.state.attributes.base
+            },
+            falsePosRate () {
+                return this.$store.state.attributes.falsePosRate
+            },
+            sdRate () {
+                return this.$store.state.attributes.sdRate
+            },
+            runtime () {
+                return this.$store.state.attributes.runtime
+            },
+            graphList() {
 
-            return list.filter((obj) => {return obj.cond == true}).map((obj) => {
-                    let [graphX, graphY] = obj.name.split('-');
-                    return {
-                        graphX,
-                        graphY
+                let list = [
+                    {
+                        name: 'days-incrementalTrialsPerDay',
+                        cond: !this.isNonInferiorityEnabled
+                    },
+                    {
+                        name: 'samplePerDay-incrementalTrials',
+                        cond: !this.isNonInferiorityEnabled
+                    },
+                    {
+                        name: 'sample-impact',
+                        cond: !this.isNonInferiorityEnabled
+                    },
+                    {
+                        name: 'sample-threshold',
+                        cond: this.isNonInferiorityEnabled
+                    },
+                    {
+                        name: 'sample-power',
+                        cond: true
+                    },
+                    {
+                        name: 'samplePerDay-power',
+                        cond: true
+                    },
+                    {
+                        name: 'impact-power',
+                        cond: !this.isNonInferiorityEnabled
+                    },
+                ];
+
+                return list.filter((obj) => {return obj.cond == true}).map((obj) => {
+                        let [graphX, graphY] = obj.name.split('-');
+                        return {
+                            graphX,
+                            graphY
+                        }
+                    })
+            }
+        },
+        methods: {
+            getDefaultGraphOption () {
+                let result = 'days-incrementalTrialsPerDay';
+                if (this.$store.state.nonInferiority.enabled) {
+                    result = 'sample-threshold';
+                }
+                return result
+            },
+            resize () {
+                let {width, paddingLeft, paddingRight} = window.getComputedStyle(this.$refs['pc-graph-size']);
+
+                // update svg size
+                this.width = window.parseInt(width) - window.parseInt(paddingLeft) - window.parseInt(paddingRight);
+                this.height = 220;
+            },
+            createYList ({ amount, rate = 10, cur }) { //rate of 10 and amount of 10 will reach from 0 to 100
+                let result = [];
+
+                for (let i = 0; i <= amount; i += 1) {
+                    let y = rate * i,
+                        nextY = rate * (i + 1);
+
+                    result.push(y);
+
+                    if (cur > y && cur < nextY) {
+                        result.push(cur);
                     }
-                })
-        }
-    },
-    methods: {
-        getDefaultGraphOption () {
-            let result = 'days-incrementalTrialsPerDay';
-            if (this.$store.state.nonInferiority.enabled) {
-                result = 'sample-threshold';
-            }
-            return result
-        },
-        resize () {
-            let {width, paddingLeft, paddingRight} = window.getComputedStyle(this.$refs['pc-graph-size']);
-
-            // update svg size
-            this.width = window.parseInt(width) - window.parseInt(paddingLeft) - window.parseInt(paddingRight);
-            this.height = 220;
-        },
-        createYList ({ amount, rate = 10, cur }) { //rate of 10 and amount of 10 will reach from 0 to 100
-            let result = [];
-
-            for (let i = 0; i <= amount; i += 1) {
-                let y = rate * i,
-                    nextY = rate * (i + 1);
-
-                result.push(y);
-
-                if (cur > y && cur < nextY) {
-                    result.push(cur);
-                }
-            }
-
-            return result;
-        },
-        trimInvalidSamples (newData) {
-            let result = newData[0].reduce((prevArr, xValue, i) => {
-
-                if (i == 0) {
-                    prevArr[0] = [];
-                    prevArr[1] = [];
-                    prevArr[2] = [];
                 }
 
-                // i == 0 is the name of the dataset
-                if (i == 0 || (!isNaN(xValue) && isFinite(xValue))) {
-                    prevArr[0].push(newData[0][i]);
-                    prevArr[1].push(newData[1][i]);
-                    prevArr[2].push(newData[2][i]);
-                }
+                return result;
+            },
+            trimInvalidSamples (newData) {
+                let result = newData[0].reduce((prevArr, xValue, i) => {
 
-                return prevArr;
-            }, []);
-            return result;
-        },
-        updateGraphData () {
+                    if (i == 0) {
+                        prevArr[0] = [];
+                        prevArr[1] = [];
+                        prevArr[2] = [];
+                    }
 
-            let clonedValues = this.deepCloneObject(this.$store.getters.convertDisplayedValues),
-                newData = this.deepCloneObject(dataDefault),
-                yList = this.getGraphYDataSet({amount: 10}),
-                curY = this.getCurrentYValue();
+                    // i == 0 is the name of the dataset
+                    if (i == 0 || (!isNaN(xValue) && isFinite(xValue))) {
+                        prevArr[0].push(newData[0][i]);
+                        prevArr[1].push(newData[1][i]);
+                        prevArr[2].push(newData[2][i]);
+                    }
 
-            // erase previous values but keep names of datasets
-            newData[0].length = 1;
-            newData[1].length = 1;
-            newData[2].length = 1;
+                    return prevArr;
+                }, []);
+                return result;
+            },
+            updateGraphData () {
 
-            yList.forEach((yValue, i) => {
+                let clonedValues = this.deepCloneObject(this.$store.getters.convertDisplayedValues),
+                    newData = this.deepCloneObject(dataDefault),
+                    yList = this.getGraphYDataSet({amount: 10}),
+                    curY = this.getCurrentYValue();
 
-                clonedValues = this.updateClonedValues(clonedValues, yValue);
+                // erase previous values but keep names of datasets
+                newData[0].length = 1;
+                newData[1].length = 1;
+                newData[2].length = 1;
 
-                let xValues = this.getGraphXValueForClonedValues(clonedValues, yValue);
+                yList.forEach((yValue, i) => {
 
-                 newData[0][i + 1] = xValues; // x
-                 newData[1][i + 1] = yValue; // line
-                 newData[2][i + 1] = yValue == curY ? yValue : null; // current power dot
-            });
+                    clonedValues = this.updateClonedValues(clonedValues, yValue);
 
-            newData = this.trimInvalidSamples(newData);
+                    let xValues = this.getGraphXValueForClonedValues(clonedValues, yValue);
 
-            this.chart.axis.labels({x: this.updateXLabel(), y: this.updateYLabel()});
+                     newData[0][i + 1] = xValues; // x
+                     newData[1][i + 1] = yValue; // line
+                     newData[2][i + 1] = yValue == curY ? yValue : null; // current power dot
+                });
 
-            this.chart.load({
-                columns: newData
-            });
-        },
-        deepCloneObject (obj) {
-            return JSON.parse(JSON.stringify(obj))
-        },
-        createTooltip (V) {
+                newData = this.trimInvalidSamples(newData);
 
-            return {
-                grouped: false,
-                contents ([{x = 0, value = 0, id = ''}]) {
+                this.chart.axis.labels({x: this.updateXLabel(), y: this.updateYLabel()});
 
-                    let {graphX, graphY, getMetricDisplayName, getGraphXTicksFormatted, getGraphYTicksFormatted} = V,
-                        th = getMetricDisplayName(graphX),
-                        name = getMetricDisplayName(graphY),
-                        xFormatted = getGraphXTicksFormatted(x),
-                        yFormatted = getGraphYTicksFormatted(value);
+                this.chart.load({
+                    columns: newData
+                });
+            },
+            deepCloneObject (obj) {
+                return JSON.parse(JSON.stringify(obj))
+            },
+            createTooltip (V) {
 
-                    return `
+                return {
+                    grouped: false,
+                    contents ([{x = 0, value = 0, id = ''}]) {
+
+                        let {graphX, graphY, getMetricDisplayName, getGraphXTicksFormatted, getGraphYTicksFormatted} = V,
+                            th = getMetricDisplayName(graphX),
+                            name = getMetricDisplayName(graphY),
+                            xFormatted = getGraphXTicksFormatted(x),
+                            yFormatted = getGraphYTicksFormatted(value);
+
+                        return `
                         <table class="c3-tooltip">
                             <tbody>
                                 <tr>
@@ -5667,454 +5625,460 @@ var svgGraph = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c
                             </tbody>
                         </table>
                     `
+                    }
+                }
+            },
+            updateYLabel () {
+                return this.getMetricDisplayName(this.graphY)
+            },
+            updateXLabel () {
+                return this.getMetricDisplayName(this.graphX)
+            },
+            getMetricDisplayName (metric) {
+                return {
+                    sample: 'Sample',
+                    impact: 'Impact',
+                    power: 'Power',
+                    base: 'Base',
+                    falseposrate: 'False Positive Rate',
+                    sdrate: 'Base Standard deviation',
+
+                    samplePerDay: 'Daily Visitors',
+                    incrementalTrials: 'Incremental Trials',
+
+                    days: '# of days',
+                    incrementalTrialsPerDay: 'Inc. Trials per day',
+                    threshold: 'Non Inf. Threshold',
+                }[metric] || ''
+            }
+        },
+        watch: {
+            sample () {
+                this.updateGraphData();
+            },
+            impact () {
+                this.updateGraphData();
+            },
+            power () {
+                this.updateGraphData();
+            },
+            graphY () {
+                this.updateGraphData();
+            },
+            graphX () {
+                this.updateGraphData();
+            },
+            runtime () {
+                this.updateGraphData();
+            },
+            isNonInferiorityEnabled (bool) {
+                if (this.graphList.indexOf(this.graphType) == -1) {
+                    let { graphX, graphY } = this.graphList[0];
+                    this.graphType = `${graphX}-${graphY}`;
                 }
             }
         },
-        updateYLabel () {
-            return this.getMetricDisplayName(this.graphY)
+        mounted () {
+            let {resize, createTooltip} = this,
+                vueInstance = this;
+            resize();
+
+            this.dataDefault = dataDefault;
+
+            this.chart = c3.generate({
+                bindto: this.$refs['pc-graph'],
+                size: {
+                    width: this.width,
+                    height: this.height
+                },
+                legend: {
+                    show: false
+                },
+                data: {
+                    x: 'x',
+                    columns: this.dataDefault,
+                    type: 'area'
+                },
+                grid: {
+                    x: {
+                        show: true
+                    },
+                    y: {
+                        show: true
+                    }
+                },
+                axis: {
+                    x: {
+                        label:  this.updateXLabel(),
+                        tick: {
+                            values (minMax) {
+                                let [min, max] = minMax.map((num) => {return window.parseInt(num)}),
+                                    amount = 7,
+                                    ratio = (max - min) / amount,
+                                    result = new Array(amount + 1);
+
+                                // create the values
+                                result = Array.from(result).map((undef, i) => {
+                                    return (min + (ratio * i)).toFixed(2)
+                                });
+
+                                return result
+                            },
+                            format (x) {
+                                return vueInstance.getGraphXTicksFormatted(x)
+                            }
+                        }
+                    },
+                    y: {
+                        label: this.updateYLabel(),
+                        tick: {
+                            values () {
+                                return vueInstance.getGraphYTicks()
+                            },
+                            format (y) {
+                                return vueInstance.getGraphYTicksFormatted(y)
+                            }
+                        }
+                    }
+                },
+                padding: {
+                    top: 20,
+                    left: 70,
+                    right: 20
+                },
+                tooltip: createTooltip(this)
+            });
+
+            this.updateGraphData();
         },
-        updateXLabel () {
-            return this.getMetricDisplayName(this.graphX)
+        components: {
+            svgGraphTabItem
+        }
+    };
+
+    let validateFunctions = {
+            '*': {
+                // Base rate > 0
+                base: {
+                    fn (value) {
+                        return value > 0
+                    },
+                    defaultVal: 10
+                },
+                // Power be between 0 and 100%(incl)
+                power: {
+                    fn (value) {
+                        return value >= 0 && value <= 100
+                    },
+                    defaultVal: 80
+                },
+                days: {
+                    fn (value) {
+                        return value > 0
+                    },
+                    defaultVal: 14
+                },
+                nonInfThreshold: {
+                    fn (value) {
+                        return value > 0
+                    },
+                    defaultVal: 0
+                },
+                variants: {
+                    fn (value) {
+                        return Number.isInteger(value) && value > 1
+                    },
+                    defaultVal: 1
+                }
+            },
+            gTest: {
+                // Limit Gtest rate input to be between 0.0001% and 99.999%
+                base: {
+                    fn (value) {
+                        return value >= 0.01 && value <= 99.9
+                    }
+                }
+            },
+            tTest: {
+                // Standard deviation > 0
+                sdRate: {
+                    fn (value) {
+                        return value > 0
+                    },
+                    defaultVal: 10
+                }
+            }
         },
-        getMetricDisplayName (metric) {
+        validationCache = {};
+
+    var pcBlockField = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return (_vm.enableEdit)?_c('span',{staticClass:"pc-value-field-wrapper",class:_vm.fieldWrapperClasses,on:{"click":function($event){return _vm.setFocus()}}},[_c('span',{staticClass:"pc-value-formatting pc-value--formatted",class:'pc-value-formatting-' + _vm.fieldProp,style:(_vm.fieldFormattedStyle),attrs:{"aria-hidden":"true","data-prefix":_vm.prefix,"data-suffix":_vm.suffix}},[_c('span',{ref:"pc-formatted-value",staticClass:"pc-value-display"},[_vm._v(_vm._s(_vm.formattedVal))])]),_vm._v(" "),_c('span',{staticClass:"pc-value-formatting",class:'pc-value-formatting-' + _vm.fieldProp,style:(_vm.fieldEditableStyle),attrs:{"data-prefix":_vm.prefix,"data-suffix":_vm.suffix}},[_c('span',{directives:[{name:"initialvalue",rawName:"v-initialvalue"}],ref:"pc-value",staticClass:"pc-value-display",attrs:{"data-test":_vm.isFocused,"contenteditable":!_vm.isReadOnly},on:{"focus":function($event){return _vm.setFocusStyle(true)},"blur":_vm.blur,"input":_vm.updateVal}})])]):_c('span',{staticClass:"pc-value-display pc-field-not-editable"},[_vm._v(" "+_vm._s(_vm.prefix)+" "),_c('strong',[_vm._v(_vm._s(_vm.formattedVal))]),_vm._v(" "+_vm._s(_vm.suffix)+" ")])},staticRenderFns: [],
+        template: '#pc-block-field',
+        props: [
+            'lockedField',
+            'enableEdit',
+            'isReadOnly',
+            'fieldProp',
+            'fieldValue',
+            'prefix',
+            'suffix',
+            'fieldFromBlock'
+        ],
+        data () {
             return {
-                sample: 'Sample',
-                impact: 'Impact',
-                power: 'Power',
-                base: 'Base',
-                falseposrate: 'False Positive Rate',
-                sdrate: 'Base Standard deviation',
-
-                samplePerDay: 'Daily Visitors',
-                incrementalTrials: 'Incremental Trials',
-
-                days: '# of days',
-                incrementalTrialsPerDay: 'Inc. Trials per day',
-                threshold: 'Non Inf. Threshold',
-            }[metric] || ''
-        }
-    },
-    watch: {
-        sample () {
-            this.updateGraphData();
-        },
-        impact () {
-            this.updateGraphData();
-        },
-        power () {
-            this.updateGraphData();
-        },
-        graphY () {
-            this.updateGraphData();
-        },
-        graphX () {
-            this.updateGraphData();
-        },
-        runtime () {
-            this.updateGraphData();
-        },
-        isNonInferiorityEnabled (bool) {
-            if (this.graphList.indexOf(this.graphType) == -1) {
-                let { graphX, graphY } = this.graphList[0];
-                this.graphType = `${graphX}-${graphY}`;
+                islockedFieldSet: (this.lockedField || '').length > 0,
+                val: parseFloat(this.fieldValue),
+                isFocused: false,
             }
-        }
-    },
-    mounted () {
-        let {resize, createTooltip} = this,
-            vueInstance = this;
-        resize();
-
-        this.dataDefault = dataDefault;
-
-        this.chart = c3.generate({
-            bindto: this.$refs['pc-graph'],
-            size: {
-                width: this.width,
-                height: this.height
+        },
+        computed: {
+            isLocked () {
+                return this.lockedField && this.lockedField == this.fieldProp
             },
-            legend: {
-                show: false
-            },
-            data: {
-                x: 'x',
-                columns: this.dataDefault,
-                type: 'area'
-            },
-            grid: {
-                x: {
-                    show: true
-                },
-                y: {
-                    show: true
-                }
-            },
-            axis: {
-                x: {
-                    label:  this.updateXLabel(),
-                    tick: {
-                        values (minMax) {
-                            let [min, max] = minMax.map((num) => {return window.parseInt(num)}),
-                                amount = 7,
-                                ratio = (max - min) / amount,
-                                result = new Array(amount + 1);
+            formattedVal () {
+                let result = this.val;
+                let sep = ',';
 
-                            // create the values
-                            result = Array.from(result).map((undef, i) => {
-                                return (min + (ratio * i)).toFixed(2)
-                            });
+                if (result / 1000 >= 1) {
+                    let [integer, decimal] = (result + '').split('.');
 
-                            return result
-                        },
-                        format (x) {
-                            return vueInstance.getGraphXTicksFormatted(x)
+                    result = integer.split('').reduceRight((prev, cur, i, arr) => {
+                        let resultStr = cur + prev,
+                            iFromLeft = arr.length - i;
+
+                        if (iFromLeft % 3 == 0 && iFromLeft != 0 && i != 0) {
+                            resultStr = sep + resultStr;
                         }
+
+                        return resultStr;
+                    }, '');
+
+                    if (decimal) {
+                        result += '.' + decimal;
+
                     }
-                },
-                y: {
-                    label: this.updateYLabel(),
-                    tick: {
-                        values () {
-                            return vueInstance.getGraphYTicks()
-                        },
-                        format (y) {
-                            return vueInstance.getGraphYTicksFormatted(y)
-                        }
+
+                }
+
+                return result;
+            },
+            fieldWrapperClasses () {
+                let obj = {};
+
+                obj['pc-field--read-only'] = this.isReadOnly;
+                obj['pc-field--focused'] = this.isFocused;
+                obj['pc-field-' + this.fieldProp] = true;
+
+                return obj
+            },
+            fieldFormattedStyle () {
+                let result = {};
+                if (this.isFocused) {
+                    result.display = 'none';
+                }
+
+                return result
+            },
+            fieldEditableStyle () {
+                let result = {};
+                if (!this.isFocused) {
+                    result.opacity = 0;
+                }
+
+                return result
+            },
+            testType () {
+                return this.$store.state.attributes.testType
+            }
+        },
+        methods: {
+            getSanitizedPcValue () {
+                // People will use copy paste. We need some data sanitization
+
+                // remove markup
+                let oldValue = this.$refs['pc-value'].textContent + '',
+                    newValue;
+
+                // remove commas
+                newValue = oldValue.replace(/,/g, '');
+
+                // try to extract numbers from it
+                newValue = parseFloat(newValue);
+
+                newValue = this.validateField(newValue);
+
+                return newValue
+
+            },
+            updateVal () {
+                if (this.enableEdit) {
+                    let value = this.getSanitizedPcValue();
+
+                    if (value != this.val) {
+                        this.val = value;
                     }
                 }
             },
-            padding: {
-                top: 20,
-                left: 70,
-                right: 20
+            formatDisplay () {
+                if (this.enableEdit) {
+                    this.$refs['pc-value'].textContent = this.formatNumberFields(this.getSanitizedPcValue());
+                } else {
+                    this.val = this.formatNumberFields(this.val);
+                }
             },
-            tooltip: createTooltip(this)
-        });
+            formatNumberFields (value) {
+                let result = parseFloat(value);
 
-        this.updateGraphData();
-    },
-    components: {
-        svgGraphTabItem
-    }
-};
+                result = this.validateField(result);
 
-let validateFunctions = {
-        '*': {
-            // Base rate > 0
-            base: {
-                fn (value) {
-                    return value > 0
-                },
-                defaultVal: 10
+                return result || 0
             },
-            // Power be between 0 and 100%(incl)
-            power: {
-                fn (value) {
-                    return value >= 0 && value <= 100
-                },
-                defaultVal: 80
+
+            blur () {
+                this.formatDisplay();
+                this.setFocusStyle(false);
             },
-            days: {
-                fn (value) {
-                    return value > 0
-                },
-                defaultVal: 14
+            setFocusStyle (bool) {
+                this.isFocused = bool;
             },
-            nonInfThreshold: {
-                fn (value) {
-                    return value > 0
-                },
-                defaultVal: 0
-            }
-        },
-        gTest: {
-            // Limit Gtest rate input to be between 0.0001% and 99.999%
-            base: {
-                fn (value) {
-                    return value >= 0.01 && value <= 99.9
+            setFocus () {
+                let el = this.$refs['pc-value'];
+                el.focus();
+            },
+            validateField (value) {
+                let validateConfigList = this.getValidationConfig(),
+                    isValid = true,
+                    result = value;
+
+                if (isNaN(result) || !isFinite(result)) {
+                    result = validateConfigList.defaultVal;
+                }
+
+                if (validateConfigList.fns.length > 0) {
+                    validateConfigList.fns.forEach((fn) => {
+                        if (!fn(result)) {
+                            isValid = false;
+                        }
+                    });
+                }
+
+                if (!isValid) {
+                    result = validateConfigList.defaultVal;
+                }
+
+                return result
+            },
+            getValidationConfig () {
+                let {fieldProp, testtype} = this,
+                    validationTypeCategories,
+                    result;
+
+                if (validationCache[testtype] && validationCache[testtype][fieldProp]) {
+                    return validationCache[testtype][fieldProp]
+                }
+
+                validationTypeCategories = [validateFunctions['*'], validateFunctions[testtype]].filter(Boolean);
+
+                result = validationTypeCategories.reduce((prev, cur) => {
+                    let {fn, defaultVal} = cur[fieldProp] || {};
+
+                    if (typeof fn != 'undefined') {
+                        prev.fns.push(fn);
+                    }
+                    if (typeof defaultVal != 'undefined') {
+                        prev.defaultVal = defaultVal;
+                    }
+                    return prev
+                }, {fns: [], defaultVal: 0});
+
+                //cacheing
+                validationCache[testtype] = validationCache[testtype] || {};
+                validationCache[testtype][fieldProp] = result;
+
+                return result
+            },
+            placeCaretAtEnd (el) {
+                if (typeof window.getSelection != "undefined"
+                        && typeof document.createRange != "undefined") {
+                    var range = document.createRange();
+                    range.selectNodeContents(el);
+                    range.collapse(false);
+                    var sel = window.getSelection();
+                    sel.removeAllRanges();
+                    sel.addRange(range);
+                } else if (typeof document.body.createTextRange != "undefined") {
+                    var textRange = document.body.createTextRange();
+                    textRange.moveToElementText(el);
+                    textRange.collapse(false);
+                    textRange.select();
                 }
             }
+
         },
-        tTest: {
-            // Standard deviation > 0
-            sdRate: {
-                fn (value) {
-                    return value > 0
-                },
-                defaultVal: 10
+        watch: {
+            val (newValue, oldValue) {
+                let newVal = parseFloat(this.formatNumberFields(newValue)),
+                    oldVal = parseFloat(this.formatNumberFields(oldValue));
+
+                if (this.isReadOnly || !this.isFocused || (newVal == oldVal)) {
+                    return;
+                }
+
+                // updating calculations
+                this.$store.dispatch('field:change', {
+                    prop: this.fieldProp,
+                    value: newVal || 0
+                });
+            },
+            fieldValue () {
+                // in case some input field on the same block changes the main math values
+                // we need to update the input fiel
+                let anotherFieldInBlockIsUpdating = !this.isFocused;
+                if (!this.isReadOnly && !anotherFieldInBlockIsUpdating) {
+                    return
+                }
+
+                this.val = this.fieldValue;
+                if (this.enableEdit) {
+                    this.$refs['pc-value'].textContent = this.val;
+                }
+            },
+            isFocused (newValue) {
+                this.$emit('update:focus', {
+                    fieldProp: this.fieldFromBlock || this.fieldProp,
+                    value: newValue
+                });
+            }
+        },
+        directives: {
+            initialvalue: {
+                inserted (el, directive, vnode) {
+                    el.textContent = vnode.context.val;
+                }
             }
         }
     };
-let validationCache = {};
 
-var pcBlockField = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return (_vm.enableEdit)?_c('span',{staticClass:"pc-value-field-wrapper",class:_vm.fieldWrapperClasses,on:{"click":function($event){_vm.setFocus();}}},[_c('span',{staticClass:"pc-value-formatting pc-value--formatted",class:'pc-value-formatting-' + _vm.fieldProp,style:(_vm.fieldFormattedStyle),attrs:{"aria-hidden":"true","data-prefix":_vm.prefix,"data-suffix":_vm.suffix}},[_c('span',{ref:"pc-formatted-value",staticClass:"pc-value-display"},[_vm._v(_vm._s(_vm.formattedVal))])]),_vm._v(" "),_c('span',{staticClass:"pc-value-formatting",class:'pc-value-formatting-' + _vm.fieldProp,style:(_vm.fieldEditableStyle),attrs:{"data-prefix":_vm.prefix,"data-suffix":_vm.suffix}},[_c('span',{directives:[{name:"initialvalue",rawName:"v-initialvalue"}],ref:"pc-value",staticClass:"pc-value-display",attrs:{"data-test":_vm.isFocused,"contenteditable":!_vm.isReadOnly},on:{"focus":function($event){_vm.setFocusStyle(true);},"blur":_vm.blur,"input":_vm.updateVal}})])]):_c('span',{staticClass:"pc-value-display pc-field-not-editable"},[_vm._v(" "+_vm._s(_vm.prefix)+" "),_c('strong',[_vm._v(_vm._s(_vm.formattedVal))]),_vm._v(" "+_vm._s(_vm.suffix)+" ")])},staticRenderFns: [],
-    template: '#pc-block-field',
-    props: [
-        'lockedField',
-        'enableEdit',
-        'isReadOnly',
-        'fieldProp',
-        'fieldValue',
-        'prefix',
-        'suffix',
-        'fieldFromBlock'
-    ],
-    data () {
-        return {
-            islockedFieldSet: (this.lockedField || '').length > 0,
-            val: parseFloat(this.fieldValue),
-            isFocused: false,
-        }
-    },
-    computed: {
-        isLocked () {
-            return this.lockedField && this.lockedField == this.fieldProp
-        },
-        formattedVal () {
-            let result = this.val;
-            let sep = ',';
-
-            if (result / 1000 >= 1) {
-                let [integer, decimal] = (result + '').split('.');
-
-                result = integer.split('').reduceRight((prev, cur, i, arr) => {
-                    let resultStr = cur + prev,
-                        iFromLeft = arr.length - i;
-
-                    if (iFromLeft % 3 == 0 && iFromLeft != 0 && i != 0) {
-                        resultStr = sep + resultStr;
-                    }
-
-                    return resultStr;
-                }, '');
-
-                if (decimal) {
-                    result += '.' + decimal;
-
-                }
-
-            }
-
-            return result;
-        },
-        fieldWrapperClasses () {
-            let obj = {};
-
-            obj['pc-field--read-only'] = this.isReadOnly;
-            obj['pc-field--focused'] = this.isFocused;
-            obj['pc-field-' + this.fieldProp] = true;
-
-            return obj
-        },
-        fieldFormattedStyle () {
-            let result = {};
-            if (this.isFocused) {
-                result.display = 'none';
-            }
-
-            return result
-        },
-        fieldEditableStyle () {
-            let result = {};
-            if (!this.isFocused) {
-                result.opacity = 0;
-            }
-
-            return result
-        },
-        testType () {
-            return this.$store.state.attributes.testType
-        }
-    },
-    methods: {
-        getSanitizedPcValue () {
-            // People will use copy paste. We need some data sanitization
-
-            // remove markup
-            let oldValue = this.$refs['pc-value'].textContent + '',
-                newValue;
-
-            // remove commas
-            newValue = oldValue.replace(/,/g, '');
-
-            // try to extract numbers from it
-            newValue = parseFloat(newValue);
-
-            newValue = this.validateField(newValue);
-
-            return newValue
-
-        },
-        updateVal () {
-            if (this.enableEdit) {
-                let value = this.getSanitizedPcValue();
-
-                if (value != this.val) {
-                    this.val = value;
-                }
+    var pcSvgChain = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('svg',{staticClass:"pc-svg-chain-icon",style:(_vm.svgBgLine),attrs:{"width":"100%","height":"59px","viewBox":`0 0 ${_vm.svgBoxWidth} 59`,"version":"1.1","xmlns":"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink","aria-hidden":"true"}},[_c('g',{attrs:{"id":"Power-Calculator","transform":"translate(-811.000000, -485.000000)"}},[_c('g',{attrs:{"transform":"translate(676.000000, 327.000000)"}},[_c('g',{attrs:{"id":"Chain","transform":"translate(132.000000, 158.000000)"}},[_c('path',{attrs:{"d":"M12.1680332,24.5 L14.5,24.5 C16.709139,24.5 18.5,26.290861 18.5,28.5 L18.5,29.5 C18.5,31.709139 16.709139,33.5 14.5,33.5 L9.5,33.5 C7.290861,33.5 5.5,31.709139 5.5,29.5 L5.5,28.5 C6.20701437,28.5 6.87368104,28.5 7.5,28.5 L7.5,29.5 C7.5,30.6045695 8.3954305,31.5 9.5,31.5 L14.5,31.5 C15.6045695,31.5 16.5,30.6045695 16.5,29.5 L16.5,28.5 C16.5,27.3954305 15.6045695,26.5 14.5,26.5 L13.7237764,26.5 C13.463452,25.7924504 12.944871,25.1257837 12.1680332,24.5 Z","id":"Rectangle-5","fill":_vm.svgFillColor,"fill-rule":"nonzero","transform":"translate(12.000000, 29.000000) scale(-1, -1) translate(-12.000000, -29.000000) "}}),_vm._v(" "),_c('path',{attrs:{"d":"M18.1680332,24.5 L20.5,24.5 C22.709139,24.5 24.5,26.290861 24.5,28.5 L24.5,29.5 C24.5,31.709139 22.709139,33.5 20.5,33.5 L15.5,33.5 C13.290861,33.5 11.5,31.709139 11.5,29.5 L11.5,28.5 C12.2070144,28.5 12.873681,28.5 13.5,28.5 L13.5,29.5 C13.5,30.6045695 14.3954305,31.5 15.5,31.5 L20.5,31.5 C21.6045695,31.5 22.5,30.6045695 22.5,29.5 L22.5,28.5 C22.5,27.3954305 21.6045695,26.5 20.5,26.5 L19.7237764,26.5 C19.463452,25.7924504 18.944871,25.1257837 18.1680332,24.5 Z","id":"Rectangle-5","fill":_vm.svgFillColor,"fill-rule":"nonzero"}})])])])])},staticRenderFns: [],
+        props: ['fieldFromBlock'],
+        data () {
+            return {
+                svgBoxWidth: 26
             }
         },
-        formatDisplay () {
-            if (this.enableEdit) {
-                this.$refs['pc-value'].textContent = this.formatNumberFields(this.getSanitizedPcValue());
-            } else {
-                this.val = this.formatNumberFields(this.val);
-            }
-        },
-        formatNumberFields (value) {
-            let result = parseFloat(value);
-
-            result = this.validateField(result);
-
-            return result || 0
-        },
-
-        blur () {
-            this.formatDisplay();
-            this.setFocusStyle(false);
-        },
-        setFocusStyle (bool) {
-            this.isFocused = bool;
-        },
-        setFocus () {
-            let el = this.$refs['pc-value'];
-            el.focus();
-        },
-        validateField (value) {
-            let validateConfigList = this.getValidationConfig(),
-                isValid = true,
-                result = value;
-
-            if (isNaN(result) || !isFinite(result)) {
-                result = validateConfigList.defaultVal;
-            }
-
-            if (validateConfigList.fns.length > 0) {
-                validateConfigList.fns.forEach((fn) => {
-                    if (!fn(result)) {
-                        isValid = false;
-                    }
-                });
-            }
-
-            if (!isValid) {
-                result = validateConfigList.defaultVal;
-            }
-
-            return result
-        },
-        getValidationConfig () {
-            let {fieldProp, testtype} = this,
-                validationTypeCategories,
-                result;
-
-            if (validationCache[testtype] && validationCache[testtype][fieldProp]) {
-                return validationCache[testtype][fieldProp]
-            }
-
-            validationTypeCategories = [validateFunctions['*'], validateFunctions[testtype]].filter(Boolean);
-
-            result = validationTypeCategories.reduce((prev, cur) => {
-                let {fn, defaultVal} = cur[fieldProp] || {};
-
-                if (typeof fn != 'undefined') {
-                    prev.fns.push(fn);
-                }
-                if (typeof defaultVal != 'undefined') {
-                    prev.defaultVal = defaultVal;
-                }
-                return prev
-            }, {fns: [], defaultVal: 0});
-
-            //cacheing
-            validationCache[testtype] = validationCache[testtype] || {};
-            validationCache[testtype][fieldProp] = result;
-
-            return result
-        },
-        placeCaretAtEnd (el) {
-            if (typeof window.getSelection != "undefined"
-                    && typeof document.createRange != "undefined") {
-                var range = document.createRange();
-                range.selectNodeContents(el);
-                range.collapse(false);
-                var sel = window.getSelection();
-                sel.removeAllRanges();
-                sel.addRange(range);
-            } else if (typeof document.body.createTextRange != "undefined") {
-                var textRange = document.body.createTextRange();
-                textRange.moveToElementText(el);
-                textRange.collapse(false);
-                textRange.select();
-            }
-        }
-
-    },
-    watch: {
-        val (newValue, oldValue) {
-            let newVal = parseFloat(this.formatNumberFields(newValue)),
-                oldVal = parseFloat(this.formatNumberFields(oldValue));
-
-            if (this.isReadOnly || !this.isFocused || (newVal == oldVal)) {
-                return;
-            }
-
-            // updating calculations
-            this.$store.dispatch('field:change', {
-                prop: this.fieldProp,
-                value: newVal || 0
-            });
-        },
-        fieldValue () {
-            // in case some input field on the same block changes the main math values
-            // we need to update the input fiel
-            let anotherFieldInBlockIsUpdating = !this.isFocused;
-            if (!this.isReadOnly && !anotherFieldInBlockIsUpdating) {
-                return
-            }
-
-            this.val = this.fieldValue;
-            if (this.enableEdit) {
-                this.$refs['pc-value'].textContent = this.val;
-            }
-        },
-        isFocused (newValue) {
-            this.$emit('update:focus', {
-                fieldProp: this.fieldFromBlock || this.fieldProp,
-                value: newValue
-            });
-        }
-    },
-    directives: {
-        initialvalue: {
-            inserted (el, directive, vnode) {
-                el.textContent = vnode.context.val;
-            }
-        }
-    }
-};
-
-var pcSvgChain = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('svg',{staticClass:"pc-svg-chain-icon",style:(_vm.svgBgLine),attrs:{"width":"100%","height":"59px","viewBox":`0 0 ${_vm.svgBoxWidth} 59`,"version":"1.1","xmlns":"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink","aria-hidden":"true"}},[_c('g',{attrs:{"id":"Power-Calculator","transform":"translate(-811.000000, -485.000000)"}},[_c('g',{attrs:{"transform":"translate(676.000000, 327.000000)"}},[_c('g',{attrs:{"id":"Chain","transform":"translate(132.000000, 158.000000)"}},[_c('path',{attrs:{"d":"M12.1680332,24.5 L14.5,24.5 C16.709139,24.5 18.5,26.290861 18.5,28.5 L18.5,29.5 C18.5,31.709139 16.709139,33.5 14.5,33.5 L9.5,33.5 C7.290861,33.5 5.5,31.709139 5.5,29.5 L5.5,28.5 C6.20701437,28.5 6.87368104,28.5 7.5,28.5 L7.5,29.5 C7.5,30.6045695 8.3954305,31.5 9.5,31.5 L14.5,31.5 C15.6045695,31.5 16.5,30.6045695 16.5,29.5 L16.5,28.5 C16.5,27.3954305 15.6045695,26.5 14.5,26.5 L13.7237764,26.5 C13.463452,25.7924504 12.944871,25.1257837 12.1680332,24.5 Z","id":"Rectangle-5","fill":_vm.svgFillColor,"fill-rule":"nonzero","transform":"translate(12.000000, 29.000000) scale(-1, -1) translate(-12.000000, -29.000000) "}}),_vm._v(" "),_c('path',{attrs:{"d":"M18.1680332,24.5 L20.5,24.5 C22.709139,24.5 24.5,26.290861 24.5,28.5 L24.5,29.5 C24.5,31.709139 22.709139,33.5 20.5,33.5 L15.5,33.5 C13.290861,33.5 11.5,31.709139 11.5,29.5 L11.5,28.5 C12.2070144,28.5 12.873681,28.5 13.5,28.5 L13.5,29.5 C13.5,30.6045695 14.3954305,31.5 15.5,31.5 L20.5,31.5 C21.6045695,31.5 22.5,30.6045695 22.5,29.5 L22.5,28.5 C22.5,27.3954305 21.6045695,26.5 20.5,26.5 L19.7237764,26.5 C19.463452,25.7924504 18.944871,25.1257837 18.1680332,24.5 Z","id":"Rectangle-5","fill":_vm.svgFillColor,"fill-rule":"nonzero"}})])])])])},staticRenderFns: [],
-    props: ['fieldFromBlock'],
-    data () {
-        return {
-            svgBoxWidth: 26
-        }
-    },
-    computed: {
-        calculateProp () {
-            return this.$store.state.attributes.calculateProp
-        },
-        svgFillColor () {
-            return this.calculateProp == this.fieldFromBlock ? '#E2B634' : '#C1CFD8'
-        },
-        svgBgColor () {
-            return this.calculateProp == this.fieldFromBlock ? '#FEF1CB' : '#F0F0F0'
-        },
-        svgBgLine () {
-            let { svgFillColor, svgBgColor, svgBoxWidth } = this,
-                strokeWidth = 2,
-                stokeStyle = `linear-gradient(
+        computed: {
+            calculateProp () {
+                return this.$store.state.attributes.calculateProp
+            },
+            svgFillColor () {
+                return this.calculateProp == this.fieldFromBlock ? '#E2B634' : '#C1CFD8'
+            },
+            svgBgColor () {
+                return this.calculateProp == this.fieldFromBlock ? '#FEF1CB' : '#F0F0F0'
+            },
+            svgBgLine () {
+                let { svgFillColor, svgBgColor, svgBoxWidth } = this,
+                    strokeWidth = 2,
+                    stokeStyle = `linear-gradient(
                     0deg,
                     transparent,
                     transparent calc(50% - ${strokeWidth/2}px - 1px),
@@ -6123,7 +6087,7 @@ var pcSvgChain = {render: function(){var _vm=this;var _h=_vm.$createElement;var 
                     transparent calc(50% + ${strokeWidth/2}px + 1px),
                     transparent 100%
                 )`,
-                strokeMask = `linear-gradient(
+                    strokeMask = `linear-gradient(
                     90deg,
                     transparent,
                     transparent calc(50% - ${svgBoxWidth/2}px - 1px),
@@ -6134,1097 +6098,1247 @@ var pcSvgChain = {render: function(){var _vm=this;var _h=_vm.$createElement;var 
                 )`;
 
 
-            return `background: ${strokeMask}, ${stokeStyle};`.replace(/\n/g, '');
+                return `background: ${strokeMask}, ${stokeStyle};`.replace(/\n/g, '');
+            }
         }
-    }
-};
+    };
 
-var pcBlock = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div')},staticRenderFns: [],
-    props: ['fieldFromBlock'],
-    data () {
-        return {
-            // isCalculated: this.calculateProp == this.fieldFromBlock,
-        }
-    },
-    computed: {
-        isCalculated: {
-            get () {
-                return this.$store.state.attributes.calculateProp == this.fieldFromBlock
-            },
-            set () {
-                this.$store.dispatch('update:calculateprop', {value: this.fieldFromBlock});
+    var pcBlock = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div')},staticRenderFns: [],
+        props: ['fieldFromBlock'],
+        data () {
+            return {
+                // isCalculated: this.calculateProp == this.fieldFromBlock,
             }
         },
-
-        calculateProp () {
-            return this.$store.state.attributes.calculateProp
-        },
-        testType () {
-            return this.$store.state.attributes.testType
-        }
-    },
-    components: {
-        'pc-block-field': pcBlockField,
-        'pc-svg-chain': pcSvgChain,
-    }
-};
-
-var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--sample",class:{'pc-block-focused': _vm.isBlockFocused == 'sample', 'pc-block-to-calculate': _vm.calculateProp == 'sample'}},[_c('pc-svg-chain',{attrs:{"calculateProp":_vm.calculateProp,"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--sample",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Sample Size ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_vm._m(0),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"sample","fieldValue":_vm.sample,"isReadOnly":_vm.calculateProp == 'sample',"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right pc-value-field--lockable",class:_vm.getLockedStateClass('visitorsPerDay')},[_c('label',[_vm._m(1),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"visitorsPerDay","fieldValue":_vm.visitorsPerDay,"isReadOnly":_vm.lockedField == 'visitorsPerDay',"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit,"lockedField":_vm.lockedField},on:{"update:focus":_vm.updateFocus}})],1),_vm._v(" "),_c('button',{staticClass:"pc-swap-button",attrs:{"type":"button"},on:{"click":_vm.switchLockedField}},[_c('svg',{attrs:{"width":"20px","height":"20px","viewBox":"0 0 20 20","version":"1.1","xmlns":"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink"}},[_c('desc',[_vm._v("Lock "+_vm._s(_vm.lockedField == 'days' ? 'number of days' : 'visitors per day'))]),_vm._v(" "),_c('defs',[_c('circle',{attrs:{"id":"path-1","cx":"13","cy":"13","r":"10"}}),_vm._v(" "),_c('filter',{attrs:{"x":"-5.0%","y":"-5.0%","width":"110.0%","height":"110.0%","filterUnits":"objectBoundingBox","id":"filter-2"}},[_c('feGaussianBlur',{attrs:{"stdDeviation":"0.5","in":"SourceAlpha","result":"shadowBlurInner1"}}),_vm._v(" "),_c('feOffset',{attrs:{"dx":"0","dy":"1","in":"shadowBlurInner1","result":"shadowOffsetInner1"}}),_vm._v(" "),_c('feComposite',{attrs:{"in":"shadowOffsetInner1","in2":"SourceAlpha","operator":"arithmetic","k2":"-1","k3":"1","result":"shadowInnerInner1"}}),_vm._v(" "),_c('feColorMatrix',{attrs:{"values":"0 0 0 0 0.489716199   0 0 0 0 0.489716199   0 0 0 0 0.489716199  0 0 0 0.5 0","type":"matrix","in":"shadowInnerInner1"}})],1)]),_vm._v(" "),_c('g',{attrs:{"id":"Page-1","stroke":"none","stroke-width":"1","fill":"none","fill-rule":"evenodd"}},[_c('g',{attrs:{"id":"Power-Calculator","transform":"translate(-550.000000, -522.000000)"}},[_c('g',{attrs:{"id":"Switcher","transform":"translate(547.000000, 519.000000)"}},[_c('g',{attrs:{"id":"Oval-3"}},[_c('use',{attrs:{"fill":"#EFEFEF","fill-rule":"evenodd","xlink:href":"#path-1"}}),_vm._v(" "),_c('use',{attrs:{"fill":"black","fill-opacity":"1","filter":"url(#filter-2)","xlink:href":"#path-1"}})]),_vm._v(" "),_c('g',{attrs:{"id":"Group","stroke-width":"1","fill-rule":"evenodd","transform":"translate(7.000000, 7.000000)","fill":"#155EAB"}},[_c('path',{attrs:{"d":"M4.5,4.20404051 L4.5,9.9127641 L2.5,9.9127641 L2.5,4.20404051 L0.5,4.20404051 L3.5,0.70872359 L6.5,4.20404051 L4.5,4.20404051 Z","id":"Combined-Shape"}}),_vm._v(" "),_c('path',{attrs:{"d":"M9.5,5.49531692 L9.5,11.2040405 L7.5,11.2040405 L7.5,5.49531692 L5.5,5.49531692 L8.5,2 L11.5,5.49531692 L9.5,5.49531692 Z","id":"Combined-Shape","transform":"translate(8.500000, 6.602020) scale(1, -1) translate(-8.500000, -6.602020) "}})])])])])])])]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right-swap pc-value-field--lockable",class:_vm.getLockedStateClass('days')},[_c('label',[_c('pc-block-field',{attrs:{"fieldProp":"runtime","prefix":"","suffix":" days","fieldValue":_vm.runtime,"isReadOnly":_vm.lockedField == 'days',"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit,"lockedField":_vm.lockedField,"aria-label":"Days"},on:{"update:focus":_vm.updateFocus}})],1)])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Total # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of visitors")])])},function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Daily # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of visitors")])])}],_scopeId: 'data-v-297fe272',
-    props: ['enableEdit', 'isBlockFocused', 'fieldFromBlock'],
-    template: '#sample-comp',
-    extends: pcBlock,
-    data () {
-        return {
-            variants: 2,
-            focusedBlock: ''
-        }
-    },
-    computed: {
-        sample () {
-            return this.$store.state.attributes.sample
-        },
-        visitorsPerDay () {
-            return this.$store.state.attributes.visitorsPerDay
-        },
-        runtime () {
-            return this.$store.state.attributes.runtime
-        },
-        lockedField () {
-            return this.$store.state.attributes.lockedField
-        }
-    },
-    methods: {
-        updateFocus ({fieldProp, value}) {
-
-            if (this.focusedBlock == fieldProp && value === false) {
-                this.focusedBlock = '';
-            } else if (value === true) {
-                this.focusedBlock = fieldProp;
-            }
-
-            this.$emit('update:focus', {
-                fieldProp: this.fieldFromBlock,
-                value: value
-            });
-        },
-        switchLockedField () {
-            this.$store.dispatch('switch:lockedfield');
-        },
-        getLockedStateClass (param) {
-            return this.lockedField == param ? 'pc-value-field--locked' : 'pc-value-field--unlocked'
-        }
-    }
-};
-
-var impactComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--impact",class:{'pc-block-focused': _vm.isBlockFocused, 'pc-block-to-calculate': _vm.calculateProp == 'impact'}},[_c('pc-svg-chain',{attrs:{"calculateProp":_vm.calculateProp,"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--impact",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Impact ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Relative")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"prefix":_vm.isnoninferiority ? '' : '±',"suffix":"%","fieldProp":"impact","fieldValue":_vm.impact,"testType":_vm.testType,"isReadOnly":_vm.calculateProp == 'impact',"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Absolute")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldProp":"impactByMetricValue","suffix":_vm.testType == 'gTest' ? '%' : '',"fieldValue":_vm.impactByMetricDisplay,"testType":_vm.testType,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit,"aria-label":"visitors with goals"},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" going from "+_vm._s(_vm.addPercentToString(_vm.base))+" to either "+_vm._s(_vm.addPercentToString(_vm.impactByMetricMinDisplay))+" or "+_vm._s(_vm.addPercentToString(_vm.impactByMetricMaxDisplay))+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-left"},[_c('label',[_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldProp":"impactByVisitors","fieldValue":_vm.impactByVisitorsDisplay,"testType":_vm.testType,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit && _vm.calculateProp != 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testType == 'gTest' ? ' Incremental trials': ' Incremental change in the metric')+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-right"},[_c('label',[_c('pc-block-field',{attrs:{"fieldProp":"impactByVisitorsPerDay","fieldValue":_vm.impactByVisitorsPerDayDisplay,"testType":_vm.testType,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit && _vm.calculateProp != 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testType == 'gTest' ? ' Incremental trials per day': ' Incremental change in the metric per day')+" ")])],1)])])],1)},staticRenderFns: [],
-    extends: pcBlock,
-    template: '#impact-comp',
-    props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused', 'isnoninferiority'],
-    data () {
-        return {
-            focusedBlock: ''
-        }
-    },
-    computed: {
-        days () {
-            return this.$store.state.attributes.runtime
-        },
-        base () {
-            return this.$store.state.attributes.base
-        },
-        sample () {
-            return this.$store.state.attributes.sample
-        },
-        impact () {
-            return this.$store.state.attributes.impact
-        },
-        testType () {
-            return this.$store.state.attributes.testType
-        },
-        isReadOnly () {
-            return this.calculateProp == 'impact'
-        },
-        impactByMetricDisplay () {
-            return this.$store.getters.impactByMetricDisplay
-        },
-        impactByMetricMinDisplay () {
-            return this.$store.getters.impactByMetricMinDisplay
-        },
-        impactByMetricMaxDisplay () {
-            return this.$store.getters.impactByMetricMaxDisplay
-        },
-        impactByVisitorsDisplay () {
-            return this.$store.getters.impactByVisitorsDisplay
-        },
-        impactByVisitorsPerDayDisplay () {
-            return this.$store.getters.impactByVisitorsPerDayDisplay
-        }
-    },
-    watch: {
-        isReadOnly () {
-            return this.calculateProp == 'impact'
-        }
-    },
-    methods: {
-        updateFocus ({fieldProp, value}) {
-            if (this.focusedBlock == fieldProp && value === false) {
-                this.focusedBlock = '';
-            } else if (value === true) {
-                this.focusedBlock = fieldProp;
-            }
-
-            this.$emit('update:focus', {
-                fieldProp: this.fieldFromBlock,
-                value: value
-            });
-        },
-        addPercentToString (str) {
-            let result = str;
-            if (this.testType == 'gTest') {
-                result += '%';
-            }
-
-            return result
-        }
-    }
-};
-
-var baseComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--base",class:{'pc-block-focused': _vm.focusedblock == 'base'}},[_c('pc-svg-chain',{attrs:{"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),(_vm.testType == 'gTest')?_c('div',{staticClass:"pc-header"},[_vm._v(" Base Rate ")]):_c('div',{staticClass:"pc-header"},[_vm._v(" Base Average ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v(_vm._s(_vm.testType == 'gTest' ? 'Base Rate' : 'Base Average')+" "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("conversion")])]),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"base","suffix":_vm.testType == 'gTest' ? '%' : '',"fieldValue":_vm.base,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_vm._m(0),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"visitorsWithGoals","fieldValue":_vm.visitorsWithGoals,"fieldFromBlock":_vm.fieldFromBlock,"isBlockFocused":_vm.isBlockFocused,"isReadOnly":_vm.isReadOnly,"enableEdit":_vm.enableEdit && this.calculateProp != 'sample'},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),(_vm.testType == 'tTest')?_c('li',{staticClass:"pc-input-item pc-input-sd-rate"},[_c('label',[_c('pc-block-field',{attrs:{"prefix":"±","fieldProp":"sdRate","fieldFromBlock":"base","fieldValue":_vm.sdRate,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v("Base Standard deviation")])],1)]):_vm._e()])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Metric Totals"),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("visitors reached goal")])])}],_scopeId: 'data-v-0d0bef2b',
-    props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused'],
-    extends: pcBlock,
-    template: '#base-comp',
-    data () {
-        return {
-            focusedBlock: '',
-        }
-    },
-    computed: {
-        isReadOnly () {
-            return this.calculateProp == 'base'
-        },
-        base () {
-            return this.$store.state.attributes.base
-        },
-        sdRate () {
-            return this.$store.state.attributes.sdRate
-        },
-        sample () {
-            return this.$store.state.attributes.sample
-        },
-        testType () {
-            return this.$store.state.attributes.testType
-        },
-        visitorsWithGoals () {
-            return this.$store.getters.visitorsWithGoals
-        }
-    },
-    methods: {
-        enableInput () {
-            this.$emit('edit:update', {prop: 'base'});
-        },
-        updateFocus ({fieldProp, value}) {
-            if (this.focusedBlock == fieldProp && value === false) {
-                this.focusedBlock = '';
-            } else if (value === true) {
-                this.focusedBlock = fieldProp;
-            }
-
-            this.$emit('update:focus', {
-                fieldProp: this.fieldFromBlock,
-                value: value
-            });
-        }
-
-    }
-};
-
-var pcTooltip = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-tooltip"},[_c('div',{on:{"mouseover":function($event){_vm.showTooltip(true);},"mouseout":function($event){_vm.showTooltip(false);}}},[_vm._t("text")],2),_vm._v(" "),_c('div',{directives:[{name:"show",rawName:"v-show",value:(_vm.isTooltipShown),expression:"isTooltipShown"}],staticClass:"tooltip-wrapper"},[_vm._t("tooltip")],2)])},staticRenderFns: [],
-    template: '#pc-tooltip',
-    data () {
-        return {
-            isTooltipShown: false
-        }
-    },
-    methods: {
-        showTooltip (bool) {
-            this.isTooltipShown = bool;
-        }
-    }
-
-};
-
-var nonInferiority = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-non-inferiority"},[_c('label',{staticClass:"pc-non-inf-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.enabled),expression:"enabled"}],attrs:{"type":"checkbox"},domProps:{"checked":Array.isArray(_vm.enabled)?_vm._i(_vm.enabled,null)>-1:(_vm.enabled)},on:{"change":function($event){var $$a=_vm.enabled,$$el=$event.target,$$c=$$el.checked?(true):(false);if(Array.isArray($$a)){var $$v=null,$$i=_vm._i($$a,$$v);if($$el.checked){$$i<0&&(_vm.enabled=$$a.concat([$$v]));}else{$$i>-1&&(_vm.enabled=$$a.slice(0,$$i).concat($$a.slice($$i+1)));}}else{_vm.enabled=$$c;}}}}),_vm._v(" Use non inferiority test ")])])},staticRenderFns: [],
-    props: [ 'lockedField' ],
-    data () {
-        return {
-        }
-    },
-    computed: {
-        enabled: {
-            get () {
-                return this.$store.state.nonInferiority.enabled
-            },
-            set (newValue) {
-                this.$store.dispatch('change:noninferiority', {
-                    prop: 'enabled',
-                    value: newValue
-                });
-            }
-        },
-        isRelative () {
-            return this.$store.state.nonInferiority.selected == 'relative'
-        }
-    }
-};
-
-var nonInferiorityComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--noninferiority",class:{'pc-block-focused': _vm.focusedblock == 'noninferiority'}},[_c('pc-svg-chain',{attrs:{"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Non Inferiority ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Acceptable Cost "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v(" "+_vm._s(_vm.isRelative ? 'relative difference of' : 'absolute impact per day of')+" ")])]),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"threshold","suffix":_vm.isRelative ? '%' : '',"fieldValue":_vm.threshold,"fieldFromBlock":_vm.fieldFromBlock,"isBlockFocused":_vm.isBlockFocused,"isReadOnly":_vm.isReadOnly,"enableEdit":true},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v(" Type "+_vm._s(_vm.isRelative ? '' : '(per day)')+" "),_c('small',{staticClass:"pc-input-sub-title"})]),_vm._v(" "),_c('div',{staticClass:"pc-non-inf-select-wrapper"},[_c('select',{directives:[{name:"model",rawName:"v-model",value:(_vm.selected),expression:"selected"}],staticClass:"pc-non-inf-select",on:{"change":function($event){var $$selectedVal = Array.prototype.filter.call($event.target.options,function(o){return o.selected}).map(function(o){var val = "_value" in o ? o._value : o.value;return val}); _vm.selected=$event.target.multiple ? $$selectedVal : $$selectedVal[0];}}},_vm._l((_vm.options),function(option,index){return _c('option',{key:index,domProps:{"value":option.value}},[_vm._v(" "+_vm._s(option.text)+" ")])}))])])]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-left-bottom"},[_c('label',[_vm._m(0),_vm._v(" "),_c('div',{staticClass:"pc-non-inf-select-wrapper"},[_c('select',{directives:[{name:"model",rawName:"v-model",value:(_vm.expectedChange),expression:"expectedChange"}],staticClass:"pc-non-inf-select",on:{"change":function($event){var $$selectedVal = Array.prototype.filter.call($event.target.options,function(o){return o.selected}).map(function(o){var val = "_value" in o ? o._value : o.value;return val}); _vm.expectedChange=$event.target.multiple ? $$selectedVal : $$selectedVal[0];}}},[_c('option',{attrs:{"value":"nochange"}},[_vm._v(" No Change ")]),_vm._v(" "),_c('option',{attrs:{"value":"degradation"}},[_vm._v(" Degradation ")]),_vm._v(" "),_c('option',{attrs:{"value":"improvement"}},[_vm._v(" Improvement ")])])])])])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title no-sub-title"},[_vm._v(" Expected Change "),_c('small',{staticClass:"pc-input-sub-title"})])}],
-    props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused'],
-    extends: pcBlock,
-    template: '#base-comp',
-    data () {
-        return {
-            focusedBlock: '',
-            options: [
-                {
-                    text: 'relative',
-                    value: 'relative'
+        computed: {
+            isCalculated: {
+                get () {
+                    return this.$store.state.attributes.calculateProp == this.fieldFromBlock
                 },
-                {
-                    text: 'absolute',
-                    value: 'absolutePerDay'
+                set () {
+                    this.$store.dispatch('update:calculateprop', {value: this.fieldFromBlock});
                 }
-            ]
-        }
-    },
-    computed: {
-        isReadOnly () {
-            return this.calculateProp == 'base'
-        },
-        enabled () {
-            return this.$store.state.nonInferiority.enabled
-        },
-        threshold () {
-            return this.$store.state.nonInferiority.threshold
-        },
-        isRelative () {
-            return this.$store.state.nonInferiority.selected == 'relative'
-        },
-        selected: {
-            get () {
-                return this.$store.state.nonInferiority.selected
             },
-            set (newValue) {
-                this.$store.dispatch('change:noninferiority', {
-                    prop: 'selected',
-                    value: newValue
-                });
-            }
-        },
-        expectedChange: {
-            get () {
-                return this.$store.state.nonInferiority.expectedChange
+
+            calculateProp () {
+                return this.$store.state.attributes.calculateProp
             },
-            set (newValue) {
-                this.$store.dispatch('field:change', {
-                    prop: 'expectedChange',
-                    value: newValue
-                });
+            testType () {
+                return this.$store.state.attributes.testType
             }
         },
-    },
-    methods: {
-        enableInput () {
-            this.$emit('edit:update', {prop: 'base'});
-        },
-        updateFocus ({fieldProp, value}) {
-            if (this.focusedBlock == fieldProp && value === false) {
-                this.focusedBlock = '';
-            } else if (value === true) {
-                this.focusedBlock = fieldProp;
-            }
-
-            this.$emit('update:focus', {
-                fieldProp: this.fieldFromBlock,
-                value: value
-            });
+        components: {
+            'pc-block-field': pcBlockField,
+            'pc-svg-chain': pcSvgChain,
         }
+    };
 
-    }
-};
-
-var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"power-calculator"},[_c('form',{staticClass:"pc-form",attrs:{"action":"."}},[_c('div',{staticClass:"pc-main-header"},[_c('div',{staticClass:"pc-test-type"},[_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"gTest","checked":"checked"},domProps:{"checked":_vm._q(_vm.testType,"gTest")},on:{"change":function($event){_vm.testType="gTest";}}}),_vm._v(" Binary Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A binary metric is one that can be only two values like 0 or 1, yes or no, converted or not converted ")])]),_vm._v(" "),_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"tTest"},domProps:{"checked":_vm._q(_vm.testType,"tTest")},on:{"change":function($event){_vm.testType="tTest";}}}),_vm._v(" Continuous Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A continuous metric is one that can be any number like time on site or the number of rooms sold ")])])],1),_vm._v(" "),_c('non-inferiority'),_vm._v(" "),_vm._m(0),_vm._v(" "),_c('label',{staticClass:"pc-false-positive"},[_c('pc-block-field',{staticClass:"pc-false-positive-input",class:{ 'pc-top-fields-error': _vm.falsePosRate > 10 },attrs:{"suffix":"%","fieldProp":"falsePosRate","fieldValue":_vm.falsePosRate,"enableEdit":true}}),_vm._v(" false positive rate ")],1),_vm._v(" "),_c('label',{staticClass:"pc-power"},[_c('pc-block-field',{staticClass:"pc-power-input",class:{ 'pc-top-fields-error': _vm.power < 80 },attrs:{"suffix":"%","fieldProp":"power","fieldValue":_vm.power,"enableEdit":true}}),_vm._v(" power ")],1)],1),_vm._v(" "),_c('div',{staticClass:"pc-blocks-wrapper",class:{'pc-blocks-wrapper-ttest': _vm.testType == 'tTest'}},[_c('base-comp',{attrs:{"fieldFromBlock":"base","isBlockFocused":_vm.focusedBlock == 'base',"enableEdit":_vm.enabledMainInputs.base},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('sample-comp',{attrs:{"fieldFromBlock":"sample","enableEdit":_vm.enabledMainInputs.sample,"isBlockFocused":_vm.focusedBlock == 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),(!_vm.nonInferiorityEnabled)?_c('impact-comp',{attrs:{"fieldFromBlock":"impact","enableEdit":_vm.enabledMainInputs.impact,"isBlockFocused":_vm.focusedBlock == 'impact'},on:{"update:focus":_vm.updateFocus}}):_vm._e(),_vm._v(" "),(_vm.nonInferiorityEnabled)?_c('non-inferiority-comp',{attrs:{"fieldFromBlock":"non-inferiority","enableEdit":_vm.enabledMainInputs['non-inferiority'],"isBlockFocused":_vm.focusedBlock == 'non-inferiority'},on:{"update:focus":_vm.updateFocus}}):_vm._e(),_vm._v(" "),_c('svg-graph')],1)])])},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-title"},[_vm._v("Power Calculator "),_c('sup',{staticStyle:{"color":"#F00","font-size":"11px"}},[_vm._v("BETA")])])}],
-    mounted () {
-        // start of application
-        this.$store.dispatch('init:calculator');
-    },
-    props: ['parentmetricdata'],
-    data () {
-        // values if parent component sends them
-        let importedData = this.parentmetricdata || {};
-
-        let data = {
-            focusedBlock: '',
-
-            // false means the editable ones are the secondary mode (metric totals, days&daily trials and absolute impact)
-            enabledMainInputs: {
-                base: true,
-                sample: true,
-                impact: true,
-                power: true,
-                'non-inferiority': true
+    var sampleComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--sample",class:{'pc-block-focused': _vm.isBlockFocused == 'sample', 'pc-block-to-calculate': _vm.calculateProp == 'sample'}},[_c('pc-svg-chain',{attrs:{"calculateProp":_vm.calculateProp,"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--sample",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Sample Size ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs",class:{'pc-inputs-no-grid': _vm.onlyTotalVisitors}},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_vm._m(0),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"sample","fieldValue":_vm.sample,"isReadOnly":_vm.calculateProp == 'sample',"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right pc-value-field--lockable",class:[_vm.getLockedStateClass('visitorsPerDay'), {'pc-hidden': _vm.onlyTotalVisitors}]},[_c('label',[_vm._m(1),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"visitorsPerDay","fieldValue":_vm.visitorsPerDay,"isReadOnly":_vm.lockedField == 'visitorsPerDay',"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit,"lockedField":_vm.lockedField},on:{"update:focus":_vm.updateFocus}})],1),_vm._v(" "),_c('button',{staticClass:"pc-swap-button",attrs:{"type":"button"},on:{"click":_vm.switchLockedField}},[_c('svg',{attrs:{"width":"20px","height":"20px","viewBox":"0 0 20 20","version":"1.1","xmlns":"http://www.w3.org/2000/svg","xmlns:xlink":"http://www.w3.org/1999/xlink"}},[_c('desc',[_vm._v("Lock "+_vm._s(_vm.lockedField == 'days' ? 'number of days' : 'visitors per day'))]),_vm._v(" "),_c('defs',[_c('circle',{attrs:{"id":"path-1","cx":"13","cy":"13","r":"10"}}),_vm._v(" "),_c('filter',{attrs:{"x":"-5.0%","y":"-5.0%","width":"110.0%","height":"110.0%","filterUnits":"objectBoundingBox","id":"filter-2"}},[_c('feGaussianBlur',{attrs:{"stdDeviation":"0.5","in":"SourceAlpha","result":"shadowBlurInner1"}}),_vm._v(" "),_c('feOffset',{attrs:{"dx":"0","dy":"1","in":"shadowBlurInner1","result":"shadowOffsetInner1"}}),_vm._v(" "),_c('feComposite',{attrs:{"in":"shadowOffsetInner1","in2":"SourceAlpha","operator":"arithmetic","k2":"-1","k3":"1","result":"shadowInnerInner1"}}),_vm._v(" "),_c('feColorMatrix',{attrs:{"values":"0 0 0 0 0.489716199   0 0 0 0 0.489716199   0 0 0 0 0.489716199  0 0 0 0.5 0","type":"matrix","in":"shadowInnerInner1"}})],1)]),_vm._v(" "),_c('g',{attrs:{"id":"Page-1","stroke":"none","stroke-width":"1","fill":"none","fill-rule":"evenodd"}},[_c('g',{attrs:{"id":"Power-Calculator","transform":"translate(-550.000000, -522.000000)"}},[_c('g',{attrs:{"id":"Switcher","transform":"translate(547.000000, 519.000000)"}},[_c('g',{attrs:{"id":"Oval-3"}},[_c('use',{attrs:{"fill":"#EFEFEF","fill-rule":"evenodd","xlink:href":"#path-1"}}),_vm._v(" "),_c('use',{attrs:{"fill":"black","fill-opacity":"1","filter":"url(#filter-2)","xlink:href":"#path-1"}})]),_vm._v(" "),_c('g',{attrs:{"id":"Group","stroke-width":"1","fill-rule":"evenodd","transform":"translate(7.000000, 7.000000)","fill":"#155EAB"}},[_c('path',{attrs:{"d":"M4.5,4.20404051 L4.5,9.9127641 L2.5,9.9127641 L2.5,4.20404051 L0.5,4.20404051 L3.5,0.70872359 L6.5,4.20404051 L4.5,4.20404051 Z","id":"Combined-Shape"}}),_vm._v(" "),_c('path',{attrs:{"d":"M9.5,5.49531692 L9.5,11.2040405 L7.5,11.2040405 L7.5,5.49531692 L5.5,5.49531692 L8.5,2 L11.5,5.49531692 L9.5,5.49531692 Z","id":"Combined-Shape","transform":"translate(8.500000, 6.602020) scale(1, -1) translate(-8.500000, -6.602020) "}})])])])])])])]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right-swap pc-value-field--lockable",class:[_vm.getLockedStateClass('days'), {'pc-hidden': _vm.onlyTotalVisitors}]},[_c('label',[_c('pc-block-field',{attrs:{"fieldProp":"runtime","prefix":"","suffix":" days","fieldValue":_vm.runtime,"isReadOnly":_vm.lockedField == 'days',"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit,"lockedField":_vm.lockedField,"aria-label":"Days"},on:{"update:focus":_vm.updateFocus}})],1)])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Total # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of new visitors")])])},function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Daily # "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("of new visitors")])])}],_scopeId: 'data-v-297fe272',
+        props: ['enableEdit', 'isBlockFocused', 'fieldFromBlock'],
+        template: '#sample-comp',
+        extends: pcBlock,
+        data () {
+            return {
+                focusedBlock: ''
             }
-        };
-
-        // mergeComponentData has no array support for now
-        return this.mergeComponentData(data, JSON.parse(JSON.stringify(importedData)));
-    },
-    computed: {
-        disableBaseSecondaryInput () {
-            // only metric total is available and as it depends on sample this
-            // creates a circular dependency
-            // this also forces main input back
-            return this.calculateProp == 'sample'
         },
-
-        // in case parent component needs this information
-        metricData () {
-            let result = {
-                    testType: this.testType,
-                    calculateProp: this.calculateProp,
-                    view: this.view,
-                    lockedField: this.lockedField,
-                    nonInferiority: this.nonInferiority
-                };
-            return JSON.parse(JSON.stringify(result))
+        computed: {
+            sample () {
+                return this.$store.state.attributes.sample
+            },
+            visitorsPerDay () {
+                return this.$store.state.attributes.visitorsPerDay
+            },
+            runtime () {
+                return this.$store.state.attributes.runtime
+            },
+            lockedField () {
+                return this.$store.state.attributes.lockedField
+            },
+            onlyTotalVisitors () {
+                return this.$store.state.attributes.onlyTotalVisitors
+            },
         },
+        methods: {
+            updateFocus ({fieldProp, value}) {
 
-        nonInferiorityEnabled () {
-            return this.$store.state.nonInferiority.enabled
-        },
+                if (this.focusedBlock == fieldProp && value === false) {
+                    this.focusedBlock = '';
+                } else if (value === true) {
+                    this.focusedBlock = fieldProp;
+                }
 
-        nonInferioritySelected () {
-            return this.$store.state.nonInferiority.selected
-        },
+                this.$emit('update:focus', {
+                    fieldProp: this.fieldFromBlock,
+                    value: value
+                });
+            },
+            switchLockedField () {
+                this.$store.dispatch('switch:lockedfield');
+            },
+            getLockedStateClass (param) {
+                return this.lockedField == param ? 'pc-value-field--locked' : 'pc-value-field--unlocked'
+            }
+        }
+    };
 
-        falsePosRate () {
-            return this.$store.state.attributes.falsePosRate
+    var impactComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--impact",class:{'pc-block-focused': _vm.isBlockFocused, 'pc-block-to-calculate': _vm.calculateProp == 'impact'}},[_c('pc-svg-chain',{attrs:{"calculateProp":_vm.calculateProp,"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('label',{staticClass:"pc-calc-radio pc-calc-radio--impact",class:{'pc-calc-radio--active': _vm.isCalculated},attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.isCalculated),expression:"isCalculated"}],attrs:{"type":"radio"},domProps:{"value":true,"checked":_vm._q(_vm.isCalculated,true)},on:{"change":function($event){_vm.isCalculated=true;}}}),_vm._v(" "+_vm._s(_vm.isCalculated ? 'Calculating' : 'Calculate')+" ")]),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Impact ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Relative")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"prefix":_vm.isnoninferiority ? '' : '±',"suffix":"%","fieldProp":"impact","fieldValue":_vm.impact,"testType":_vm.testType,"isReadOnly":_vm.calculateProp == 'impact',"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v("Absolute")]),_vm._v(" "),_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldProp":"impactByMetricValue","suffix":_vm.testType == 'gTest' ? '%' : '',"fieldValue":_vm.impactByMetricDisplay,"testType":_vm.testType,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit,"aria-label":"visitors with goals"},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" going from "+_vm._s(_vm.addPercentToString(_vm.base))+" to either "+_vm._s(_vm.addPercentToString(_vm.impactByMetricMinDisplay))+" or "+_vm._s(_vm.addPercentToString(_vm.impactByMetricMaxDisplay))+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-left"},[_c('label',[_c('pc-block-field',{staticClass:"pc-input-field",attrs:{"fieldProp":"impactByVisitors","fieldValue":_vm.impactByVisitorsDisplay,"testType":_vm.testType,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit && _vm.calculateProp != 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testType == 'gTest' ? ' Incremental trials': ' Incremental change in the metric')+" ")])],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-bottom-right"},[_c('label',[_c('pc-block-field',{attrs:{"fieldProp":"impactByVisitorsPerDay","fieldValue":_vm.impactByVisitorsPerDayDisplay,"testType":_vm.testType,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit && _vm.calculateProp != 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v(" "+_vm._s(_vm.testType == 'gTest' ? ' Incremental trials per day': ' Incremental change in the metric per day')+" ")])],1)])])],1)},staticRenderFns: [],
+        extends: pcBlock,
+        template: '#impact-comp',
+        props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused', 'isnoninferiority'],
+        data () {
+            return {
+                focusedBlock: ''
+            }
         },
-
-        power () {
-            return this.$store.state.attributes.power
-        },
-        testType: {
-            get () {
+        computed: {
+            days () {
+                return this.$store.state.attributes.runtime
+            },
+            base () {
+                return this.$store.state.attributes.base
+            },
+            sample () {
+                return this.$store.state.attributes.sample
+            },
+            impact () {
+                return this.$store.state.attributes.impact
+            },
+            testType () {
                 return this.$store.state.attributes.testType
             },
-            set (newValue) {
-                this.$store.dispatch('field:change', {
-                    prop: 'testType',
-                    value: newValue || 0
-                });
-            }
-        }
-
-    },
-    methods: {
-        updateFocus ({fieldProp, value}) {
-            if (this.focusedBlock == fieldProp && value === false) {
-                this.focusedBlock = '';
-            } else if (value === true) {
-                this.focusedBlock = fieldProp;
+            isReadOnly () {
+                return this.calculateProp == 'impact'
+            },
+            impactByMetricDisplay () {
+                return this.$store.getters.impactByMetricDisplay
+            },
+            impactByMetricMinDisplay () {
+                return this.$store.getters.impactByMetricMinDisplay
+            },
+            impactByMetricMaxDisplay () {
+                return this.$store.getters.impactByMetricMaxDisplay
+            },
+            impactByVisitorsDisplay () {
+                return this.$store.getters.impactByVisitorsDisplay
+            },
+            impactByVisitorsPerDayDisplay () {
+                return this.$store.getters.impactByVisitorsPerDayDisplay
             }
         },
-        mergeComponentData (base, toClone) {
-            // merges default data with imported one from parent component
-            let result = recursive(base, toClone);
-
-            // no array support for now
-            function recursive (baseRef, cloneRef) {
-                Object.keys(cloneRef).forEach((prop) => {
-                    if (typeof cloneRef[prop] == 'object') {
-                        baseRef[prop] = recursive(baseRef[prop], cloneRef[prop]);
-                    } else {
-                        baseRef[prop] = cloneRef[prop];
-                    }
-                });
-
-                return baseRef;
+        watch: {
+            isReadOnly () {
+                return this.calculateProp == 'impact'
             }
-
-            return result;
-        }
-    },
-    watch: {
-        // in case parent component needs this information
-        metricData () {
-            this.$emit('update:metricdata', this.metricData);
-        }
-    },
-    components: {
-        'svg-graph': svgGraph,
-        'pc-block-field': pcBlockField,
-        'pc-tooltip': pcTooltip,
-        'sample-comp': sampleComp,
-        'impact-comp' : impactComp,
-        'base-comp': baseComp,
-        'non-inferiority': nonInferiority,
-        'non-inferiority-comp': nonInferiorityComp
-
-    }
-};
-
-var actions = {
-    'field:change' (context, { prop, value }) {
-        // add validations necessary here
-
-        switch (prop) {
-
-            // these 3 cases will call the same extra action
-            case 'base':
-                context.commit('field:change', { prop, value });
-                if (context.state.nonInferiority.enabled === true && context.state.nonInferiority.selected == 'absolutePerDay') {
-                    context.dispatch('change:noninferiorityimpact');
+        },
+        methods: {
+            updateFocus ({fieldProp, value}) {
+                if (this.focusedBlock == fieldProp && value === false) {
+                    this.focusedBlock = '';
+                } else if (value === true) {
+                    this.focusedBlock = fieldProp;
                 }
 
-                context.dispatch('update:proptocalculate', context.getters.calculatedValues);
-            break;
+                this.$emit('update:focus', {
+                    fieldProp: this.fieldFromBlock,
+                    value: value
+                });
+            },
+            addPercentToString (str) {
+                let result = str;
+                if (this.testType == 'gTest') {
+                    result += '%';
+                }
 
-            case 'sample':
-            case 'runtime':
-            case 'visitorsPerDay':
-                context.dispatch('sample:sideeffect', {prop, value});
-                context.dispatch('update:proptocalculate', context.getters.calculatedValues);
-            break;
-
-            case 'threshold':
-                context.dispatch('threshold:sideeffect', {prop, value});
-                context.dispatch('change:noninferiorityimpact');
-            break;
-
-            case 'impactByMetricValue':
-                context.dispatch('convert:absoluteimpact', {prop, value});
-            break;
-
-            case 'expectedChange':
-                context.commit('field:change', { prop, value });
-                context.dispatch('change:noninferiorityimpact');
-            break;
-
-            case 'visitorsWithGoals':
-                context.dispatch('convert:visitorswithgoals', {prop, value});
-            break;
-
-            default:
-                context.commit('field:change', { prop, value });
-
-                // calculate new value for calculated prop
-                context.dispatch('update:proptocalculate', context.getters.calculatedValues);
-            break;
+                return result
+            }
         }
-    },
-    'change:noninferiority' (context, { prop, value }) {
-        // add validations necessary here
-        context.commit('change:noninferiority', { prop, value });
-        context.dispatch('change:noninferiorityimpact');
+    };
 
-        if (prop == 'enabled') {
+    var baseComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--base",class:{'pc-block-focused': _vm.focusedblock == 'base'}},[_c('pc-svg-chain',{attrs:{"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),(_vm.testType == 'gTest')?_c('div',{staticClass:"pc-header"},[_vm._v(" Base Rate ")]):_c('div',{staticClass:"pc-header"},[_vm._v(" Base Average ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_c('span',{staticClass:"pc-input-title"},[_vm._v(_vm._s(_vm.testType == 'gTest' ? 'Base Rate' : 'Base Average')+" "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("conversion")])]),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"base","suffix":_vm.testType == 'gTest' ? '%' : '',"fieldValue":_vm.base,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_vm._m(0),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"visitorsWithGoals","fieldValue":_vm.visitorsWithGoals,"fieldFromBlock":_vm.fieldFromBlock,"isBlockFocused":_vm.isBlockFocused,"isReadOnly":_vm.isReadOnly,"enableEdit":_vm.enableEdit && this.calculateProp != 'sample'},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),(_vm.testType == 'tTest')?_c('li',{staticClass:"pc-input-item pc-input-sd-rate"},[_c('label',[_c('pc-block-field',{attrs:{"prefix":"±","fieldProp":"sdRate","fieldFromBlock":"base","fieldValue":_vm.sdRate,"isReadOnly":_vm.isReadOnly,"isBlockFocused":_vm.isBlockFocused,"enableEdit":_vm.enableEdit},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('span',{staticClass:"pc-input-details"},[_vm._v("Base Standard deviation")])],1)]):_vm._e()])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Metric Totals"),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("visitors reached goal")])])}],_scopeId: 'data-v-0d0bef2b',
+        props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused'],
+        extends: pcBlock,
+        template: '#base-comp',
+        data () {
+            return {
+                focusedBlock: '',
+            }
+        },
+        computed: {
+            isReadOnly () {
+                return this.calculateProp == 'base'
+            },
+            base () {
+                return this.$store.state.attributes.base
+            },
+            sdRate () {
+                return this.$store.state.attributes.sdRate
+            },
+            sample () {
+                return this.$store.state.attributes.sample
+            },
+            testType () {
+                return this.$store.state.attributes.testType
+            },
+            visitorsWithGoals () {
+                return this.$store.getters.visitorsWithGoals
+            }
+        },
+        methods: {
+            enableInput () {
+                this.$emit('edit:update', {prop: 'base'});
+            },
+            updateFocus ({fieldProp, value}) {
+                if (this.focusedBlock == fieldProp && value === false) {
+                    this.focusedBlock = '';
+                } else if (value === true) {
+                    this.focusedBlock = fieldProp;
+                }
 
-            if (value === true) {
-                context.dispatch('field:change', {
-                    prop: 'lockedField',
-                    value: 'days'
+                this.$emit('update:focus', {
+                    fieldProp: this.fieldFromBlock,
+                    value: value
                 });
             }
-        } else {
-            // update values based on nonInferiority.selected
-            context.dispatch('update:proptocalculate', context.getters.calculatedValues);
+
         }
-    },
-    'change:noninferiorityimpact' (context) {
-        let impactValue = context.getters.nonInferiorityImpact;
+    };
 
-        if (context.state.nonInferiority.enabled === true) {
-            this.__impactBackup = context.state.attributes.impact;
-        } else {
-            impactValue = this.__impactBackup || 0;
-        }
-
-        context.dispatch('field:change', {
-            prop: 'impact',
-            value: impactValue
-        });
-    },
-    'switch:lockedfield' (context) {
-        let newLockedField = context.state.attributes.lockedField == 'days' ? 'visitorsPerDay' : 'days';
-
-        if (context.state.nonInferiority.enabled === true) {
-            newLockedField = 'days';
-        }
-
-        context.commit('switch:lockedfield', {
-            value: newLockedField
-        });
-    },
-    'sample:sideeffect' (context, { prop, value }) {
-        const isSampleCalculated = context.state.attributes.calculateProp == 'sample';
-        let lockedField = context.state.attributes.lockedField;
-
-        let stateMachine = {
-            calculated: {
-                sample: false,
-                runtime: lockedField == 'days',
-                visitorsPerDay: lockedField != 'days',
-            },
-            notCalculated: {
-                sample: true,
-                runtime: lockedField == 'days' && prop == 'sample',
-                visitorsPerDay: lockedField != 'days' && prop == 'sample',
+    var pcTooltip = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-tooltip"},[_c('div',{on:{"mouseover":function($event){return _vm.showTooltip(true)},"mouseout":function($event){return _vm.showTooltip(false)}}},[_vm._t("text")],2),_vm._v(" "),_c('div',{directives:[{name:"show",rawName:"v-show",value:(_vm.isTooltipShown),expression:"isTooltipShown"}],staticClass:"tooltip-wrapper"},[_vm._t("tooltip")],2)])},staticRenderFns: [],
+        template: '#pc-tooltip',
+        data () {
+            return {
+                isTooltipShown: false
             }
-        };
+        },
+        methods: {
+            showTooltip (bool) {
+                this.isTooltipShown = bool;
+            }
+        }
 
-        let input = stateMachine[isSampleCalculated ? 'calculated' : 'notCalculated'];
+    };
 
-        let data = {
-            sample: context.state.attributes.sample,
-            visitorsPerDay: context.state.attributes.visitorsPerDay,
-            runtime: context.state.attributes.runtime
-        };
+    var nonInferiority = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-non-inferiority"},[_c('label',{staticClass:"pc-non-inf-label"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.enabled),expression:"enabled"}],attrs:{"type":"checkbox"},domProps:{"checked":Array.isArray(_vm.enabled)?_vm._i(_vm.enabled,null)>-1:(_vm.enabled)},on:{"change":function($event){var $$a=_vm.enabled,$$el=$event.target,$$c=$$el.checked?(true):(false);if(Array.isArray($$a)){var $$v=null,$$i=_vm._i($$a,$$v);if($$el.checked){$$i<0&&(_vm.enabled=$$a.concat([$$v]));}else{$$i>-1&&(_vm.enabled=$$a.slice(0,$$i).concat($$a.slice($$i+1)));}}else{_vm.enabled=$$c;}}}}),_vm._v(" Use non inferiority test ")])])},staticRenderFns: [],
+        props: [ 'lockedField' ],
+        data () {
+            return {
+            }
+        },
+        computed: {
+            enabled: {
+                get () {
+                    return this.$store.state.nonInferiority.enabled
+                },
+                set (newValue) {
+                    this.$store.dispatch('change:noninferiority', {
+                        prop: 'enabled',
+                        value: newValue
+                    });
+                }
+            },
+            isRelative () {
+                return this.$store.state.nonInferiority.selected == 'relative'
+            }
+        }
+    };
 
-        // override of the prop changed by the action change:fields with the new value
-        data[prop] = value;
+    var nonInferiorityComp = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-block pc-block--noninferiority",class:{'pc-block-focused': _vm.focusedblock == 'noninferiority'}},[_c('pc-svg-chain',{attrs:{"fieldFromBlock":_vm.fieldFromBlock}}),_vm._v(" "),_c('div',{staticClass:"pc-header"},[_vm._v(" Non Inferiority ")]),_vm._v(" "),_c('ul',{staticClass:"pc-inputs"},[_c('li',{staticClass:"pc-input-item pc-input-left"},[_c('label',[_vm._m(0),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"thresholdRelative","suffix":"%","fieldValue":_vm.thresholdRelative,"fieldFromBlock":_vm.fieldFromBlock,"isBlockFocused":_vm.isBlockFocused,"isReadOnly":_vm.isReadOnly,"enableEdit":true},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-right"},[_c('label',[_vm._m(1),_vm._v(" "),_c('pc-block-field',{attrs:{"fieldProp":"thresholdAbsolute","suffix":"","fieldValue":_vm.thresholdAbsolute,"fieldFromBlock":_vm.fieldFromBlock,"isBlockFocused":_vm.isBlockFocused,"isReadOnly":_vm.isReadOnly,"enableEdit":true},on:{"update:focus":_vm.updateFocus}})],1)]),_vm._v(" "),_c('li',{staticClass:"pc-input-item pc-input-left-bottom"},[_c('label',[_vm._m(2),_vm._v(" "),_c('div',{staticClass:"pc-non-inf-select-wrapper"},[_c('select',{directives:[{name:"model",rawName:"v-model",value:(_vm.expectedChange),expression:"expectedChange"}],staticClass:"pc-non-inf-select",on:{"change":function($event){var $$selectedVal = Array.prototype.filter.call($event.target.options,function(o){return o.selected}).map(function(o){var val = "_value" in o ? o._value : o.value;return val}); _vm.expectedChange=$event.target.multiple ? $$selectedVal : $$selectedVal[0];}}},[_c('option',{attrs:{"value":"nochange"}},[_vm._v(" No Change ")]),_vm._v(" "),_c('option',{attrs:{"value":"degradation"}},[_vm._v(" Degradation ")]),_vm._v(" "),_c('option',{attrs:{"value":"improvement"}},[_vm._v(" Improvement ")])])])])])])],1)},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Relative "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("change")])])},function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title"},[_vm._v("Absolute "),_c('small',{staticClass:"pc-input-sub-title"},[_vm._v("impact per day")])])},function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('span',{staticClass:"pc-input-title no-sub-title"},[_vm._v(" Expected Change "),_c('small',{staticClass:"pc-input-sub-title"})])}],
+        props: ['enableEdit', 'fieldFromBlock', 'isBlockFocused'],
+        extends: pcBlock,
+        template: '#base-comp',
+        data () {
+            return {
+                focusedBlock: '',
+                options: [
+                    {
+                        text: 'relative',
+                        value: 'relative'
+                    },
+                    {
+                        text: 'absolute',
+                        value: 'absolutePerDay'
+                    }
+                ]
+            }
+        },
+        computed: {
+            isReadOnly () {
+                return this.calculateProp == 'base'
+            },
+            enabled () {
+                return this.$store.state.nonInferiority.enabled
+            },
+            threshold () {
+                return this.$store.state.nonInferiority.threshold
+            },
+            thresholdRelative () {
+                return this.$store.state.nonInferiority.thresholdRelative
+            },
+            thresholdAbsolute () {
+                return this.$store.state.nonInferiority.thresholdAbsolute
+            },
+            isRelative () {
+                return this.$store.state.nonInferiority.selected == 'relative'
+            },
+            selected: {
+                get () {
+                    return this.$store.state.nonInferiority.selected
+                },
+                set (newValue) {
+                    this.$store.dispatch('change:noninferiority', {
+                        prop: 'selected',
+                        value: newValue
+                    });
+                }
+            },
+            expectedChange: {
+                get () {
+                    return this.$store.state.nonInferiority.expectedChange
+                },
+                set (newValue) {
+                    this.$store.dispatch('field:change', {
+                        prop: 'expectedChange',
+                        value: newValue
+                    });
+                }
+            },
+        },
+        methods: {
+            enableInput () {
+                this.$emit('edit:update', {prop: 'base'});
+            },
+            updateFocus ({fieldProp, value}) {
+                if (this.focusedBlock == fieldProp && value === false) {
+                    this.focusedBlock = '';
+                } else if (value === true) {
+                    this.focusedBlock = fieldProp;
+                }
 
-        context.commit('sample:sideeffect', {
-            prop: prop,
-            value: data[prop]
-        });
+                this.$emit('update:focus', {
+                    fieldProp: this.fieldFromBlock,
+                    value: value
+                });
+            }
 
-        // looks throught the stat machine list and updates all values based on data
-        Object.keys(input).forEach((key) => {
-            if (input[key] == true) {
-                if (key != prop) {
-                    let result = 0;
-                    if (key == 'runtime') {
-                        result = Math.ceil(window.parseInt(data.sample) / data.visitorsPerDay);
-                        result = isNaN(result) ? '-' : result;
+        }
+    };
 
-                    } else if (key == 'visitorsPerDay') {
-                        let isInvalid = false;
-                        result = Math.floor(window.parseInt(data.sample) / data.runtime);
-                        isInvalid = isNaN(result);
+    var powerCalculator = {render: function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"power-calculator"},[_c('form',{staticClass:"pc-form",attrs:{"action":"."}},[_c('div',{staticClass:"pc-main-header"},[_c('div',{staticClass:"pc-controls-left"},[_c('div',{staticClass:"pc-test-type"},[_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"gTest","checked":"checked"},domProps:{"checked":_vm._q(_vm.testType,"gTest")},on:{"change":function($event){_vm.testType="gTest";}}}),_vm._v(" Binomial Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A binomial metric is one that can be only two values like 0 or 1, yes or no, converted or not converted ")])]),_vm._v(" "),_c('pc-tooltip',{staticClass:"pc-test-type-tooltip-wrapper"},[_c('label',{staticClass:"pc-test-type-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.testType),expression:"testType"}],attrs:{"type":"radio","name":"test-mode","value":"tTest"},domProps:{"checked":_vm._q(_vm.testType,"tTest")},on:{"change":function($event){_vm.testType="tTest";}}}),_vm._v(" Continuous Metric ")]),_vm._v(" "),_c('span',{attrs:{"slot":"tooltip"},slot:"tooltip"},[_vm._v(" A continuous metric is one that can be any number like time on site or the number of rooms sold ")])])],1),_vm._v(" "),_c('div',{staticClass:"pc-traffic-mode"},[_c('label',{staticClass:"pc-traffic-mode-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.trafficMode),expression:"trafficMode"}],attrs:{"type":"radio","name":"traffic-mode","value":"daily","checked":"checked","disabled":_vm.nonInferiorityEnabled},domProps:{"checked":_vm._q(_vm.trafficMode,"daily")},on:{"change":function($event){_vm.trafficMode="daily";}}}),_vm._v(" Daily traffic ")]),_vm._v(" "),_c('label',{staticClass:"pc-traffic-mode-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.trafficMode),expression:"trafficMode"}],attrs:{"type":"radio","name":"traffic-mode","value":"total","disabled":_vm.nonInferiorityEnabled},domProps:{"checked":_vm._q(_vm.trafficMode,"total")},on:{"change":function($event){_vm.trafficMode="total";}}}),_vm._v(" Total traffic ")])]),_vm._v(" "),_c('non-inferiority'),_vm._v(" "),_c('div',{staticClass:"pc-comparison-mode"},[_c('label',{staticClass:"pc-comparison-mode-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.comparisonMode),expression:"comparisonMode"}],attrs:{"type":"radio","name":"comparison-mode","value":"all","checked":"checked"},domProps:{"checked":_vm._q(_vm.comparisonMode,"all")},on:{"change":function($event){_vm.comparisonMode="all";}}}),_vm._v(" Base vs All variants ")]),_vm._v(" "),_c('label',{staticClass:"pc-traffic-mode-labels",attrs:{"slot":"text"},slot:"text"},[_c('input',{directives:[{name:"model",rawName:"v-model",value:(_vm.comparisonMode),expression:"comparisonMode"}],attrs:{"type":"radio","name":"comparison-mode","value":"one"},domProps:{"checked":_vm._q(_vm.comparisonMode,"one")},on:{"change":function($event){_vm.comparisonMode="one";}}}),_vm._v(" Base vs One variant ")])])],1),_vm._v(" "),_vm._m(0),_vm._v(" "),_c('div',{staticClass:"pc-controls-right"},[_c('label',{staticClass:"pc-variants"},[_c('pc-block-field',{staticClass:"pc-variants-input",attrs:{"fieldProp":"variants","prefix":"base + ","fieldValue":_vm.variants,"enableEdit":true}}),_vm._v(" variant"+_vm._s(_vm.variants > 1 ? 's' : '')+" ")],1),_vm._v(" "),_c('label',{staticClass:"pc-false-positive"},[_c('pc-block-field',{staticClass:"pc-false-positive-input",class:{ 'pc-top-fields-error': _vm.falsePosRate > 10 },attrs:{"suffix":"%","fieldProp":"falsePosRate","fieldValue":_vm.falsePosRate,"enableEdit":true}}),_vm._v(" false positive rate ")],1),_vm._v(" "),_c('label',{staticClass:"pc-power"},[_c('pc-block-field',{staticClass:"pc-power-input",class:{ 'pc-top-fields-error': _vm.power < 80 },attrs:{"suffix":"%","fieldProp":"power","fieldValue":_vm.power,"enableEdit":true}}),_vm._v(" power ")],1)])]),_vm._v(" "),_c('div',{staticClass:"pc-blocks-wrapper",class:{'pc-blocks-wrapper-ttest': _vm.testType == 'tTest'}},[_c('base-comp',{attrs:{"fieldFromBlock":"base","isBlockFocused":_vm.focusedBlock == 'base',"enableEdit":_vm.enabledMainInputs.base},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),_c('sample-comp',{attrs:{"fieldFromBlock":"sample","enableEdit":_vm.enabledMainInputs.sample,"isBlockFocused":_vm.focusedBlock == 'sample'},on:{"update:focus":_vm.updateFocus}}),_vm._v(" "),(!_vm.nonInferiorityEnabled)?_c('impact-comp',{attrs:{"fieldFromBlock":"impact","enableEdit":_vm.enabledMainInputs.impact,"isBlockFocused":_vm.focusedBlock == 'impact'},on:{"update:focus":_vm.updateFocus}}):_vm._e(),_vm._v(" "),(_vm.nonInferiorityEnabled)?_c('non-inferiority-comp',{attrs:{"fieldFromBlock":"non-inferiority","enableEdit":_vm.enabledMainInputs['non-inferiority'],"isBlockFocused":_vm.focusedBlock == 'non-inferiority'},on:{"update:focus":_vm.updateFocus}}):_vm._e(),_vm._v(" "),_c('svg-graph')],1)])])},staticRenderFns: [function(){var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('div',{staticClass:"pc-title"},[_vm._v("Power Calculator "),_c('sup',{staticStyle:{"color":"#F00","font-size":"11px"}},[_vm._v("BETA")])])}],
+        mounted () {
+            // start of application
+            this.$store.dispatch('init:calculator');
+        },
+        props: ['parentmetricdata'],
+        data () {
+            // values if parent component sends them
+            let importedData = this.parentmetricdata || {};
 
-                        result = isNaN(result) || isInvalid ? '-' : result;
+            let data = {
+                focusedBlock: '',
 
-                    } else if (key == 'sample') {
-                        let isInvalid = false;
-                        result = Math.ceil(data.runtime * data.visitorsPerDay);
-                        isInvalid = isNaN(result);
+                // false means the editable ones are the secondary mode (metric totals, days&daily trials and absolute impact)
+                enabledMainInputs: {
+                    base: true,
+                    sample: true,
+                    impact: true,
+                    power: true,
+                    'non-inferiority': true
+                }
+            };
 
-                        result = isInvalid ? '-' : result;
+            // mergeComponentData has no array support for now
+            return this.mergeComponentData(data, JSON.parse(JSON.stringify(importedData)));
+        },
+        computed: {
+            disableBaseSecondaryInput () {
+                // only metric total is available and as it depends on sample this
+                // creates a circular dependency
+                // this also forces main input back
+                return this.calculateProp == 'sample'
+            },
+
+            // in case parent component needs this information
+            metricData () {
+                let result = {
+                        testType: this.testType,
+                        calculateProp: this.calculateProp,
+                        view: this.view,
+                        lockedField: this.lockedField,
+                        nonInferiority: this.nonInferiority,
+                        comparisonMode: this.comparisonMode,
+                    };
+                return JSON.parse(JSON.stringify(result))
+            },
+
+            nonInferiorityEnabled () {
+                return this.$store.state.nonInferiority.enabled
+            },
+
+            nonInferioritySelected () {
+                return this.$store.state.nonInferiority.selected
+            },
+
+            falsePosRate () {
+                return this.$store.state.attributes.falsePosRate
+            },
+            power () {
+                return this.$store.state.attributes.power
+            },
+            variants () {
+                return this.$store.state.attributes.variants
+            },
+            comparisonMode: {
+                get () {
+                    return this.$store.state.attributes.comparisonMode
+                },
+                set (newValue) {
+                    this.$store.dispatch('field:change', {
+                        prop: 'comparisonMode',
+                        value: newValue
+                    });
+                }
+            },
+            testType: {
+                get () {
+                    return this.$store.state.attributes.testType
+                },
+                set (newValue) {
+                    this.$store.dispatch('field:change', {
+                        prop: 'testType',
+                        value: newValue || 0
+                    });
+                }
+            },
+            trafficMode: {
+                get () {
+                    if (this.$store.state.attributes.onlyTotalVisitors) {
+                        return 'total';
                     }
 
-                    context.commit('sample:sideeffect', {
-                        prop: key,
-                        value: result
+                    return 'daily';
+                },
+                set (newValue) {
+                    this.$store.dispatch('field:change', {
+                        prop: 'onlyTotalVisitors',
+                        value: newValue == 'total'
                     });
                 }
             }
-        });
-    },
-    'threshold:sideeffect' (context, { prop, value }) {
-        context.commit('field:change', { prop, value });
-        if (context.state.attributes.calculateProp == 'sample') {
-            context.dispatch('sample:sideeffect', context.getters.calculatedValues);
-        }
-        context.dispatch('update:proptocalculate', context.getters.calculatedValues);
-    },
-    'update:calculateprop' (context, { value }) {
-        context.commit('update:calculateprop', { value });
-    },
-    'convert:absoluteimpact' (context, { prop, value }) {
-        let impactObj = {
-                prop: 'impact',
-                value: context.getters.displayValue('impact', context.getters.calculateImpactFromAbsoluteImpact(value))
-            };
-
-        context.dispatch('field:change', impactObj);
-    },
-    'convert:visitorswithgoals' (context, { prop, value }) {
-        let newValue = context.getters.baseFromVisitorsWithGoals(value);
-
-        context.dispatch('field:change', {
-            prop: 'base',
-            value: newValue
-        });
-    },
-    'update:proptocalculate' (context) {
-        let calculatedObj = context.getters.calculatedValues;
-        context.commit('update:proptocalculate', calculatedObj);
-
-        if (calculatedObj.prop == 'sample') {
-            // apply side effects
-            context.dispatch('sample:sideeffect', calculatedObj);
-        }
-    },
-    'init:calculator' (context) {
-        if (context.state.nonInferiority.enabled) {
-            context.dispatch('change:noninferiorityimpact');
-        }
-
-        if (context.state.attributes.calculateProp != 'sample') {
-            context.dispatch('field:change', {
-                prop: 'sample',
-                value: context.state.attributes.sample
-            });
-        }
-
-        context.dispatch('update:proptocalculate');
-    },
-    'test:reset' (context, stateObj) {
-        context.commit('test:reset', stateObj);
-        context.dispatch('init:calculator');
-    }
-};
-
-var mutations = {
-        'update:proptocalculate' (state, {prop, value}) {
-            state.attributes[prop] = value;
-        }
-};
-
-var attributes = {
-    state:{
-        testType: 'gTest',
-        calculateProp: 'sample', // power, impact, base, sample
-
-        sample: 561364,
-        base: 10,
-        impact: 2,
-        power: 80,
-        falsePosRate: 10,
-        sdRate: 10,
-
-        runtime: 14, //days
-
-        visitorsPerDay: Math.ceil(561364 / 14),
-        lockedField: 'days'
-    },
-
-    mutations: {
-        'field:change' (state, { prop, value }) {
-            if (typeof state[prop] != 'undefined') {
-                state[prop] = value;
-            }
         },
-        'sample:sideeffect' (state, { prop, value }) {
-            state[prop] = value;
-        },
-        'switch:lockedfield' (state, { value }) {
-            state.lockedField = value;
-        },
-        'update:calculateprop' (state, { value }) {
-            state.calculateProp = value;
-        },
-        'test:reset' (state, stateObj) {
-            let props = Object.keys(state);
-            props.forEach((prop) => {
-                if (prop in stateObj) {
-                    state[prop] = stateObj[prop];
+        methods: {
+            updateFocus ({fieldProp, value}) {
+                if (this.focusedBlock == fieldProp && value === false) {
+                    this.focusedBlock = '';
+                } else if (value === true) {
+                    this.focusedBlock = fieldProp;
                 }
-            });
-        }
-    },
+            },
+            mergeComponentData (base, toClone) {
+                // merges default data with imported one from parent component
+                let result = recursive(base, toClone);
 
-    getters: {
-        visitorsPerDay (state, getters) {
-            return state.visitorsPerDay
-        },
-        lockedField (state, getters) {
-            return state.lockedField
-        },
-        runtime (state, getters) {
-            return state.runtime
-        },
-        visitorsWithGoals (state, getters) {
-            let result = statFormulas.getVisitorsWithGoals({
-                    total_sample_size: getters.extractValue('sample'),
-                    base_rate: getters.extractValue('base')
-                });
+                // no array support for now
+                function recursive (baseRef, cloneRef) {
+                    Object.keys(cloneRef).forEach((prop) => {
+                        if (typeof cloneRef[prop] == 'object') {
+                            baseRef[prop] = recursive(baseRef[prop], cloneRef[prop]);
+                        } else {
+                            baseRef[prop] = cloneRef[prop];
+                        }
+                    });
 
-            return getters.displayValue('metricTotals', result)
-        },
-        impactByMetric (state, getters) {
-            return function impactByMetricInner (prop = 'value') {
-                let impactByMetricObj = statFormulas.getAbsoluteImpactInMetricHash({
-                    base_rate: getters.extractValue('base', state.base),
-                    effect_size: getters.extractValue('impact', state.impact)
-                });
-
-                return impactByMetricObj[prop];
-            }
-        },
-        impactByVisitors (state, getters) {
-            return statFormulas.getAbsoluteImpactInVisitors({
-                total_sample_size: getters.extractValue('sample', state.sample),
-                base_rate: getters.extractValue('base', state.base),
-                effect_size: getters.extractValue('impact', state.impact)
-            })
-        },
-        impactByVisitorsPerDay (state, getters) {
-            return Math.floor(getters.impactByVisitors / state.runtime);
-        },
-        impactByMetricDisplay (state, getters) {
-            return getters.displayValue('impactByMetricValue', getters.impactByMetric());
-        },
-        impactByMetricMinDisplay (state, getters) {
-            return getters.displayValue('impactByMetricValue', getters.impactByMetric('min'));
-        },
-        impactByMetricMaxDisplay (state, getters) {
-            return getters.displayValue('impactByMetricValue', getters.impactByMetric('max'));
-        },
-        impactByVisitorsDisplay (state, getters) {
-            return getters.displayValue('impactByVisitors', getters.impactByVisitors)
-        },
-        impactByVisitorsPerDayDisplay (state, getters) {
-            return getters.displayValue('impactByVisitorsPerDay', getters.impactByVisitorsPerDay)
-        },
-        calculateImpactFromAbsoluteImpact (state, getters) {
-            return function calculateImpactFromAbsoluteImpactInner (absolute_effect_size) {
-
-                let absoluteImpact = getters.extractValue('impactByMetricValue', absolute_effect_size);
-                return statFormulas.getRelativeImpactFromAbsolute({
-                    absolute_effect_size: absoluteImpact,
-                    base_rate: getters.extractValue('base', state.base)
-                });
-            }
-        },
-        baseFromVisitorsWithGoals (state, getters) {
-            return function baseFromVisitorsWithGoalsInner (value) {
-                return getters.displayValue(
-                    'base',
-                    statFormulas.getBaseRate({
-                        total_sample_size: getters.extractValue('sample', state.sample),
-                        visitors_with_goals: value
-                    })
-                )
-            }
-        }
-
-    }
-};
-
-var nonInferiority$1 = {
-    state:{
-        threshold: 0,
-        selected: 'relative', // relative, absolutePerDay
-        enabled: false,
-        expectedChange: 'nochange' // nochange, degradation, improvement
-    },
-    mutations: {
-        'field:change' (state, { prop, value }) {
-            if (typeof state[prop] != 'undefined') {
-                state[prop] = value;
-            }
-        },
-        'change:noninferiority' (state, {prop, value}) {
-            state[prop] = value;
-        },
-        'test:reset' (state, stateObj) {
-            let props = Object.keys(state);
-            props.forEach((prop) => {
-                if (prop in stateObj) {
-                    state[prop] = stateObj[prop];
+                    return baseRef;
                 }
-            });
-        }
-    },
-    getters: {
-        nonInferiorityImpact (state, getters, rootState) {
-            let { expectedChange, threshold, selected } = state,
-                newImpact = 0,
-                visitorsPerDay = rootState.attributes.visitorsPerDay,
-                base = getters.extractValue('base', rootState.attributes.base);
-
-            if (selected == 'absolutePerDay') {
-                threshold = threshold/(base*visitorsPerDay)*100;
-            }
-            switch (expectedChange) {
-                case 'nochange':
-                default:
-                    // zero
-                break;
-
-                case 'degradation':
-                    newImpact = -threshold/2;
-                break;
-
-                case 'improvement':
-                    newImpact = threshold;
-                break;
-            }
-
-            return newImpact
-        },
-        mu (state, getters) {
-            return getters.customMu({
-                runtime: getters.runtime,
-                thresholdCorrectedValue: getters.thresholdCorrectedValue,
-                visitors_per_day: getters.visitorsPerDay,
-                base_rate: getters.extractValue('base'),
-            });
-        },
-        customMu (state, getters) {
-            return function customMuInner ({runtime, thresholdCorrectedValue, visitors_per_day, base_rate}) {
-                let mu = 0;
-
-                if (state.enabled) {
-                    let thresholdType = state.selected,
-                        data = {
-                            runtime,
-                            threshold: -( getters.extractValue('nonInfThreshold', thresholdCorrectedValue) ),
-                            visitors_per_day,
-                            base_rate
-                        };
-                    mu = {
-                        absolutePerDay: statFormulas.getMuFromAbsolutePerDay,
-                        relative: statFormulas.getMuFromRelativeDifference
-                    }[thresholdType](data);
-                }
-
-                return mu
-            }
-        },
-        opts (state, getters) {
-            if (!state.enabled) {
-                return false
-            }
-
-            let opts = {
-                selected: state.selected,
-                lockedField: getters.lockedField,
-                thresholdCorrectedValue: getters.thresholdCorrectedValue,
-                runtime: getters.runtime,
-                visitorsPerDay: getters.visitorsPerDay,
-            };
-
-            return getters.customOpts(opts);
-        },
-        customOpts (state, getters) {
-            return function customOptsInner ({ selected, lockedField, thresholdCorrectedValue, runtime, visitorsPerDay }) {
-                let type = selected,
-                    opts;
-
-                opts = {
-                    type,
-                    calculating: lockedField,
-                    threshold: -( getters.extractValue('nonInfThreshold', thresholdCorrectedValue) ),
-                };
-
-                if (type == 'absolutePerDay') {
-                    if (lockedField == 'visitorsPerDay') {
-                        opts = Object.assign(
-                            opts,
-                            {
-                                days: runtime
-                            }
-                        );
-                    } else {
-                        opts = Object.assign(
-                            opts,
-                            {
-                                visitors_per_day: getters.extractValue('sample', visitorsPerDay)
-                            }
-                        );
-                    }
-                }
-
-                return opts
-            }
-
-        },
-        alternative (state, getters) {
-            if (!state.enabled) {
-                // in this case the test type would be 'comparative'
-                return false
-            }
-
-            return getters.customAlternative({type: 'noninferiority'});
-        },
-        customAlternative (state, getters) {
-            return function customAlternativeInner ({type}) {
-                return statFormulas.getAlternative({type});
-            }
-        },
-        thresholdCorrectedValue (state, getters) {
-            let { threshold, selected } = state;
-
-            return getters.customThresholdCorrectedValue({ threshold, selected });
-        },
-        customThresholdCorrectedValue (state) {
-            return function customThresholdCorrectedValueInner ({ threshold, selected }) {
-                // when relative is selected the value we will convert it to
-                // percentage
-
-                let nonInfThreshold = threshold;
-                const isRelative = selected == 'relative';
-
-                let result = nonInfThreshold;
-                if (isRelative) {
-                    result = result / 100;
-                }
-
                 return result;
             }
+        },
+        watch: {
+            // in case parent component needs this information
+            metricData () {
+                this.$emit('update:metricdata', this.metricData);
+            }
+        },
+        components: {
+            'svg-graph': svgGraph,
+            'pc-block-field': pcBlockField,
+            'pc-tooltip': pcTooltip,
+            'sample-comp': sampleComp,
+            'impact-comp' : impactComp,
+            'base-comp': baseComp,
+            'non-inferiority': nonInferiority,
+            'non-inferiority-comp': nonInferiorityComp
+
         }
-    }
-};
+    };
 
-// getters to present data and format for calculations
-let validations = {
-    sample: {type: 'int'},
-    base: {
-        gTest: {type: 'percentage'},
-        tTest: {type: 'float'}
-    },
-    impact: {type: 'percentage'},
-    runtime: {type: 'int'},
-    power: {type: 'percentage'},
-    falsePosRate: {type: 'percentage'},
-    impactByMetricValue: {
-        gTest: {type: 'percentage'},
-        tTest: {type: 'float'}
-    },
-    impactByVisitors: {type: 'int'},
-    impactByVisitorsPerDay: {type: 'int'},
-    metricTotals: {type: 'int'},
-    sdRate: {type: 'float'},
-    nonInfThreshold: {type: 'float'}
-};
+    var actions = {
+        'field:change' (context, { prop, value }) {
+            // add validations necessary here
 
-// add validation for component version of main data
-validations.totalSample = validations.sample;
-validations.relativeImpact = validations.impact;
-validations.baseRate = validations.base;
+            switch (prop) {
 
+                // these 3 cases will call the same extra action
+                case 'base':
+                    context.commit('field:change', { prop, value });
+                    if (context.state.nonInferiority.enabled === true) {
+                        if (context.state.nonInferiority.selected == 'absolutePerDay') {
+                            context.dispatch('change:noninferiorityimpact');
+                        }
+                        context.dispatch('convert:noninferioritythreshold', { prop, value });
+                    }
 
+                    context.dispatch('update:proptocalculate', context.getters.calculatedValues);
+                break;
 
-var dataFormat = {
-    displayValue (state) {
-        return function displayValueInner (prop, value) {
-            let result = value,
-                type = getType(prop, 'displayValue', state.attributes.testType);
+                case 'sample':
+                case 'runtime':
+                case 'visitorsPerDay':
+                    context.dispatch('sample:sideeffect', {prop, value});
+                    context.dispatch('update:proptocalculate', context.getters.calculatedValues);
 
-            if (type == 'int') {
-                result = window.parseInt(result);
+                    if (context.state.nonInferiority.enabled === true && prop == 'visitorsPerDay') {
+                        context.dispatch('convert:noninferioritythreshold', { prop, value });
+                    }
+                break;
+
+                case 'thresholdRelative':
+                case 'thresholdAbsolute':
+                    context.dispatch('threshold:sideeffect', {prop, value});
+                    context.dispatch('change:noninferiorityimpact');
+                    context.dispatch('convert:noninferioritythreshold', { prop, value });
+                break;
+
+                case 'impactByMetricValue':
+                    context.dispatch('convert:absoluteimpact', {prop, value});
+                break;
+
+                case 'expectedChange':
+                    context.commit('field:change', { prop, value });
+                    context.dispatch('change:noninferiorityimpact');
+                break;
+
+                case 'visitorsWithGoals':
+                    context.dispatch('convert:visitorswithgoals', {prop, value});
+                break;
+
+                default:
+                    context.commit('field:change', { prop, value });
+
+                    if (context.state.nonInferiority.enabled === true) {
+                        context.dispatch('convert:noninferioritythreshold', { prop, value });
+                    }
+
+                    // calculate new value for calculated prop
+                    context.dispatch('update:proptocalculate', context.getters.calculatedValues);
+                break;
+            }
+        },
+        'change:noninferiority' (context, { prop, value }) {
+            // add validations necessary here
+            context.commit('change:noninferiority', { prop, value });
+            context.dispatch('change:noninferiorityimpact');
+
+            if (prop == 'enabled') {
+
+                if (value === true) {
+                    context.dispatch('field:change', {
+                        prop: 'lockedField',
+                        value: 'days'
+                    });
+                    context.dispatch('field:change', {
+                        prop: 'onlyTotalVisitors',
+                        value: false
+                    });
+                    context.dispatch('update:calculateprop', {value: 'sample'});
+                }
+            } else {
+                // update values based on nonInferiority.selected
+                context.dispatch('update:proptocalculate', context.getters.calculatedValues);
+            }
+        },
+        'change:noninferiorityimpact' (context) {
+            let impactValue = context.getters.nonInferiorityImpact;
+
+            if (context.state.nonInferiority.enabled === true) {
+                this.__impactBackup = context.state.attributes.impact;
+                context.dispatch('convert:noninferioritythreshold', {
+                    prop: 'impact',
+                    value: impactValue
+                });
+            } else {
+                impactValue = this.__impactBackup || 0;
             }
 
-            if (type == 'float') {
-                result = window.parseFloat(result);
+            context.dispatch('field:change', {
+                prop: 'impact',
+                value: impactValue
+            });
+        },
+        'switch:lockedfield' (context) {
+            let newLockedField = context.state.attributes.lockedField == 'days' ? 'visitorsPerDay' : 'days';
+
+            if (context.state.nonInferiority.enabled === true) {
+                newLockedField = 'days';
             }
 
-            if (type == 'percentage') {
-                result = (window.parseFloat(result) * 100).toFixed(2);
-                result = +result.toString();
+            context.commit('switch:lockedfield', {
+                value: newLockedField
+            });
+        },
+        'sample:sideeffect' (context, { prop, value }) {
+            const isSampleCalculated = context.state.attributes.calculateProp == 'sample';
+            let lockedField = context.state.attributes.lockedField;
+
+            let stateMachine = {
+                calculated: {
+                    sample: false,
+                    runtime: lockedField == 'days',
+                    visitorsPerDay: lockedField != 'days',
+                },
+                notCalculated: {
+                    sample: true,
+                    runtime: lockedField == 'days' && prop == 'sample',
+                    visitorsPerDay: lockedField != 'days' && prop == 'sample',
+                }
+            };
+
+            let input = stateMachine[isSampleCalculated ? 'calculated' : 'notCalculated'];
+
+            let data = {
+                sample: context.state.attributes.sample,
+                visitorsPerDay: context.state.attributes.visitorsPerDay,
+                runtime: context.state.attributes.runtime
+            };
+
+            // override of the prop changed by the action change:fields with the new value
+            data[prop] = value;
+
+            context.commit('sample:sideeffect', {
+                prop: prop,
+                value: data[prop]
+            });
+
+            // looks throught the stat machine list and updates all values based on data
+            Object.keys(input).forEach((key) => {
+                if (input[key] == true) {
+                    if (key != prop) {
+                        let result = 0;
+                        if (key == 'runtime') {
+                            result = Math.ceil(window.parseInt(data.sample) / data.visitorsPerDay);
+                            result = isNaN(result) ? '-' : result;
+
+                        } else if (key == 'visitorsPerDay') {
+                            let isInvalid = false;
+                            result = Math.floor(window.parseInt(data.sample) / data.runtime);
+                            isInvalid = isNaN(result);
+
+                            result = isNaN(result) || isInvalid ? '-' : result;
+
+                        } else if (key == 'sample') {
+                            let isInvalid = false;
+                            result = Math.ceil(data.runtime * data.visitorsPerDay);
+                            isInvalid = isNaN(result);
+
+                            result = isInvalid ? '-' : result;
+                        }
+
+                        context.commit('sample:sideeffect', {
+                            prop: key,
+                            value: result
+                        });
+                    }
+                }
+            });
+        },
+        'threshold:sideeffect' (context, { prop, value }) {
+            context.commit('field:change', { prop, value });
+            if (context.state.attributes.calculateProp == 'sample') {
+                context.dispatch('sample:sideeffect', context.getters.calculatedValues);
+            }
+            context.dispatch('update:proptocalculate', context.getters.calculatedValues);
+        },
+        'update:calculateprop' (context, { value }) {
+            context.commit('update:calculateprop', { value });
+        },
+        'convert:absoluteimpact' (context, { prop, value }) {
+            let impactObj = {
+                    prop: 'impact',
+                    value: context.getters.displayValue('impact', context.getters.calculateImpactFromAbsoluteImpact(value))
+                };
+
+            context.dispatch('field:change', impactObj);
+        },
+        'convert:visitorswithgoals' (context, { prop, value }) {
+            let newValue = context.getters.baseFromVisitorsWithGoals(value);
+
+            context.dispatch('field:change', {
+                prop: 'base',
+                value: newValue
+            });
+        },
+        'convert:noninferioritythreshold' (context, { prop, value }) {
+            let valueToCalculate,
+                currentValue,
+                propToUpdate,
+                calculatedValue = 0;
+
+            switch (prop) {
+                case 'thresholdRelative':
+                    valueToCalculate = 'absolute';
+                    currentValue = value;
+                break;
+
+                case 'thresholdAbsolute':
+                    valueToCalculate = 'relative';
+                    currentValue = value;
+                break;
+                default:
+                    if (context.state.nonInferiority.selected == 'absolutePerDay') {
+                        valueToCalculate = 'relative';
+                    } else {
+                        valueToCalculate = 'absolute';
+                    }
+                    currentValue = context.state.nonInferiority.threshold;
+                break;
             }
 
-            return isNaN(result) || !isFinite(result) ? '-' : result;
+            if (valueToCalculate == 'absolute') {
+                calculatedValue = context.getters.displayValue('nonInfThresholdAbsolute', context.getters.calculateAbsoluteFromRelative(currentValue));
+                calculatedValue = Math.round(calculatedValue * 100) / 100;
+                propToUpdate = 'thresholdAbsolute';
+            } else if (valueToCalculate == 'relative') {
+                calculatedValue = context.getters.displayValue('nonInfThresholdRelative', context.getters.calculateRelativeFromAbsolute(currentValue));
+                propToUpdate = 'thresholdRelative';
+            }
+
+            context.commit('change:noninferiority', {
+                prop: propToUpdate,
+                value: calculatedValue
+            });
+        },
+        'update:proptocalculate' (context) {
+            let calculatedObj = context.getters.calculatedValues;
+            context.commit('update:proptocalculate', calculatedObj);
+
+            if (calculatedObj.prop == 'sample') {
+                // apply side effects
+                context.dispatch('sample:sideeffect', calculatedObj);
+            }
+        },
+        'init:calculator' (context) {
+            if (context.state.nonInferiority.enabled) {
+                context.dispatch('change:noninferiorityimpact');
+            }
+
+            if (context.state.attributes.calculateProp != 'sample') {
+                context.dispatch('field:change', {
+                    prop: 'sample',
+                    value: context.state.attributes.sample
+                });
+            }
+
+            context.dispatch('update:proptocalculate');
+        },
+        'test:reset' (context, stateObj) {
+            context.commit('test:reset', stateObj);
+            context.dispatch('init:calculator');
         }
-    },
-    extractValue (state) {
-        return function extractValueInner (prop, value) { // value is option and is used when we don't want to update the state
-            let result = typeof value == 'undefined' ? state.attributes[prop] : value,
-                type = getType(prop, 'extractValue', state.attributes.testType);
+    };
 
-            if (type == 'int') {
-                return window.parseInt(result);
+    var mutations = {
+            'update:proptocalculate' (state, {prop, value}) {
+                state.attributes[prop] = value;
+            }
+    };
+
+    var attributes = {
+        state:{
+            testType: 'gTest',
+            calculateProp: 'sample', // power, impact, base, sample
+
+            sample: 561364,
+            base: 10,
+            impact: 2,
+            power: 80,
+            falsePosRate: 10,
+            sdRate: 10,
+            variants: 1,
+
+            runtime: 14, //days
+
+            visitorsPerDay: Math.ceil(561364 / 14),
+            lockedField: 'days',
+            onlyTotalVisitors: false,
+            comparisonMode: 'all'
+        },
+
+        mutations: {
+            'field:change' (state, { prop, value }) {
+                if (typeof state[prop] != 'undefined') {
+                    state[prop] = value;
+                }
+            },
+            'sample:sideeffect' (state, { prop, value }) {
+                state[prop] = value;
+            },
+            'switch:lockedfield' (state, { value }) {
+                state.lockedField = value;
+            },
+            'update:calculateprop' (state, { value }) {
+                state.calculateProp = value;
+            },
+            'test:reset' (state, stateObj) {
+                let props = Object.keys(state);
+                props.forEach((prop) => {
+                    if (prop in stateObj) {
+                        state[prop] = stateObj[prop];
+                    }
+                });
+            }
+        },
+
+        getters: {
+            visitorsPerDay (state, getters) {
+                return state.visitorsPerDay
+            },
+            lockedField (state, getters) {
+                return state.lockedField
+            },
+            runtime (state, getters) {
+                return state.runtime
+            },
+            visitorsWithGoals (state, getters) {
+                let result = statFormulas.getVisitorsWithGoals({
+                        total_sample_size: getters.extractValue('sample'),
+                        base_rate: getters.extractValue('base')
+                    });
+
+                return getters.displayValue('metricTotals', result)
+            },
+            impactByMetric (state, getters) {
+                return function impactByMetricInner (prop = 'value') {
+                    let impactByMetricObj = statFormulas.getAbsoluteImpactInMetricHash({
+                        base_rate: getters.extractValue('base', state.base),
+                        effect_size: getters.extractValue('impact', state.impact)
+                    });
+
+                    return impactByMetricObj[prop];
+                }
+            },
+            impactByVisitors (state, getters) {
+                return statFormulas.getAbsoluteImpactInVisitors({
+                    total_sample_size: getters.extractValue('sample', state.sample),
+                    base_rate: getters.extractValue('base', state.base),
+                    effect_size: getters.extractValue('impact', state.impact)
+                })
+            },
+            impactByVisitorsPerDay (state, getters) {
+                return Math.floor(getters.impactByVisitors / state.runtime);
+            },
+            impactByMetricDisplay (state, getters) {
+                return getters.displayValue('impactByMetricValue', getters.impactByMetric());
+            },
+            impactByMetricMinDisplay (state, getters) {
+                return getters.displayValue('impactByMetricValue', getters.impactByMetric('min'));
+            },
+            impactByMetricMaxDisplay (state, getters) {
+                return getters.displayValue('impactByMetricValue', getters.impactByMetric('max'));
+            },
+            impactByVisitorsDisplay (state, getters) {
+                return getters.displayValue('impactByVisitors', getters.impactByVisitors)
+            },
+            impactByVisitorsPerDayDisplay (state, getters) {
+                return getters.displayValue('impactByVisitorsPerDay', getters.impactByVisitorsPerDay)
+            },
+            calculateImpactFromAbsoluteImpact (state, getters) {
+                return function calculateImpactFromAbsoluteImpactInner (absolute_effect_size) {
+
+                    let absoluteImpact = getters.extractValue('impactByMetricValue', absolute_effect_size);
+                    return statFormulas.getRelativeImpactFromAbsolute({
+                        absolute_effect_size: absoluteImpact,
+                        base_rate: getters.extractValue('base', state.base)
+                    });
+                }
+            },
+            baseFromVisitorsWithGoals (state, getters) {
+                return function baseFromVisitorsWithGoalsInner (value) {
+                    return getters.displayValue(
+                        'base',
+                        statFormulas.getBaseRate({
+                            total_sample_size: getters.extractValue('sample', state.sample),
+                            visitors_with_goals: value
+                        })
+                    )
+                }
             }
 
-            if (type == 'float') {
-                return window.parseFloat(result);
-            }
+        }
+    };
 
-            if (type == 'percentage') {
-                return window.parseFloat(result) / 100;
+    var nonInferiority$1 = {
+        state:{
+            threshold: 0,
+            thresholdRelative: 0,
+            thresholdAbsolute: 0,
+            selected: 'relative', // relative, absolutePerDay
+            enabled: false,
+            expectedChange: 'nochange' // nochange, degradation, improvement
+        },
+        mutations: {
+            'field:change' (state, { prop, value }) {
+                switch (prop) {
+                    case 'thresholdRelative':
+                        state.threshold = value;
+                        state.selected = 'relative';
+                    break;
+                    case 'thresholdAbsolute':
+                        state.threshold = value;
+                        state.selected = 'absolutePerDay';
+                    break;
+                    case 'threshold':
+                        if (state.selected == 'absolutePerDay') {
+                            state.thresholdAbsolute = value;
+                        } else {
+                            state.thresholdRelative = value;
+                        }
+                    break;
+                    case 'selected':
+                        if (value == 'absolutePerDay') {
+                            state.thresholdAbsolute = state.threshold;
+                        } else {
+                            state.thresholdRelative = state.threshold;
+                        }
+                    break;
+                    default:
+
+                    break;
+                }
+
+                if (typeof state[prop] != 'undefined') {
+                    state[prop] = value;
+                }
+            },
+            'change:noninferiority' (state, {prop, value}) {
+                state[prop] = value;
+            },
+            'test:reset' (state, stateObj) {
+                let props = Object.keys(state);
+                props.forEach((prop) => {
+                    if (prop in stateObj) {
+                        state[prop] = stateObj[prop];
+                    }
+                });
+            }
+        },
+        getters: {
+            nonInferiorityImpact (state, getters, rootState) {
+                let { expectedChange, threshold, selected } = state,
+                    newImpact = 0,
+                    visitorsPerDay = rootState.attributes.visitorsPerDay,
+                    base = getters.extractValue('base', rootState.attributes.base);
+
+                if (selected == 'absolutePerDay') {
+                    threshold = threshold/(base*visitorsPerDay)*100;
+                }
+                switch (expectedChange) {
+                    case 'nochange':
+                    default:
+                        // zero
+                    break;
+
+                    case 'degradation':
+                        newImpact = -threshold/2;
+                    break;
+
+                    case 'improvement':
+                        newImpact = threshold;
+                    break;
+                }
+
+                return newImpact
+            },
+            mu (state, getters) {
+                return getters.customMu({
+                    runtime: getters.runtime,
+                    thresholdCorrectedValue: getters.thresholdCorrectedValue,
+                    visitors_per_day: getters.visitorsPerDay,
+                    base_rate: getters.extractValue('base'),
+                });
+            },
+            customMu (state, getters) {
+                return function customMuInner ({runtime, thresholdCorrectedValue, visitors_per_day, base_rate}) {
+                    let mu = 0;
+
+                    if (state.enabled) {
+                        let thresholdType = state.selected,
+                            data = {
+                                runtime,
+                                threshold: -( getters.extractValue('nonInfThreshold', thresholdCorrectedValue) ),
+                                visitors_per_day,
+                                base_rate
+                            };
+                        mu = {
+                            absolutePerDay: statFormulas.getMuFromAbsolutePerDay,
+                            relative: statFormulas.getMuFromRelativeDifference
+                        }[thresholdType](data);
+                    }
+
+                    return mu
+                }
+            },
+            opts (state, getters) {
+                if (!state.enabled) {
+                    return false
+                }
+
+                let opts = {
+                    selected: state.selected,
+                    lockedField: getters.lockedField,
+                    thresholdCorrectedValue: getters.thresholdCorrectedValue,
+                    runtime: getters.runtime,
+                    visitorsPerDay: getters.visitorsPerDay,
+                };
+
+                return getters.customOpts(opts);
+            },
+            customOpts (state, getters) {
+                return function customOptsInner ({ selected, lockedField, thresholdCorrectedValue, runtime, visitorsPerDay }) {
+                    let type = selected,
+                        opts;
+
+                    opts = {
+                        type,
+                        calculating: lockedField,
+                        threshold: -( getters.extractValue('nonInfThreshold', thresholdCorrectedValue) ),
+                    };
+
+                    if (type == 'absolutePerDay') {
+                        if (lockedField == 'visitorsPerDay') {
+                            opts = Object.assign(
+                                opts,
+                                {
+                                    days: runtime
+                                }
+                            );
+                        } else {
+                            opts = Object.assign(
+                                opts,
+                                {
+                                    visitors_per_day: getters.extractValue('sample', visitorsPerDay)
+                                }
+                            );
+                        }
+                    }
+
+                    return opts
+                }
+
+            },
+            alternative (state, getters) {
+                if (!state.enabled) {
+                    // in this case the test type would be 'comparative'
+                    return false
+                }
+
+                return getters.customAlternative({type: 'noninferiority'});
+            },
+            customAlternative (state, getters) {
+                return function customAlternativeInner ({type}) {
+                    return statFormulas.getAlternative({type});
+                }
+            },
+            thresholdCorrectedValue (state, getters) {
+                let { threshold, selected } = state;
+
+                return getters.customThresholdCorrectedValue({ threshold, selected });
+            },
+            customThresholdCorrectedValue (state) {
+                return function customThresholdCorrectedValueInner ({ threshold, selected }) {
+                    // when relative is selected the value we will convert it to
+                    // percentage
+
+                    let nonInfThreshold = threshold;
+                    const isRelative = selected == 'relative';
+
+                    let result = nonInfThreshold;
+                    if (isRelative) {
+                        result = result / 100;
+                    }
+
+                    return result;
+                }
+            },
+            calculateRelativeFromAbsolute (state, getters, rootState) {
+                return function caclulateRelativeFromAbsoluteInner(absoluteThreshold) {
+                    let visitorsPerDay = rootState.attributes.visitorsPerDay,
+                    base = getters.extractValue('base', rootState.attributes.base);
+
+                    return absoluteThreshold/(base*visitorsPerDay);
+                }
+            },
+            calculateAbsoluteFromRelative (state, getters, rootState) {
+                return function calculateAbsoluteFromRelativeInner(relativeThreshold) {
+                    let visitorsPerDay = rootState.attributes.visitorsPerDay,
+                    base = getters.extractValue('base', rootState.attributes.base);
+
+                    return (relativeThreshold*base*visitorsPerDay)/100;
+                }
             }
         }
-    }
-};
+    };
 
-function getType (prop, methodName, testType) {
-    let validationConfig = validations[prop],
-        result,
-        throwError = false;
+    // getters to present data and format for calculations
+    let validations = {
+        sample: {type: 'int'},
+        base: {
+            gTest: {type: 'percentage'},
+            tTest: {type: 'float'}
+        },
+        impact: {type: 'percentage'},
+        runtime: {type: 'int'},
+        variants: {type: 'int'},
+        power: {type: 'percentage'},
+        falsePosRate: {type: 'percentage'},
+        impactByMetricValue: {
+            gTest: {type: 'percentage'},
+            tTest: {type: 'float'}
+        },
+        impactByVisitors: {type: 'int'},
+        impactByVisitorsPerDay: {type: 'int'},
+        metricTotals: {type: 'int'},
+        sdRate: {type: 'float'},
+        nonInfThreshold: {type: 'float'},
+        nonInfThresholdRelative: {type: 'percentage'},
+        nonInfThresholdAbsolute: {type: 'float'},
+    };
 
-    if (validationConfig) {
-        if (validationConfig.type) {
-            result = validationConfig.type;
-        } else if (validationConfig[testType] && validationConfig[testType].type) {
-            result = validationConfig[testType].type;
+    // add validation for component version of main data
+    validations.totalSample = validations.sample;
+    validations.relativeImpact = validations.impact;
+    validations.baseRate = validations.base;
+
+
+
+    var dataFormat = {
+        displayValue (state) {
+            return function displayValueInner (prop, value) {
+                let result = value,
+                    type = getType(prop, 'displayValue', state.attributes.testType);
+
+                if (type == 'int') {
+                    result = window.parseInt(result);
+                }
+
+                if (type == 'float') {
+                    result = window.parseFloat(result);
+                }
+
+                if (type == 'percentage') {
+                    result = (window.parseFloat(result) * 100).toFixed(2);
+                    result = +result.toString();
+                }
+
+                return isNaN(result) || !isFinite(result) ? '-' : result;
+            }
+        },
+        extractValue (state) {
+            return function extractValueInner (prop, value) { // value is option and is used when we don't want to update the state
+                let result = typeof value == 'undefined' ? state.attributes[prop] : value,
+                    type = getType(prop, 'extractValue', state.attributes.testType);
+
+                if (type == 'int') {
+                    return window.parseInt(result);
+                }
+
+                if (type == 'float') {
+                    return window.parseFloat(result);
+                }
+
+                if (type == 'percentage') {
+                    return window.parseFloat(result) / 100;
+                }
+            }
+        }
+    };
+
+    function getType (prop, methodName, testType) {
+        let validationConfig = validations[prop],
+            result,
+            throwError = false;
+
+        if (validationConfig) {
+            if (validationConfig.type) {
+                result = validationConfig.type;
+            } else if (validationConfig[testType] && validationConfig[testType].type) {
+                result = validationConfig[testType].type;
+            } else {
+                throwError = true;
+            }
         } else {
             throwError = true;
         }
-    } else {
-        throwError = true;
-    }
 
-    if (throwError) {
-        throw new Error(`Type not found for "${prop}" when trying to call "${methodName}".`)
-    }
-
-    return result || ''
-}
-
-var math = {
-    calculatedValues (state, getters) {
-        let prop = state.attributes.calculateProp,
-            value = getters.formulaToSolve(getters.convertDisplayedValues);
-        return {
-            prop,
-            value: getters.displayValue(prop, value)
-        };
-    },
-    formulaToSolve (state, getters) {
-        let calculateProp = state.attributes.calculateProp;
-
-        return getters.formulaToSolveProp[calculateProp];
-    },
-    formulaToSolveProp (state, getters) {
-        // used for the graph as we need to pass many different values to dynamic attributes
-        let testType = state.attributes.testType;
-
-        return statFormulas[testType];
-    },
-    convertDisplayedValues (state, getters) {
-        let { mu, opts, alternative } = getters;
-
-        return {
-            mu,
-            opts,
-            alternative,
-            total_sample_size: getters.extractValue('sample'),
-            base_rate: getters.extractValue('base'),
-            effect_size: getters.extractValue('impact'),
-            alpha: getters.extractValue('falsePosRate'),
-            beta: 1 - getters.extractValue('power'), // power of 80%, beta is actually 20%
-            sd_rate: getters.extractValue('sdRate')
+        if (throwError) {
+            throw new Error(`Type not found for "${prop}" when trying to call "${methodName}".`)
         }
+
+        return result || ''
     }
-};
 
-var store = {
-    modules: {
-        attributes,
-        nonInferiority: nonInferiority$1,
-    },
-    actions,
-    mutations,
-    getters: Object.assign({}, dataFormat, math)
-};
+    var math = {
+        calculatedValues (state, getters) {
+            let prop = state.attributes.calculateProp,
+                value = getters.formulaToSolve(getters.convertDisplayedValues);
+            return {
+                prop,
+                value: getters.displayValue(prop, value)
+            };
+        },
+        formulaToSolve (state, getters) {
+            let calculateProp = state.attributes.calculateProp;
 
-var index = {
-    powerCalculator,
-    store
-};
+            return getters.formulaToSolveProp[calculateProp];
+        },
+        formulaToSolveProp (state, getters) {
+            // used for the graph as we need to pass many different values to dynamic attributes
+            let testType = state.attributes.testType;
 
-return index;
+            return statFormulas[testType];
+        },
+        convertDisplayedValues (state, getters) {
+            let { mu, opts, alternative } = getters;
 
-})));
+            return {
+                mu,
+                opts,
+                alternative,
+                variants: getters.extractValue('variants'),
+                total_sample_size: getters.extractValue('sample'),
+                base_rate: getters.extractValue('base'),
+                effect_size: getters.extractValue('impact'),
+                alpha: state.attributes.comparisonMode === 'all' ? statFormulas.getCorrectedAlpha(getters.extractValue('falsePosRate'), getters.extractValue('variants')) : getters.extractValue('falsePosRate'),
+                beta: 1 - getters.extractValue('power'), // power of 80%, beta is actually 20%
+                sd_rate: getters.extractValue('sdRate')
+            }
+        }
+    };
+
+    var store = {
+        modules: {
+            attributes,
+            nonInferiority: nonInferiority$1,
+        },
+        actions,
+        mutations,
+        getters: Object.assign({}, dataFormat, math)
+    };
+
+    var index = {
+        powerCalculator,
+        store
+    };
+
+    return index;
+
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,9592 @@
+{
+  "name": "powercalculator",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@types/babel-types": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.5.tgz",
+      "integrity": "sha512-0t0R7fKAXT/P++S98djRkXbL9Sxd9NNtfNg3BNw2EQOjVIkiMBdmO55N2Tp3wGK3mylmM7Vck9h5tEoSuSUabA==",
+      "dev": true
+    },
+    "@types/babylon": {
+      "version": "6.16.5",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
+      "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+      "dev": true,
+      "requires": {
+        "@types/babel-types": "*"
+      }
+    },
+    "@types/node": {
+      "version": "11.9.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.4.tgz",
+      "integrity": "sha512-Zl8dGvAcEmadgs1tmSPcvwzO1YRsz38bVJQvH1RvRqSR9/5n61Q1ktcDL0ht3FXWR+ZpVmXVwN1LuH4Ax23NsA==",
+      "dev": true
+    },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "optional": true
+    },
+    "acorn": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "dev": true
+    },
+    "acorn-globals": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+      "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "dev": true
+        }
+      }
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.1.tgz",
+      "integrity": "sha512-XDN92U311aINL77ieWHmqCcNlwjoP5cHXDxIxbf2MaPYuCXOHS7gHH8jktxeK5omgd52XbSTX6a4Piwd1pQmzA==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
+      "optional": true
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
+      }
+    },
+    "append-transform": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+      "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^1.0.0"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.0.1"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true,
+      "optional": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true,
+      "optional": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true,
+      "optional": true
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
+    },
+    "babel": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel/-/babel-6.23.0.tgz",
+      "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "requires": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-define-map": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
+      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-regex": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-jest": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.4.tgz",
+      "integrity": "sha512-A9NB6/lZhYyypR9ATryOSDcqBaqNdzq4U+CN+/wcMsLcmKkPxQEoTKLajGfd3IkxNyVBT8NewUK2nWyGbSzHEQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-istanbul": "^4.1.5",
+        "babel-preset-jest": "^22.4.4"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+      "integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0",
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.10.1",
+        "test-exclude": "^4.2.1"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.4.tgz",
+      "integrity": "sha512-DUvGfYaAIlkdnygVIEl0O4Av69NtuQWcrjMOv6DODPuhuGLDnbsARz3AwiiI/EkIMMlxQDUcrZ9yoyJvTNjcVQ==",
+      "dev": true
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
+      "dev": true
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true,
+      "requires": {
+        "babel-helper-remap-async-to-generator": "^6.24.1",
+        "babel-plugin-syntax-async-functions": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "^6.24.1",
+        "babel-helper-function-name": "^6.24.1",
+        "babel-helper-optimise-call-expression": "^6.24.1",
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
+      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "^6.24.1",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-types": "^6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "^6.24.1",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "^6.24.1",
+        "babel-helper-get-function-arity": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1",
+        "babel-traverse": "^6.24.1",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "^6.24.1",
+        "babel-runtime": "^6.22.0",
+        "regexpu-core": "^2.0.0"
+      }
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+        "babel-runtime": "^6.22.0"
+      }
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.10.0"
+      }
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "babel-types": "^6.24.1"
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
+      "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+        "babel-plugin-transform-async-to-generator": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+        "babel-plugin-transform-es2015-classes": "^6.23.0",
+        "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+        "babel-plugin-transform-es2015-for-of": "^6.23.0",
+        "babel-plugin-transform-es2015-function-name": "^6.22.0",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+        "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+        "babel-plugin-transform-es2015-object-super": "^6.22.0",
+        "babel-plugin-transform-es2015-parameters": "^6.23.0",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+        "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+        "babel-plugin-transform-regenerator": "^6.22.0",
+        "browserslist": "^3.2.6",
+        "invariant": "^2.2.2",
+        "semver": "^5.3.0"
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "^6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+        "babel-plugin-transform-es2015-classes": "^6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+        "babel-plugin-transform-es2015-for-of": "^6.22.0",
+        "babel-plugin-transform-es2015-function-name": "^6.24.1",
+        "babel-plugin-transform-es2015-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+        "babel-plugin-transform-es2015-object-super": "^6.24.1",
+        "babel-plugin-transform-es2015-parameters": "^6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+        "babel-plugin-transform-es2015-spread": "^6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+        "babel-plugin-transform-regenerator": "^6.24.1"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.4.tgz",
+      "integrity": "sha512-+dxMtOFwnSYWfum0NaEc0O03oSdwBsjx4tMSChRDPGwu/4wSY6Q6ANW3wkjKpJzzguaovRs/DODcT4hbSN8yiA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^22.4.4",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+      }
+    },
+    "babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "dev": true
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "browserslist": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+      "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30000844",
+        "electron-to-chromium": "^1.3.47"
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-2.0.0.tgz",
+      "integrity": "sha512-3U5kUA5VPsRUA3nofm/BXX7GVHKfxz0hOBAPxXrIvHzlDRkQVqEn6yi8QJegxl4LzOHLdvb7XF5dVawa/VVYBg==",
+      "dev": true
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "^0.2.0"
+      },
+      "dependencies": {
+        "callsites": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+          "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+          "dev": true
+        }
+      }
+    },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000938",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000938.tgz",
+      "integrity": "sha512-ekW8NQ3/FvokviDxhdKLZZAx7PptXNwxKgXtnR5y+PR3hckwuP3yJ1Ir+4/c97dsHNqtAyfKUGdw8P4EYzBNgw==",
+      "dev": true
+    },
+    "capture-exit": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+      "integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+      "dev": true,
+      "requires": {
+        "rsvp": "^3.3.3"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      }
+    },
+    "character-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
+      "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-regex": "^1.0.3"
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
+      "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true,
+      "optional": true
+    },
+    "coffeescript-compiler": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/coffeescript-compiler/-/coffeescript-compiler-0.1.1.tgz",
+      "integrity": "sha1-gai9RKeL2kIffgtR8o0TyFO+uAU=",
+      "dev": true,
+      "optional": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "constantinople": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
+      "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "dev": true,
+      "requires": {
+        "@types/babel-types": "^7.0.0",
+        "@types/babylon": "^6.16.2",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0"
+      }
+    },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
+      "dev": true,
+      "requires": {
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.4.3",
+        "minimist": "^1.2.0",
+        "object-assign": "^4.1.0",
+        "os-homedir": "^1.0.1",
+        "parse-json": "^2.2.0",
+        "require-from-string": "^1.1.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "boom": "2.x.x"
+      }
+    },
+    "css-modules-loader-core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/css-modules-loader-core/-/css-modules-loader-core-1.1.0.tgz",
+      "integrity": "sha1-WQhmgpShvs0mGuCkziGwtVHyHRY=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.1",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
+          "integrity": "sha1-AA29H47vIXqjaLmiEsX8QLKo8/I=",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "css-parse": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
+      "dev": true,
+      "optional": true
+    },
+    "css-selector-tokenizer": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
+      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^0.1.0",
+        "fastparse": "^1.1.1",
+        "regexpu-core": "^1.0.0"
+      },
+      "dependencies": {
+        "regexpu-core": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+          "dev": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        }
+      }
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+      "dev": true
+    },
+    "cssom": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+      "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "default-require-extensions": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+      "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "doctypes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
+      "dev": true,
+      "optional": true
+    },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.3.113",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.113.tgz",
+      "integrity": "sha512-De+lPAxEcpxvqPTyZAXELNpRZXABRxf+uL/rSykstQhzj/B0l1150G/ExIIxKc16lI89Hgz81J0BHAcbTqK49g==",
+      "dev": true
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.4",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^1.0.1",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "4.0.2",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-vue": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-4.7.1.tgz",
+      "integrity": "sha512-esETKhVMI7Vdli70Wt4bvAwnZBJeM0pxVX9Yb0wWKxdCJc2EADalVYK/q2FzMw8oKN0wPMdqVCKS8kmR89recA==",
+      "dev": true,
+      "requires": {
+        "vue-eslint-parser": "^2.0.3"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "^0.1.0"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "expect": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.3.tgz",
+      "integrity": "sha512-XcNXEPehqn8b/jm8FYotdX0YrXn36qp4HWlrVT4ktwQas1l1LPxiVWncYnnL2eyMtKAmVIaG0XAp0QlrqJaxaA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^22.4.3",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.4.3",
+        "jest-message-util": "^22.4.3",
+        "jest-regex-util": "^22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fastparse": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
+      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
+      "dev": true
+    },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
+      }
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "fileset": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
+      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
+      }
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "requires": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      }
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+      "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
+      "dev": true
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.1"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.9.2",
+        "node-pre-gyp": "^0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
+    },
+    "generic-names": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/generic-names/-/generic-names-1.0.3.tgz",
+      "integrity": "sha1-LXhqEhruUIh2eWk56OO/+DbCCRc=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^0.2.16"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "dev": true,
+      "requires": {
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^2.0.0"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
+    },
+    "globule": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
+    "handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "hash-sum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+      "dev": true
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
+      }
+    },
+    "html-minifier": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
+          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "image-size": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+      "dev": true,
+      "optional": true
+    },
+    "import-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^2.0.0",
+        "resolve-cwd": "^2.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E=",
+      "dev": true,
+      "optional": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.5.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+      "dev": true
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "dev": true,
+      "requires": {
+        "is-primitive": "^2.0.0"
+      }
+    },
+    "is-expression": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
+      "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "acorn": "~4.0.2",
+        "object-assign": "^4.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^1.0.0"
+      }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+      "dev": true
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "istanbul-api": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.7.tgz",
+      "integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.4",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.2.1",
+        "istanbul-lib-hook": "^1.2.2",
+        "istanbul-lib-instrument": "^1.10.2",
+        "istanbul-lib-report": "^1.1.5",
+        "istanbul-lib-source-maps": "^1.2.6",
+        "istanbul-reports": "^1.5.1",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
+      }
+    },
+    "istanbul-lib-coverage": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
+      "integrity": "sha512-PzITeunAgyGbtY1ibVIUiV679EFChHjoMNRibEIobvmrCRaIgwLxNucOSimtNWUhEib/oO7QY2imD75JVgCJWQ==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.2.tgz",
+      "integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^0.4.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
+      "integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
+      "dev": true,
+      "requires": {
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.2.1",
+        "semver": "^5.3.0"
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.5.tgz",
+      "integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^1.2.1",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.6.tgz",
+      "integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "istanbul-lib-coverage": "^1.2.1",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.5.1.tgz",
+      "integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.0.3"
+      }
+    },
+    "jStat": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/jStat/-/jStat-1.7.1.tgz",
+      "integrity": "sha512-toueem/U5hyHM6pqe6OZOL/5P8MrY7Ss1K8Brg+TcfX+RAjDU/sbwy72fwzmLPQ5ykdBe1UEoWQHc7OSNWMUDQ==",
+      "dev": true
+    },
+    "jest": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.4.tgz",
+      "integrity": "sha512-eBhhW8OS/UuX3HxgzNBSVEVhSuRDh39Z1kdYkQVWna+scpgsrD7vSeBI7tmEvsguPDMnfJodW28YBnhv/BzSew==",
+      "dev": true,
+      "requires": {
+        "import-local": "^1.0.0",
+        "jest-cli": "^22.4.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "jest-cli": {
+          "version": "22.4.4",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.4.tgz",
+          "integrity": "sha512-I9dsgkeyjVEEZj9wrGrqlH+8OlNob9Iptyl+6L5+ToOLJmHm4JwOPatin1b2Bzp5R5YRQJ+oiedx7o1H7wJzhA==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "import-local": "^1.0.0",
+            "is-ci": "^1.0.10",
+            "istanbul-api": "^1.1.14",
+            "istanbul-lib-coverage": "^1.1.1",
+            "istanbul-lib-instrument": "^1.8.0",
+            "istanbul-lib-source-maps": "^1.2.1",
+            "jest-changed-files": "^22.2.0",
+            "jest-config": "^22.4.4",
+            "jest-environment-jsdom": "^22.4.1",
+            "jest-get-type": "^22.1.0",
+            "jest-haste-map": "^22.4.2",
+            "jest-message-util": "^22.4.0",
+            "jest-regex-util": "^22.1.0",
+            "jest-resolve-dependencies": "^22.1.0",
+            "jest-runner": "^22.4.4",
+            "jest-runtime": "^22.4.4",
+            "jest-snapshot": "^22.4.0",
+            "jest-util": "^22.4.1",
+            "jest-validate": "^22.4.4",
+            "jest-worker": "^22.2.2",
+            "micromatch": "^2.3.11",
+            "node-notifier": "^5.2.1",
+            "realpath-native": "^1.0.0",
+            "rimraf": "^2.5.4",
+            "slash": "^1.0.0",
+            "string-length": "^2.0.0",
+            "strip-ansi": "^4.0.0",
+            "which": "^1.2.12",
+            "yargs": "^10.0.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.4.3.tgz",
+      "integrity": "sha512-83Dh0w1aSkUNFhy5d2dvqWxi/y6weDwVVLU6vmK0cV9VpRxPzhTeGimbsbRDSnEoszhF937M4sDLLeS7Cu/Tmw==",
+      "dev": true,
+      "requires": {
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-config": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.4.tgz",
+      "integrity": "sha512-9CKfo1GC4zrXSoMLcNeDvQBfgtqGTB1uP8iDIZ97oB26RCUb886KkKWhVcpyxVDOUxbhN+uzcBCeFe7w+Iem4A==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^22.4.1",
+        "jest-environment-node": "^22.4.1",
+        "jest-get-type": "^22.1.0",
+        "jest-jasmine2": "^22.4.4",
+        "jest-regex-util": "^22.1.0",
+        "jest-resolve": "^22.4.2",
+        "jest-util": "^22.4.1",
+        "jest-validate": "^22.4.4",
+        "pretty-format": "^22.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.3.tgz",
+      "integrity": "sha512-/QqGvCDP5oZOF6PebDuLwrB2BMD8ffJv6TAGAdEVuDx1+uEgrHpSFrfrOiMRx2eJ1hgNjlQrOQEHetVwij90KA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.3.tgz",
+      "integrity": "sha512-uPKBEAw7YrEMcXueMKZXn/rbMxBiSv48fSqy3uEnmgOlQhSX+lthBqHb1fKWNVmFqAp9E/RsSdBfiV31LbzaOg==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^2.1.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz",
+      "integrity": "sha512-FviwfR+VyT3Datf13+ULjIMO5CSeajlayhhYQwpzgunswoaLIPutdbrnfUHEMyJCwvqQFaVtTmn9+Y8WCt6n1w==",
+      "dev": true,
+      "requires": {
+        "jest-mock": "^22.4.3",
+        "jest-util": "^22.4.3",
+        "jsdom": "^11.5.1"
+      }
+    },
+    "jest-environment-node": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.3.tgz",
+      "integrity": "sha512-reZl8XF6t/lMEuPWwo9OLfttyC26A5AMgDyEQ6DBgZuyfyeNUzYT8BFo6uxCCP/Av/b7eb9fTi3sIHFPBzmlRA==",
+      "dev": true,
+      "requires": {
+        "jest-mock": "^22.4.3",
+        "jest-util": "^22.4.3"
+      }
+    },
+    "jest-get-type": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.3.tgz",
+      "integrity": "sha512-4Q9fjzuPVwnaqGKDpIsCSoTSnG3cteyk2oNVjBX12HHOaF1oxql+uUiqZb5Ndu7g/vTZfdNwwy4WwYogLh29DQ==",
+      "dev": true,
+      "requires": {
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^22.4.3",
+        "jest-serializer": "^22.4.3",
+        "jest-worker": "^22.4.3",
+        "micromatch": "^2.3.11",
+        "sane": "^2.0.0"
+      }
+    },
+    "jest-jasmine2": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.4.tgz",
+      "integrity": "sha512-nK3vdUl50MuH7vj/8at7EQVjPGWCi3d5+6aCi7Gxy/XMWdOdbH1qtO/LjKbqD8+8dUAEH+BVVh7HkjpCWC1CSw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^22.4.0",
+        "graceful-fs": "^4.1.11",
+        "is-generator-fn": "^1.0.0",
+        "jest-diff": "^22.4.0",
+        "jest-matcher-utils": "^22.4.0",
+        "jest-message-util": "^22.4.0",
+        "jest-snapshot": "^22.4.0",
+        "jest-util": "^22.4.1",
+        "source-map-support": "^0.5.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.10",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
+          "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-leak-detector": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz",
+      "integrity": "sha512-NZpR/Ls7+ndO57LuXROdgCGz2RmUdC541tTImL9bdUtU3WadgFGm0yV+Ok4Fuia/1rLAn5KaJ+i76L6e3zGJYQ==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^22.4.3"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+      "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-get-type": "^22.4.3",
+        "pretty-format": "^22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.3.tgz",
+      "integrity": "sha512-iAMeKxhB3Se5xkSjU0NndLLCHtP4n+GtCqV0bISKA5dmOXQfEbdEmYiu2qpnWBDCQdEafNDDU6Q+l6oBMd/+BA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0-beta.35",
+        "chalk": "^2.0.1",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0",
+        "stack-utils": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.4.3.tgz",
+      "integrity": "sha512-+4R6mH5M1G4NK16CKg9N1DtCaFmuxhcIqF4lQK/Q1CIotqMs/XBemfpDPeVZBFow6iyUNu6EBT9ugdNOTT5o5Q==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.4.3.tgz",
+      "integrity": "sha512-LFg1gWr3QinIjb8j833bq7jtQopiwdAs67OGfkPrvy7uNUbVMfTXXcOKXJaeY5GgjobELkKvKENqq1xrUectWg==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.3.tgz",
+      "integrity": "sha512-u3BkD/MQBmwrOJDzDIaxpyqTxYH+XqAXzVJP51gt29H8jpj3QgKof5GGO2uPGKGeA1yTMlpbMs1gIQ6U4vcRhw==",
+      "dev": true,
+      "requires": {
+        "browser-resolve": "^1.11.2",
+        "chalk": "^2.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz",
+      "integrity": "sha512-06czCMVToSN8F2U4EvgSB1Bv/56gc7MpCftZ9z9fBgUQM7dzHGCMBsyfVA6dZTx8v0FDcnALf7hupeQxaBCvpA==",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "^22.4.3"
+      }
+    },
+    "jest-runner": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.4.tgz",
+      "integrity": "sha512-5S/OpB51igQW9xnkM5Tgd/7ZjiAuIoiJAVtvVTBcEBiXBIFzWM3BAMPBM19FX68gRV0KWyFuGKj0EY3M3aceeQ==",
+      "dev": true,
+      "requires": {
+        "exit": "^0.1.2",
+        "jest-config": "^22.4.4",
+        "jest-docblock": "^22.4.0",
+        "jest-haste-map": "^22.4.2",
+        "jest-jasmine2": "^22.4.4",
+        "jest-leak-detector": "^22.4.0",
+        "jest-message-util": "^22.4.0",
+        "jest-runtime": "^22.4.4",
+        "jest-util": "^22.4.1",
+        "jest-worker": "^22.2.2",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-runtime": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.4.tgz",
+      "integrity": "sha512-WRTj9m///npte1YjuphCYX7GRY/c2YvJImU9t7qOwFcqHr4YMzmX6evP/3Sehz5DKW2Vi8ONYPCFWe36JVXxfw==",
+      "dev": true,
+      "requires": {
+        "babel-core": "^6.0.0",
+        "babel-jest": "^22.4.4",
+        "babel-plugin-istanbul": "^4.1.5",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^22.4.4",
+        "jest-haste-map": "^22.4.2",
+        "jest-regex-util": "^22.1.0",
+        "jest-resolve": "^22.4.2",
+        "jest-util": "^22.4.1",
+        "jest-validate": "^22.4.4",
+        "json-stable-stringify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "realpath-native": "^1.0.0",
+        "slash": "^1.0.0",
+        "strip-bom": "3.0.0",
+        "write-file-atomic": "^2.1.0",
+        "yargs": "^10.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.3.tgz",
+      "integrity": "sha512-uPaUAppx4VUfJ0QDerpNdF43F68eqKWCzzhUlKNDsUPhjOon7ZehR4C809GCqh765FoMRtTVUVnGvIoskkYHiw==",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.3.tgz",
+      "integrity": "sha512-JXA0gVs5YL0HtLDCGa9YxcmmV2LZbwJ+0MfyXBBc5qpgkEYITQFJP7XNhcHFbUvRiniRpRbGVfJrOoYhhGE0RQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^22.4.3",
+        "jest-matcher-utils": "^22.4.3",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^22.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-util": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.3.tgz",
+      "integrity": "sha512-rfDfG8wyC5pDPNdcnAlZgwKnzHvZDu8Td2NJI/jAGKEGxJPYiE4F0ss/gSAkG4778Y23Hvbz+0GMrDJTeo7RjQ==",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.11",
+        "is-ci": "^1.0.10",
+        "jest-message-util": "^22.4.3",
+        "mkdirp": "^0.5.1",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "22.4.4",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.4.tgz",
+      "integrity": "sha512-dmlf4CIZRGvkaVg3fa0uetepcua44DHtktHm6rcoNVtYlpwe6fEJRkMFsaUVcFHLzbuBJ2cPw9Gl9TKfnzMVwg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-config": "^22.4.4",
+        "jest-get-type": "^22.1.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^22.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-worker": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.4.3.tgz",
+      "integrity": "sha512-B1ucW4fI8qVAuZmicFxI1R3kr2fNeYJyvIQ1rKcuLYnenFV5K5aMbxFj6J0i00Ju83S8jP2d7Dz14+AvbIHRYQ==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^1.0.1"
+      }
+    },
+    "js-base64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
+      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw==",
+      "dev": true
+    },
+    "js-stringify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
+      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsdom": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "jstransformer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
+      "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "is-promise": "^2.0.0",
+        "promise": "^7.0.1"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
+      "optional": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
+    },
+    "less": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
+      "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "mime": "^1.2.11",
+        "mkdirp": "^0.5.0",
+        "promise": "^7.1.1",
+        "request": "2.81.0",
+        "source-map": "^0.5.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true,
+          "optional": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+          "dev": true,
+          "optional": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true,
+          "optional": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "loader-utils": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+      "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+      "dev": true,
+      "requires": {
+        "big.js": "^3.1.3",
+        "emojis-list": "^2.0.0",
+        "json5": "^0.5.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true,
+      "optional": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true,
+      "optional": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "longest": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "dev": true,
+      "requires": {
+        "vlq": "^0.2.2"
+      }
+    },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.1"
+      }
+    },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "optional": true
+    },
+    "mime-db": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.38.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+      "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+      "dev": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
+      }
+    },
+    "node-sass": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.11.0.tgz",
+      "integrity": "sha512-bHUdHTphgQJZaF1LASx0kAviPH7sGlcyNhWade4eVIpFp6tsn7SV8xNMTbsQFpEV9VXpnwTTnNYlfsZXgGgmkA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "nwsapi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.0.tgz",
+      "integrity": "sha512-ZG3bLAvdHmhIjaQ/Db1qvBxsGvFMLIRpQszyqbg31VJ53UP++uZX1/gf3Ut96pdwN9AuDwlMqIYLm0UPCdUeHg==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
+      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "dev": true,
+      "requires": {
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "dev": true,
+      "requires": {
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "5.2.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "js-base64": "^2.1.9",
+        "source-map": "^0.5.6",
+        "supports-color": "^3.2.3"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
+    "postcss-load-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0",
+        "postcss-load-options": "^1.2.0",
+        "postcss-load-plugins": "^2.3.0"
+      }
+    },
+    "postcss-load-options": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^2.1.0",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "postcss-load-plugins": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^2.1.1",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "postcss-modules": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/postcss-modules/-/postcss-modules-0.6.4.tgz",
+      "integrity": "sha1-d6WLt3uhtDkrJwwLWYUv116JqLQ=",
+      "dev": true,
+      "requires": {
+        "css-modules-loader-core": "^1.0.1",
+        "generic-names": "^1.0.2",
+        "postcss": "^5.2.8",
+        "string-hash": "^1.1.1"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+      "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
+      "dev": true,
+      "requires": {
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
+      "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "^0.7.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^6.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
+      "dev": true,
+      "requires": {
+        "flatten": "^1.0.2",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "posthtml": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.10.1.tgz",
+      "integrity": "sha512-4OW8nA6kOMyIivdEUL+b4vvSxWDEtQFiSAbM0n0baeSBcb9EQTaD9s1DqT6Qgr46oJZ1aJe8lioZZ5Exr4Ophg==",
+      "dev": true,
+      "requires": {
+        "posthtml-parser": "^0.3.0",
+        "posthtml-render": "^1.0.5"
+      }
+    },
+    "posthtml-attrs-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posthtml-attrs-parser/-/posthtml-attrs-parser-0.1.1.tgz",
+      "integrity": "sha1-zDPgAVX7mbqW9n4l4zBGHwV0Ksg=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1"
+      }
+    },
+    "posthtml-parser": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.3.3.tgz",
+      "integrity": "sha512-H/Z/yXGwl49A7hYQLV1iQ3h87NE0aZ/PMZhFwhw3lKeCAN+Ti4idrHvVvh4/GX10I7u77aQw+QB4vV5/Lzvv5A==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.9.2",
+        "isobject": "^2.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "posthtml-render": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-1.1.4.tgz",
+      "integrity": "sha512-jL6eFIzoN3xUEvbo33OAkSDE2VIKU4JQ1wENOows1DpfnrdapR/K3Q1/fB43Mq7wQlcSgRm23nFrvoioufM7eA==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "22.4.3",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "asap": "~2.0.3"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true,
+      "optional": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "dev": true
+    },
+    "pug": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.3.tgz",
+      "integrity": "sha1-ccuoJTfJWl6rftBGluQiH1Oqh44=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pug-code-gen": "^2.0.1",
+        "pug-filters": "^3.1.0",
+        "pug-lexer": "^4.0.0",
+        "pug-linker": "^3.0.5",
+        "pug-load": "^2.0.11",
+        "pug-parser": "^5.0.0",
+        "pug-runtime": "^2.0.4",
+        "pug-strip-comments": "^1.0.3"
+      }
+    },
+    "pug-attrs": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.3.tgz",
+      "integrity": "sha1-owlflw5kFR972tlX7vVftdeQXRU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "constantinople": "^3.0.1",
+        "js-stringify": "^1.0.1",
+        "pug-runtime": "^2.0.4"
+      }
+    },
+    "pug-code-gen": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.1.tgz",
+      "integrity": "sha1-CVHsgyJddNjPxHan+Zolm199BQw=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "constantinople": "^3.0.1",
+        "doctypes": "^1.1.0",
+        "js-stringify": "^1.0.1",
+        "pug-attrs": "^2.0.3",
+        "pug-error": "^1.3.2",
+        "pug-runtime": "^2.0.4",
+        "void-elements": "^2.0.1",
+        "with": "^5.0.0"
+      }
+    },
+    "pug-error": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
+      "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY=",
+      "dev": true
+    },
+    "pug-filters": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.0.tgz",
+      "integrity": "sha1-JxZVVbwEwjbkqisDZiRt+gIbYm4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "clean-css": "^4.1.11",
+        "constantinople": "^3.0.1",
+        "jstransformer": "1.0.0",
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.7",
+        "resolve": "^1.1.6",
+        "uglify-js": "^2.6.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
+          "optional": true
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "center-align": "^0.1.1",
+            "right-align": "^0.1.1",
+            "wordwrap": "0.0.2"
+          }
+        },
+        "uglify-js": {
+          "version": "2.8.29",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
+          }
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
+          "optional": true
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
+            "window-size": "0.1.0"
+          }
+        }
+      }
+    },
+    "pug-lexer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.0.0.tgz",
+      "integrity": "sha1-IQwYRX7y4XYCQnQMXmR715TOwng=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "character-parser": "^2.1.1",
+        "is-expression": "^3.0.0",
+        "pug-error": "^1.3.2"
+      }
+    },
+    "pug-linker": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.5.tgz",
+      "integrity": "sha1-npp65ABWgtAn3uuWsAD4juuDoC8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pug-error": "^1.3.2",
+        "pug-walk": "^1.1.7"
+      }
+    },
+    "pug-load": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.11.tgz",
+      "integrity": "sha1-5kjlftET/iwfRdV4WOorrWvAFSc=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "pug-walk": "^1.1.7"
+      }
+    },
+    "pug-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.0.tgz",
+      "integrity": "sha1-45Stmz/KkxI5QK/4hcBuRKt+aOQ=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pug-error": "^1.3.2",
+        "token-stream": "0.0.1"
+      }
+    },
+    "pug-runtime": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.4.tgz",
+      "integrity": "sha1-4XjhvaaKsujArPybztLFT9iM61g=",
+      "dev": true
+    },
+    "pug-strip-comments": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.3.tgz",
+      "integrity": "sha1-8VWVkiBu3G+FMQ2s9K+0igJa9Z8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "pug-error": "^1.3.2"
+      }
+    },
+    "pug-walk": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
+      "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "rands": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rands/-/rands-1.0.0.tgz",
+      "integrity": "sha1-3G+sFGfvX7AzkqqRAaciKo/jdQQ=",
+      "dev": true
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "dev": true,
+      "requires": {
+        "util.promisify": "^1.0.0"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
+      "dev": true
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.18.0",
+        "babel-types": "^6.19.0",
+        "private": "^0.1.6"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "^0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.2.1",
+        "regjsgen": "^0.2.0",
+        "regjsparser": "^0.1.4"
+      }
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
+      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
+    },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "rollup-plugin-commonjs": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz",
+      "integrity": "sha512-mg+WuD+jlwoo8bJtW3Mvx7Tz6TsIdMsdhuvCnDMoyjh0oxsVgsjB/N0X984RJCWwc5IIiqNVJhXeeITcc73++A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^5.2.1",
+        "estree-walker": "^0.5.0",
+        "magic-string": "^0.22.4",
+        "resolve": "^1.4.0",
+        "rollup-pluginutils": "^2.0.1"
+      }
+    },
+    "rollup-plugin-css-only": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-css-only/-/rollup-plugin-css-only-0.2.0.tgz",
+      "integrity": "sha1-58WDsnJv8VyI5wHq1cmtgOHPQyQ=",
+      "dev": true,
+      "requires": {
+        "rollup-pluginutils": "^1.5.2"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.2.1.tgz",
+          "integrity": "sha1-va/oCVOD2EFNXcLs9MkXO225QS4=",
+          "dev": true
+        },
+        "rollup-pluginutils": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz",
+          "integrity": "sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=",
+          "dev": true,
+          "requires": {
+            "estree-walker": "^0.2.1",
+            "minimatch": "^3.0.2"
+          }
+        }
+      }
+    },
+    "rollup-plugin-eslint": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-eslint/-/rollup-plugin-eslint-4.0.0.tgz",
+      "integrity": "sha1-n7l8DvW8DXpU7vHygXDxl03JOOw=",
+      "dev": true,
+      "requires": {
+        "eslint": "^4.1.1",
+        "rollup-pluginutils": "^2.0.1"
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",
+      "integrity": "sha512-PJcd85dxfSBWih84ozRtBkB731OjXk0KnzN0oGp7WOWcarAFkVa71cV5hTJg2qpVsV2U8EUwrzHP3tvy9vS3qg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^2.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.1.6"
+      }
+    },
+    "rollup-plugin-replace": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz",
+      "integrity": "sha512-SxrAIgpH/B5/W4SeULgreOemxcpEgKs2gcD42zXw50bhqGWmcnlXneVInQpAqzA/cIly4bJrOpeelmB9p4YXSQ==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.1",
+        "minimatch": "^3.0.2",
+        "rollup-pluginutils": "^2.0.1"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.2",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+          "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        }
+      }
+    },
+    "rollup-plugin-vue": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-vue/-/rollup-plugin-vue-2.5.4.tgz",
+      "integrity": "sha512-iioOlxZeIrAGLHgtDRoX5kb2aIVBUiy2P774lCYOUzlHgYizC6IGv8bR0ws8k7wgfDukiRyhfTb0KhB6CIrMfg==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "^6.22.0",
+        "camelcase": "^4.0.0",
+        "coffee-script": "^1.12.4",
+        "coffeescript-compiler": "^0.1.1",
+        "de-indent": "^1.0.2",
+        "debug": "^3.1.0",
+        "hash-sum": "^1.0.2",
+        "html-minifier": "^3.2.3",
+        "less": "^2.7.2",
+        "magic-string": "^0.22.4",
+        "merge-options": "^1.0.0",
+        "node-sass": "^4.5.0",
+        "parse5": "^3.0.3",
+        "postcss": "^5.2.11",
+        "postcss-load-config": "^1.2.0",
+        "postcss-modules": "^0.6.4",
+        "postcss-selector-parser": "^2.2.3",
+        "posthtml": "^0.10.1",
+        "posthtml-attrs-parser": "^0.1.1",
+        "pug": "^2.0.0-beta11",
+        "rollup-pluginutils": "^2.0.1",
+        "stylus": "^0.54.5",
+        "typescript": "^2.4.1",
+        "vue-template-compiler": ">=2.0",
+        "vue-template-es2015-compiler": "^1.6.0",
+        "vue-template-validator": "^1.1.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
+      "integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "estree-walker": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+          "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
+          "dev": true
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        }
+      }
+    },
+    "rsvp": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+      "dev": true
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+      "dev": true
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "dev": true,
+      "requires": {
+        "rx-lite": "*"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "sane": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+      "integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "capture-exit": "^1.2.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.3",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true,
+          "optional": true
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "hoek": "2.x.x"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+      "dev": true
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stack-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stdout-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
+      "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=",
+      "dev": true
+    },
+    "string-length": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "requires": {
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true,
+      "optional": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "stylus": {
+      "version": "0.54.5",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
+      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "css-parse": "1.7.x",
+        "debug": "*",
+        "glob": "7.0.x",
+        "mkdirp": "0.5.x",
+        "sax": "0.5.x",
+        "source-map": "0.1.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
+          "dev": true,
+          "optional": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^5.2.3",
+        "ajv-keywords": "^2.1.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
+      }
+    },
+    "test-exclude": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.3.tgz",
+      "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        }
+      }
+    },
+    "token-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
+      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo=",
+      "dev": true,
+      "optional": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true,
+      "optional": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "true-case-path": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
+      "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "glob": "^7.1.2"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.17.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
+      "optional": true
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
+    },
+    "void-elements": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true,
+      "optional": true
+    },
+    "vue": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.6.tgz",
+      "integrity": "sha512-Y2DdOZD8sxApS+iUlwv1v8U1qN41kq6Kw45lM6nVZKhygeWA49q7VCCXkjXqeDBXgurrKWkYQ9cJeEJwAq0b9Q==",
+      "dev": true
+    },
+    "vue-eslint-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz",
+      "integrity": "sha512-ZezcU71Owm84xVF6gfurBQUGg8WQ+WZGxgDEQu1IHFBZNx7BFZg3L1yHxrCBNNwbwFtE1GuvfJKMtb6Xuwc/Bw==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.1.0",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.6.tgz",
+      "integrity": "sha512-OakxDGyrmMQViCjkakQFbDZlG0NibiOzpLauOfyCUVRQc9yPmTqpiz9nF0VeA+dFkXegetw0E5x65BFhhLXO0A==",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
+      }
+    },
+    "vue-template-es2015-compiler": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.8.2.tgz",
+      "integrity": "sha512-cliV19VHLJqFUYbz/XeWXe5CO6guzwd0yrrqqp0bmjlMP3ZZULY7fu8RTC4+3lmHwo6ESVDHFDsvjB15hcR5IA==",
+      "dev": true
+    },
+    "vue-template-validator": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/vue-template-validator/-/vue-template-validator-1.1.5.tgz",
+      "integrity": "sha1-ItHud9BkfBqxT/frAYZZQtmzxFg=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.1"
+      }
+    },
+    "vuex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.0.tgz",
+      "integrity": "sha512-mdHeHT/7u4BncpUZMlxNaIdcN/HIt1GsGG5LKByArvYG/v6DvHcOxvDCts+7SRdCoIRGllK8IMZvQtQXLppDYg==",
+      "dev": true
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "watch": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
+      "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
+      "optional": true
+    },
+    "with": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
+      "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "acorn": "^3.1.0",
+        "acorn-globals": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true,
+          "optional": true
+        },
+        "acorn-globals": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+          "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "acorn": "^4.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "4.0.13",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+              "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        }
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "dev": true
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
+      "integrity": "sha512-ivSoxqBGYOqQVruxD35+EyCFDYNEFL/Uo6FcOnz+9xZdZzK0Zzw4r4KhbrME1Oo2gOggwJod2MnsdamSG7H9ig==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^8.1.0"
+      }
+    },
+    "yargs-parser": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+      "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "babel-core": "^6.26.0",
     "babel-jest": "^22.4.1",
     "regenerator-runtime": "^0.11.1"
+  },
+  "jest": {
+    "testURL": "http://localhost/"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -36,6 +36,7 @@ export default {
     })
   ],
   output: {
+    banner: banner,
     name: 'powercalculator',
     file: 'dist/powercalculator.js',
     format: 'umd',

--- a/src/components/impact-comp.vue
+++ b/src/components/impact-comp.vue
@@ -93,6 +93,7 @@
                     <span class="pc-input-details">
                         {{ testType == 'gTest' ? ' Incremental trials per day': ' Incremental change in the metric per day' }}
                     </span>
+                </label>
             </li>
         </ul>
     </div>

--- a/src/components/non-inferiority-comp.vue
+++ b/src/components/non-inferiority-comp.vue
@@ -10,20 +10,13 @@
         <ul class="pc-inputs">
             <li class="pc-input-item pc-input-left">
                 <label>
-                    <span class="pc-input-title">Acceptable Cost
-                        <small class="pc-input-sub-title">
-                            {{isRelative ?
-                                'relative difference of' :
-                                'absolute impact per day of'
-                            }}
-                        </small>
-                    </span>
+                    <span class="pc-input-title">Relative <small class="pc-input-sub-title">change</small></span>
 
                     <pc-block-field
-                        fieldProp="threshold"
-                        :suffix="isRelative ? '%' : ''"
+                        fieldProp="thresholdRelative"
+                        suffix="%"
 
-                        v-bind:fieldValue="threshold"
+                        v-bind:fieldValue="thresholdRelative"
                         v-bind:fieldFromBlock="fieldFromBlock"
                         v-bind:isBlockFocused="isBlockFocused"
                         v-bind:isReadOnly="isReadOnly"
@@ -35,22 +28,18 @@
 
             <li class="pc-input-item pc-input-right">
                 <label>
-                    <span class="pc-input-title">
-                        Type {{ isRelative ?
-                                '' :
-                                '(per day)'
-                            }}
-                        <small class="pc-input-sub-title">
-                        </small>
-                    </span>
+                    <span class="pc-input-title">Absolute <small class="pc-input-sub-title">impact per day</small></span>
 
-                    <div class="pc-non-inf-select-wrapper">
-                        <select v-model="selected" class="pc-non-inf-select">
-                            <option v-for="(option, index) in options" v-bind:key="index" v-bind:value="option.value">
-                                {{option.text}}
-                            </option>
-                        </select>
-                    </div>
+                    <pc-block-field
+                        fieldProp="thresholdAbsolute"
+                        suffix=""
+                        v-bind:fieldValue="thresholdAbsolute"
+                        v-bind:fieldFromBlock="fieldFromBlock"
+                        v-bind:isBlockFocused="isBlockFocused"
+                        v-bind:isReadOnly="isReadOnly"
+                        v-bind:enableEdit="true"
+
+                        v-on:update:focus="updateFocus"></pc-block-field>
                 </label>
             </li>
 
@@ -113,6 +102,12 @@ export default {
         },
         threshold () {
             return this.$store.state.nonInferiority.threshold
+        },
+        thresholdRelative () {
+            return this.$store.state.nonInferiority.thresholdRelative
+        },
+        thresholdAbsolute () {
+            return this.$store.state.nonInferiority.thresholdAbsolute
         },
         isRelative () {
             return this.$store.state.nonInferiority.selected == 'relative'

--- a/src/components/pc-block-field.vue
+++ b/src/components/pc-block-field.vue
@@ -61,6 +61,12 @@ let validateFunctions = {
                     return value > 0
                 },
                 defaultVal: 0
+            },
+            variants: {
+                fn (value) {
+                    return Number.isInteger(value) && value > 1
+                },
+                defaultVal: 1
             }
         },
         gTest: {
@@ -376,7 +382,8 @@ export default {
 
 .pc-non-inf-treshold-input,
 .pc-power-input,
-.pc-false-positive-input {
+.pc-false-positive-input,
+.pc-variants-input {
     display: inline-block;
     vertical-align: middle;
     padding: 4px 8px;
@@ -385,6 +392,10 @@ export default {
     border: 2px solid var(--gray);
     border-radius: 8px;
     font-size: inherit;
+}
+
+.pc-variants-input {
+    width: 6.5em;
 }
 
 .pc-top-fields-error {

--- a/src/components/sample-comp.vue
+++ b/src/components/sample-comp.vue
@@ -13,10 +13,10 @@
         </div>
 
 
-        <ul class="pc-inputs">
+        <ul class="pc-inputs" :class="{'pc-inputs-no-grid': onlyTotalVisitors}">
             <li class="pc-input-item pc-input-left">
                 <label>
-                    <span class="pc-input-title">Total # <small class="pc-input-sub-title">of visitors</small></span>
+                    <span class="pc-input-title">Total # <small class="pc-input-sub-title">of new visitors</small></span>
 
                     <pc-block-field
                         fieldProp="sample"
@@ -28,9 +28,9 @@
                         v-on:update:focus="updateFocus"></pc-block-field>
                 </label>
             </li>
-            <li class="pc-input-item pc-input-right pc-value-field--lockable" :class="getLockedStateClass('visitorsPerDay')">
+            <li class="pc-input-item pc-input-right pc-value-field--lockable" :class="[getLockedStateClass('visitorsPerDay'), {'pc-hidden': onlyTotalVisitors}]">
                 <label>
-                    <span class="pc-input-title">Daily # <small class="pc-input-sub-title">of visitors</small></span>
+                    <span class="pc-input-title">Daily # <small class="pc-input-sub-title">of new visitors</small></span>
 
                     <pc-block-field
                         fieldProp="visitorsPerDay"
@@ -74,7 +74,7 @@
                 </button>
 
             </li>
-            <li class="pc-input-item pc-input-right-swap pc-value-field--lockable" :class="getLockedStateClass('days')">
+            <li class="pc-input-item pc-input-right-swap pc-value-field--lockable" :class="[getLockedStateClass('days'), {'pc-hidden': onlyTotalVisitors}]">
                 <label>
                     <pc-block-field
                         fieldProp="runtime"
@@ -104,7 +104,6 @@ export default {
     extends: pcBlock,
     data () {
         return {
-            variants: 2,
             focusedBlock: ''
         }
     },
@@ -120,7 +119,10 @@ export default {
         },
         lockedField () {
             return this.$store.state.attributes.lockedField
-        }
+        },
+        onlyTotalVisitors () {
+            return this.$store.state.attributes.onlyTotalVisitors
+        },
     },
     methods: {
         updateFocus ({fieldProp, value}) {
@@ -207,6 +209,10 @@ export default {
 
 .pc-value-field--lockable.pc-value-field--locked .pc-value-field-wrapper {
     background: linear-gradient(0deg, var(--light-gray) 0%, var(--white) 100%);
+}
+
+.pc-inputs-no-grid {
+    display: block;
 }
 
 </style>

--- a/src/powercalculator.vue
+++ b/src/powercalculator.vue
@@ -2,57 +2,94 @@
     <div class="power-calculator">
         <form action="." class="pc-form">
             <div class="pc-main-header">
-                <div class="pc-test-type">
 
-                    <pc-tooltip class="pc-test-type-tooltip-wrapper">
-                        <label class="pc-test-type-labels" slot="text">
-                            <input type="radio" name="test-mode" v-model="testType" value="gTest" checked>
-                            Binary Metric
+                <div class="pc-controls-left">
+
+                    <div class="pc-test-type">
+
+                        <pc-tooltip class="pc-test-type-tooltip-wrapper">
+                            <label class="pc-test-type-labels" slot="text">
+                                <input type="radio" name="test-mode" v-model="testType" value="gTest" checked>
+                                Binomial Metric
+                            </label>
+                            <span slot="tooltip">
+                                A binomial metric is one that can be only two values like 0 or 1, yes or no, converted or not converted
+                            </span>
+                        </pc-tooltip>
+
+
+                        <pc-tooltip class="pc-test-type-tooltip-wrapper">
+                            <label class="pc-test-type-labels" slot="text">
+                                <input type="radio" name="test-mode" v-model="testType" value="tTest">
+                                Continuous Metric
+                            </label>
+                            <span slot="tooltip">
+                                A continuous metric is one that can be any number like time on site or the number of rooms sold
+                            </span>
+                        </pc-tooltip>
+
+                    </div>
+
+                    <div class="pc-traffic-mode">
+                        <label class="pc-traffic-mode-labels" slot="text">
+                            <input type="radio" name="traffic-mode" v-model="trafficMode" value="daily" checked :disabled="nonInferiorityEnabled">
+                            Daily traffic
                         </label>
-                        <span slot="tooltip">
-                            A binary metric is one that can be only two values like 0 or 1, yes or no, converted or not converted
-                        </span>
-                    </pc-tooltip>
-
-
-                    <pc-tooltip class="pc-test-type-tooltip-wrapper">
-                        <label class="pc-test-type-labels" slot="text">
-                            <input type="radio" name="test-mode" v-model="testType" value="tTest">
-                            Continuous Metric
+                        <label class="pc-traffic-mode-labels" slot="text">
+                            <input type="radio" name="traffic-mode" v-model="trafficMode" value="total" :disabled="nonInferiorityEnabled">
+                            Total traffic
                         </label>
-                        <span slot="tooltip">
-                            A continuous metric is one that can be any number like time on site or the number of rooms sold
-                        </span>
-                    </pc-tooltip>
+                    </div>
 
+                    <non-inferiority></non-inferiority>
+
+                    <div class="pc-comparison-mode">
+                        <label class="pc-comparison-mode-labels" slot="text">
+                            <input type="radio" name="comparison-mode" v-model="comparisonMode" value="all" checked>
+                            Base vs All variants
+                        </label>
+                        <label class="pc-traffic-mode-labels" slot="text">
+                            <input type="radio" name="comparison-mode" v-model="comparisonMode" value="one">
+                            Base vs One variant
+                        </label>
+                    </div>
                 </div>
-
-                <non-inferiority></non-inferiority>
-
 
                 <div class="pc-title">Power Calculator <sup style="color: #F00; font-size: 11px;">BETA</sup> </div>
 
-                <label class="pc-false-positive">
-                    <pc-block-field
-                        class="pc-false-positive-input"
-                        :class="{ 'pc-top-fields-error': falsePosRate > 10 }"
-                        suffix="%"
-                        fieldProp="falsePosRate"
-                        v-bind:fieldValue="falsePosRate"
-                        v-bind:enableEdit="true"></pc-block-field>
-                    false positive rate
-                </label>
+                <div class="pc-controls-right">
+                    <label class="pc-variants">
+                        <pc-block-field
+                            class="pc-variants-input"
+                            fieldProp="variants"
+                            prefix="base + "
+                            v-bind:fieldValue="variants"
+                            v-bind:enableEdit="true"></pc-block-field>
+                        variant{{ variants > 1 ? 's' : '' }}
+                    </label>
 
-                <label class="pc-power">
-                    <pc-block-field
-                        class="pc-power-input"
-                        suffix="%"
-                        :class="{ 'pc-top-fields-error': power < 80 }"
-                        fieldProp="power"
-                        v-bind:fieldValue="power"
-                        v-bind:enableEdit="true"></pc-block-field>
-                    power
-                </label>
+                    <label class="pc-false-positive">
+                        <pc-block-field
+                            class="pc-false-positive-input"
+                            :class="{ 'pc-top-fields-error': falsePosRate > 10 }"
+                            suffix="%"
+                            fieldProp="falsePosRate"
+                            v-bind:fieldValue="falsePosRate"
+                            v-bind:enableEdit="true"></pc-block-field>
+                        false positive rate
+                    </label>
+
+                    <label class="pc-power">
+                        <pc-block-field
+                            class="pc-power-input"
+                            suffix="%"
+                            :class="{ 'pc-top-fields-error': power < 80 }"
+                            fieldProp="power"
+                            v-bind:fieldValue="power"
+                            v-bind:enableEdit="true"></pc-block-field>
+                        power
+                    </label>
+                </div>
             </div>
 
 
@@ -151,7 +188,8 @@ export default {
                     calculateProp: this.calculateProp,
                     view: this.view,
                     lockedField: this.lockedField,
-                    nonInferiority: this.nonInferiority
+                    nonInferiority: this.nonInferiority,
+                    comparisonMode: this.comparisonMode,
                 };
             return JSON.parse(JSON.stringify(result))
         },
@@ -167,9 +205,22 @@ export default {
         falsePosRate () {
             return this.$store.state.attributes.falsePosRate
         },
-
         power () {
             return this.$store.state.attributes.power
+        },
+        variants () {
+            return this.$store.state.attributes.variants
+        },
+        comparisonMode: {
+            get () {
+                return this.$store.state.attributes.comparisonMode
+            },
+            set (newValue) {
+                this.$store.dispatch('field:change', {
+                    prop: 'comparisonMode',
+                    value: newValue
+                })
+            }
         },
         testType: {
             get () {
@@ -181,8 +232,22 @@ export default {
                     value: newValue || 0
                 })
             }
-        }
+        },
+        trafficMode: {
+            get () {
+                if (this.$store.state.attributes.onlyTotalVisitors) {
+                    return 'total';
+                }
 
+                return 'daily';
+            },
+            set (newValue) {
+                this.$store.dispatch('field:change', {
+                    prop: 'onlyTotalVisitors',
+                    value: newValue == 'total'
+                })
+            }
+        }
     },
     methods: {
         updateFocus ({fieldProp, value}) {
@@ -263,13 +328,34 @@ export default {
 
 .pc-main-header {
     display: grid;
-    grid-template-columns: min-content  min-content auto min-content min-content;
+    grid-template-columns: 33.33% 33.33% 33.33%;
     grid-template-rows: auto;
     grid-template-areas:
-        "test-type calc-options title false-positive power";
+        "controls-left title controls-right";
     align-items: center;
 
-    margin: 25px 0 25px 10px;
+    margin: 25px 10px;
+}
+
+.pc-controls-left {
+    grid-area: controls-left;
+    display: grid;
+    grid-template-columns: min-content min-content min-content min-content;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "test-type traffic comparison calc-options";
+    align-items: center;
+}
+
+.pc-controls-right {
+    grid-area: controls-right;
+    display: grid;
+    grid-template-columns: auto min-content min-content;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "variants false-positive power";
+    align-items: center;
+    justify-items: end;
 }
 
 .pc-title {
@@ -278,10 +364,17 @@ export default {
     text-align: center;
 }
 
+.pc-traffic-mode {
+    grid-area: traffic;
+}
+
 .pc-non-inf-label,
 .pc-test-type,
 .pc-false-positive,
-.pc-power {
+.pc-power,
+.pc-traffic-mode,
+.pc-variants,
+.pc-comparison-mode {
     font-size: 0.8em;
 }
 
@@ -293,24 +386,47 @@ export default {
     grid-area: calc-options;
 }
 
+.pc-comparison-mode {
+    grid-area: comparison;
+}
+
+.pc-test-type-labels,
+.pc-traffic-mode-labels,
+.pc-non-inf-label,
+.pc-comparison-mode-label {
+    white-space: nowrap;
+}
+
+.pc-non-inferiority ,
+.pc-test-type,
+.pc-traffic-mode,
+.pc-comparison-mode {
+    margin-left: 15px;
+}
+
 .pc-test-type-tooltip-wrapper {
     display: inline-block;
 }
 
-.pc-test-type-labels {
-    margin: 0 20px;
+.pc-variants {
+    grid-area: variants;
     white-space: nowrap;
+    align-self: end;
 }
 
 .pc-false-positive {
     grid-area: false-positive;
+    margin-left: 15px;
     white-space: nowrap;
+    align-self: end;
 }
 
 .pc-power {
     grid-area: power;
-    margin-left: 10px;
+    margin-left: 15px;
+    margin-right: 15px;
     white-space: nowrap;
+    align-self: end;
 }
 
 .pc-blocks-wrapper {
@@ -381,5 +497,9 @@ export default {
 
 .pc-block-to-calculate .pc-header {
     background: var(--dark-yellow);
+}
+
+.pc-hidden {
+    display: none!important;
 }
 </style>

--- a/src/powercalculator.vue
+++ b/src/powercalculator.vue
@@ -340,10 +340,11 @@ export default {
 .pc-controls-left {
     grid-area: controls-left;
     display: grid;
-    grid-template-columns: min-content min-content min-content min-content;
-    grid-template-rows: auto;
+    grid-template-columns: min-content min-content min-content;
+    grid-template-rows: 2;
     grid-template-areas:
-        "test-type traffic comparison calc-options";
+        "calc-options calc-options calc-options"
+        "test-type traffic comparison";
     align-items: center;
 }
 
@@ -384,6 +385,7 @@ export default {
 
 .pc-non-inferiority {
     grid-area: calc-options;
+    margin-bottom: 8px;
 }
 
 .pc-comparison-mode {

--- a/src/store/getters/data-format.js
+++ b/src/store/getters/data-format.js
@@ -7,6 +7,7 @@ let validations = {
     },
     impact: {type: 'percentage'},
     runtime: {type: 'int'},
+    variants: {type: 'int'},
     power: {type: 'percentage'},
     falsePosRate: {type: 'percentage'},
     impactByMetricValue: {
@@ -17,7 +18,9 @@ let validations = {
     impactByVisitorsPerDay: {type: 'int'},
     metricTotals: {type: 'int'},
     sdRate: {type: 'float'},
-    nonInfThreshold: {type: 'float'}
+    nonInfThreshold: {type: 'float'},
+    nonInfThresholdRelative: {type: 'percentage'},
+    nonInfThresholdAbsolute: {type: 'float'},
 }
 
 // add validation for component version of main data

--- a/src/store/getters/math.js
+++ b/src/store/getters/math.js
@@ -27,10 +27,11 @@ export default {
             mu,
             opts,
             alternative,
+            variants: getters.extractValue('variants'),
             total_sample_size: getters.extractValue('sample'),
             base_rate: getters.extractValue('base'),
             effect_size: getters.extractValue('impact'),
-            alpha: getters.extractValue('falsePosRate'),
+            alpha: state.attributes.comparisonMode === 'all' ? statFormulas.getCorrectedAlpha(getters.extractValue('falsePosRate'), getters.extractValue('variants')) : getters.extractValue('falsePosRate'),
             beta: 1 - getters.extractValue('power'), // power of 80%, beta is actually 20%
             sd_rate: getters.extractValue('sdRate')
         }

--- a/src/store/modules/attributes.js
+++ b/src/store/modules/attributes.js
@@ -11,11 +11,14 @@ export default {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 14, //days
 
         visitorsPerDay: Math.ceil(561364 / 14),
-        lockedField: 'days'
+        lockedField: 'days',
+        onlyTotalVisitors: false,
+        comparisonMode: 'all'
     },
 
     mutations: {

--- a/src/store/modules/non-inferiority.js
+++ b/src/store/modules/non-inferiority.js
@@ -3,12 +3,42 @@ import statFormulas from '../../js/math.js'
 export default {
     state:{
         threshold: 0,
+        thresholdRelative: 0,
+        thresholdAbsolute: 0,
         selected: 'relative', // relative, absolutePerDay
         enabled: false,
         expectedChange: 'nochange' // nochange, degradation, improvement
     },
     mutations: {
         'field:change' (state, { prop, value }) {
+            switch (prop) {
+                case 'thresholdRelative':
+                    state.threshold = value;
+                    state.selected = 'relative';
+                break;
+                case 'thresholdAbsolute':
+                    state.threshold = value;
+                    state.selected = 'absolutePerDay';
+                break;
+                case 'threshold':
+                    if (state.selected == 'absolutePerDay') {
+                        state.thresholdAbsolute = value;
+                    } else {
+                        state.thresholdRelative = value;
+                    }
+                break;
+                case 'selected':
+                    if (value == 'absolutePerDay') {
+                        state.thresholdAbsolute = state.threshold;
+                    } else {
+                        state.thresholdRelative = state.threshold;
+                    }
+                break;
+                default:
+
+                break;
+            }
+
             if (typeof state[prop] != 'undefined') {
                 state[prop] = value;
             }
@@ -161,6 +191,22 @@ export default {
                 }
 
                 return result;
+            }
+        },
+        calculateRelativeFromAbsolute (state, getters, rootState) {
+            return function caclulateRelativeFromAbsoluteInner(absoluteThreshold) {
+                let visitorsPerDay = rootState.attributes.visitorsPerDay,
+                base = getters.extractValue('base', rootState.attributes.base);
+
+                return absoluteThreshold/(base*visitorsPerDay);
+            }
+        },
+        calculateAbsoluteFromRelative (state, getters, rootState) {
+            return function calculateAbsoluteFromRelativeInner(relativeThreshold) {
+                let visitorsPerDay = rootState.attributes.visitorsPerDay,
+                base = getters.extractValue('base', rootState.attributes.base);
+
+                return (relativeThreshold*base*visitorsPerDay)/100;
             }
         }
     }

--- a/tests/effectsize.test.js
+++ b/tests/effectsize.test.js
@@ -21,9 +21,10 @@ var lower = [{control_mean:  0.001, stddev: 1, mu: 0     },
              {control_mean:  10,    stddev: 1, mu: 1,    },
              {control_mean:  10,    stddev: 1, mu: -1,   }];
 
-var configs = [{alternative: "two-sided", data: greater.concat(lower)},
-               {alternative: "greater",   data: greater},
-               {alternative: "lower",     data: lower}];
+var configs = [{alternative: "two-sided", data: greater.concat(lower),  variants: 1},
+               {alternative: "greater",   data: greater,                variants: 1},
+               {alternative: "lower",     data: lower,                  variants: 1},
+               {alternative: "lower",     data: lower,                  variants: 3}];
 
 var sample_size_continuous = util.sample_size_continuous();
 var replications = util.replications_power();
@@ -34,15 +35,17 @@ var default_beta = util.default_beta();
 configs.forEach(function(config) {
     var cases = config.data;
     cases.forEach(function(test_case) {
+        test_case.variants = config.variants;
         test("solveforeffectsize yield the expected power for continuous metrics with parameters: " + util.serialize(test_case), () => {
             var impact = statFormula.tTest.impact({
-                total_sample_size: 2*sample_size_continuous,
+                total_sample_size: (test_case.variants + 1)*sample_size_continuous,
                 base_rate: test_case.control_mean,
                 sd_rate: test_case.stddev,
                 alpha: default_fpr,
                 beta: default_beta,
                 alternative: config.alternative,
-                mu: test_case.mu
+                mu: test_case.mu,
+                variants: test_case.variants,
              });
 
             var dataset = util.simulate_continuous({
@@ -86,23 +89,26 @@ var lower_binary = [{control_rate: 0.01, mu: 0      },
                     {control_rate: 0.8,  mu: 0.08   },
                     {control_rate: 0.8,  mu: -0.08  }];
 
-var configs_binary = [{alternative: "two-sided", data: greater_binary.concat(lower_binary)},
-                      {alternative: "greater",   data: greater_binary},
-                      {alternative: "lower",     data: lower_binary}];
+var configs_binary = [{alternative: "two-sided", data: greater_binary.concat(lower_binary), variants: 1},
+                      {alternative: "greater",   data: greater_binary,                      variants: 1},
+                      {alternative: "lower",     data: lower_binary,                        variants: 1},
+                      {alternative: "greater",   data: greater_binary,                      variants: 2}];
 
 var sample_size = util.sample_size();
 
 configs_binary.forEach(function(config) {
     var cases = config.data;
     cases.forEach(function(test_case) {
+        test_case.variants = config.variants;
         test("solveforeffectsize yield the expected power for binary metrics with parameters: " + util.serialize(test_case), () => {
             var impact = statFormula.gTest.impact({
-                total_sample_size: 2*sample_size,
+                total_sample_size: (test_case.variants + 1)*sample_size,
                 base_rate: test_case.control_rate,
                 alpha: default_fpr,
                 beta: default_beta,
                 alternative: config.alternative,
-                mu: test_case.mu
+                mu: test_case.mu,
+                variants: test_case.variants,
              }); 
 
             var dataset = util.simulate_binary({

--- a/tests/power.test.js
+++ b/tests/power.test.js
@@ -24,9 +24,15 @@ var lower = [{control_rate: 0.01, change: -0.001,  mu: 0     },
              {control_rate: 0.8,  change: -0.08,   mu: 0     },
              {control_rate: 0.8,  change: -0.1,    mu: -0.08 }];
 
-var configs = [{alternative: "two-sided", data: greater.concat(lower)},
-               {alternative: "greater",   data: greater},
-               {alternative: "lower",     data: lower}];
+var configs = [{alternative: "two-sided", data: greater.concat(lower),  variants: 1},
+               {alternative: "greater",   data: greater,                variants: 1},
+               {alternative: "lower",     data: lower,                  variants: 1},
+               {alternative: "two-sided", data: greater.concat(lower),  variants: 2},
+               {alternative: "greater",   data: greater,                variants: 2},
+               {alternative: "lower",     data: lower,                  variants: 2},
+               {alternative: "two-sided", data: greater.concat(lower),  variants: 3},
+               {alternative: "greater",   data: greater,                variants: 3},
+               {alternative: "lower",     data: lower,                  variants: 3}];
 
 var sample_size = util.sample_size();
 var replications = util.replications_power();
@@ -36,6 +42,7 @@ var margin = util.margin();
 configs.forEach(function(config) {
     var cases = config.data;
     cases.forEach(function(test_case) {
+        test_case.variants = config.variants;
         test("solveforpower yield the expected power with parameters: " + util.serialize(test_case), () => {
             var dataset = util.simulate_binary({
                 "control_rate": test_case.control_rate,
@@ -45,12 +52,13 @@ configs.forEach(function(config) {
             });
         
             var target = statFormula.gTest.power({
-                "total_sample_size": 2*sample_size,
+                "total_sample_size": (test_case.variants+1)*sample_size,
                 "base_rate": test_case.control_rate,
                 "effect_size": test_case.change/test_case.control_rate,
                 "mu": test_case.mu,
                 "alternative": config.alternative,
-                "alpha": default_fpr
+                "alpha": default_fpr,
+                "variants": test_case.variants,
             });
         
             expect(util.check({

--- a/tests/samplesize.test.js
+++ b/tests/samplesize.test.js
@@ -24,9 +24,15 @@ var lower = [{control_rate: 0.01, change: -0.001,  mu: 0     },
              {control_rate: 0.8,  change: -0.08,   mu: 0     },
              {control_rate: 0.8,  change: -0.1,    mu: -0.08 }];
 
-var configs = [{alternative: "two-sided", data: greater.concat(lower)},
-               {alternative: "greater",   data: greater},
-               {alternative: "lower",     data: lower}];
+var configs = [{alternative: "two-sided", data: greater.concat(lower),  variants: 1},
+               {alternative: "greater",   data: greater,                variants: 1},
+               {alternative: "lower",     data: lower,                  variants: 1},
+               {alternative: "two-sided", data: greater.concat(lower),  variants: 2},
+               {alternative: "greater",   data: greater,                variants: 2},
+               {alternative: "lower",     data: lower,                  variants: 2},
+               {alternative: "two-sided", data: greater.concat(lower),  variants: 3},
+               {alternative: "greater",   data: greater,                variants: 3},
+               {alternative: "lower",     data: lower,                  variants: 3}];
 
 var replications = util.replications_power();
 var default_fpr = util.default_fpr();
@@ -36,6 +42,7 @@ var default_beta = util.default_beta();
 configs.forEach(function(config) {
     var cases = config.data;
     cases.forEach(function(test_case) {
+        test_case.variants = config.variants;
         test("solveforsample yield the expected power with parameters: " + util.serialize(test_case), () => {
             var sample_size = statFormula.gTest.sample({
                 base_rate: test_case.control_rate,
@@ -43,13 +50,14 @@ configs.forEach(function(config) {
                 alpha: default_fpr,
                 beta: default_beta,
                 alternative: config.alternative,
-                mu: test_case.mu
+                mu: test_case.mu,
+                variants: test_case.variants,
             });
 
             var dataset = util.simulate_binary({
                 "control_rate": test_case.control_rate,
                 "change": test_case.change,
-                "sample_size": sample_size/2,
+                "sample_size": sample_size/(1 + test_case.variants),
                 "reps": replications
             });
         

--- a/tests/samplesizefornoninferiority.test.js
+++ b/tests/samplesizefornoninferiority.test.js
@@ -19,9 +19,15 @@ var lower = [{control_rate: 0.01, change: 0.001, opts: {calculating:'days', type
              {control_rate: 0.1,  change: 0.01,  opts: {calculating:'visitorsPerDay', days: 14, type: 'absolutePerDay', threshold: 400}},
              {control_rate: 0.1,  change: 0,     opts: {calculating:'visitorsPerDay', days: 14, type: 'absolutePerDay', threshold: 400}}];
 
-var configs = [{alternative: "two-sided", data: greater.concat(lower)},
-               {alternative: "greater",   data: greater},
-               {alternative: "lower",     data: lower}];
+var configs = [{alternative: "two-sided", data: greater.concat(lower),  variants:1},
+               {alternative: "greater",   data: greater,                variants:1},
+               {alternative: "lower",     data: lower,                  variants:1},
+               {alternative: "two-sided", data: greater.concat(lower),  variants:2},
+               {alternative: "greater",   data: greater,                variants:2},
+               {alternative: "lower",     data: lower,                  variants:2},
+               {alternative: "two-sided", data: greater.concat(lower),  variants:3},
+               {alternative: "greater",   data: greater,                variants:3},
+               {alternative: "lower",     data: lower,                  variants:3}];
 
 var replications = util.replications_power();
 var default_fpr = util.default_fpr();
@@ -31,6 +37,7 @@ var default_beta = util.default_beta();
 configs.forEach(function(config) {
     var cases = config.data;
     cases.forEach(function(test_case) {
+        test_case.variants = config.variants;
         test("solveforsample yield the expected power for noninferiority testing  with parameters: " + util.serialize(test_case), () => {
             var sample_size = statFormula.gTest.sample({
                 base_rate: test_case.control_rate,
@@ -39,21 +46,22 @@ configs.forEach(function(config) {
                 beta: default_beta,
                 alternative: config.alternative,
                 opts: test_case.opts,
+                variants: test_case.variants,
             });
 
             var mu;
             if (test_case.opts.visitors_per_day) {
                 mu = test_case.opts.threshold/(test_case.opts.visitors_per_day);
             } else {
-                mu  = test_case.opts.threshold*test_case.opts.days/sample_size;
+                mu  = test_case.opts.threshold*test_case.opts.days/(2*(sample_size/(1+test_case.variants)));
             }
             var dataset = util.simulate_binary({
                 "control_rate": test_case.control_rate,
                 "change": test_case.change,
-                "sample_size": sample_size/2,
+                "sample_size": sample_size/(1+test_case.variants),
                 "reps": replications
             });
-        
+
             expect(util.check({
                 data: dataset,
                 alternative: config.alternative,

--- a/tests/store/gTest-impact.js
+++ b/tests/store/gTest-impact.js
@@ -19,11 +19,13 @@ function resetStore(obj= {}) {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 14,
 
         visitorsPerDay: Math.ceil(561364 / 14),
-        lockedField: 'days'
+        lockedField: 'days',
+        comparisonMode: 'all'
     };
 
     Object.assign(resetObj, obj)
@@ -64,6 +66,40 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10.48);
         expect(store.getters.impactByVisitorsDisplay).toBe(477);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(47);
+
+    });
+    test('Expected initial visitedPerDay when diff sample and runtime on init for 2 variants', () => {
+
+        /*
+            Init action needs to adjust sample manually in this case
+            as calculate prop will not guarantee that sample, runtime and
+            visitorsPerDay are linked when calculating impact
+        */
+
+        resetStore({
+            sample: 100000,
+            runtime: 10,
+            lockedField: 'visitorsPerDay',
+            variants: 2,
+        });
+
+        store.dispatch('update:proptocalculate');
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(10000);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(100000);
+        expect(store.state.attributes.visitorsPerDay).toBe(10000);
+        expect(store.state.attributes.runtime).toBe(10);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(6.58);
+        expect(store.getters.impactByMetricDisplay).toBe(0.66);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.34);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.66);
+        expect(store.getters.impactByVisitorsDisplay).toBe(658);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(65);
 
     });
     test('Expected initial runtime when diff sample and visitorsPerDay on init', () => {
@@ -141,6 +177,49 @@ function init () {
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(113);
     });
 
+    test('Expected initial calculated value of sample with 2 variants', () => {
+        resetStore({
+            variants: 2,
+        });
+
+        store.dispatch('update:proptocalculate');
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(56136);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(561364);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(14);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(2.75);
+        expect(store.getters.impactByMetricDisplay).toBe(0.28);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.72);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.28);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1543);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(110);
+
+        store.dispatch('switch:lockedfield');
+        store.dispatch('field:change', {prop: 'runtime', value: 7});
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(28068);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(280686);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(3.9);
+        expect(store.getters.impactByMetricDisplay).toBe(0.39);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.61);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.39);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1094);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(156);
+    });
+
     test('Expected changes when Visitors per Day changes', () => {
         resetStore();
 
@@ -180,6 +259,49 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10.33);
         expect(store.getters.impactByVisitorsDisplay).toBe(688);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(98);
+    });
+
+    test('Expected changes when Visitors per Day changes with 3 variants', () => {
+        resetStore({
+            variants: 3,
+        });
+
+        store.dispatch('field:change', {prop: 'visitorsPerDay', value: 30098});
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(42137);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(421372);
+        expect(store.state.attributes.visitorsPerDay).toBe(30098);
+        expect(store.state.attributes.runtime).toBe(14);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(3.9);
+        expect(store.getters.impactByMetricDisplay).toBe(0.39);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.61);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.39);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1643);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(117);
+
+        store.dispatch('switch:lockedfield');
+        store.dispatch('field:change', {prop: 'runtime', value: 7});
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(21068);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(210686);
+        expect(store.state.attributes.visitorsPerDay).toBe(30098);
+        expect(store.state.attributes.runtime).toBe(7);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(5.53);
+        expect(store.getters.impactByMetricDisplay).toBe(0.55);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.45);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.55);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1165);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(166);
     });
 
     test('Expected changes when False Positive Rate changes', () => {
@@ -250,6 +372,44 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10.22);
         expect(store.getters.impactByVisitorsDisplay).toBe(606);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(86);
+    });
+
+
+    test('Expected changes when Power changes with 4 variants', () => {
+        resetStore({
+            variants: 4,
+        });
+
+        store.dispatch('field:change', {prop: 'power', value: 60});
+
+        expect(store.state.attributes.power).toBe(60);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(3.16);
+        expect(store.getters.impactByMetricDisplay).toBe(0.32);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.68);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.32);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1773);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(126);
+
+        store.dispatch('switch:lockedfield');
+        store.dispatch('field:change', {prop: 'runtime', value: 7});
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(28068);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(280686);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(4.48);
+        expect(store.getters.impactByMetricDisplay).toBe(0.45);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.55);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.45);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1257);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(179);
     });
 
     test('Expected changes when Base Rate changes', () => {
@@ -351,6 +511,52 @@ function init () {
         expect(store.getters.impactByMetricMaxDisplay).toBe(10.18);
         expect(store.getters.impactByVisitorsDisplay).toBe(1253);
         expect(store.getters.impactByVisitorsPerDayDisplay).toBe(89);
+
+    });
+
+    test('Expected changes when comparison mode changes with 2 variants', () => {
+        resetStore({
+            variants: 2
+        });
+
+        store.dispatch('field:change', {prop: 'comparisonMode', value: 'one'});
+
+        // sample
+        expect(store.state.attributes.sample).toBe(561364);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(14);
+        expect(store.state.attributes.variants).toBe(2);
+        expect(store.state.attributes.comparisonMode).toBe('one');
+
+        // base block
+        expect(store.getters.visitorsWithGoals).toBe(56136);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(2.45);
+        expect(store.getters.impactByMetricDisplay).toBe(0.25);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.76);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.24);
+        expect(store.getters.impactByVisitorsDisplay).toBe(1375);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(98);
+
+        store.dispatch('switch:lockedfield');
+        store.dispatch('field:change', {prop: 'runtime', value: 7});
+
+        // base
+        expect(store.getters.visitorsWithGoals).toBe(28068);
+
+        // sample
+        expect(store.state.attributes.sample).toBe(280686);
+        expect(store.state.attributes.visitorsPerDay).toBe(40098);
+        expect(store.state.attributes.runtime).toBe(7);
+
+        // impact block
+        expect(store.state.attributes.impact).toBe(3.48);
+        expect(store.getters.impactByMetricDisplay).toBe(0.35);
+        expect(store.getters.impactByMetricMinDisplay).toBe(9.65);
+        expect(store.getters.impactByMetricMaxDisplay).toBe(10.35);
+        expect(store.getters.impactByVisitorsDisplay).toBe(976);
+        expect(store.getters.impactByVisitorsPerDayDisplay).toBe(139);
 
     });
 }

--- a/tests/store/gTest-sample.js
+++ b/tests/store/gTest-sample.js
@@ -19,11 +19,13 @@ function resetStore() {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 14,
 
         visitorsPerDay: Math.ceil(561364 / 14),
-        lockedField: 'days'
+        lockedField: 'days',
+        comparisonMode: 'all'
     };
 
     store.dispatch('test:reset', resetObj)

--- a/tests/store/non-inferiority-gTest-sample.js
+++ b/tests/store/non-inferiority-gTest-sample.js
@@ -19,6 +19,7 @@ function resetStore(obj = {}) {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 14,
 
@@ -29,7 +30,8 @@ function resetStore(obj = {}) {
         threshold: 0,
         selected: 'relative',
         enabled: true,
-        expectedChange: 'nochange'
+        expectedChange: 'nochange',
+        comparisonMode: 'all'
     }, obj);
 
     store.dispatch('test:reset', resetObj)

--- a/tests/store/non-inferiority-tTest-sample.js
+++ b/tests/store/non-inferiority-tTest-sample.js
@@ -19,6 +19,7 @@ function resetStore(obj = {}) {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 14,
 
@@ -29,7 +30,8 @@ function resetStore(obj = {}) {
         threshold: 0,
         selected: 'relative',
         enabled: true,
-        expectedChange: 'nochange'
+        expectedChange: 'nochange',
+        comparisonMode: 'all'
     }, obj);
 
     store.dispatch('test:reset', resetObj)

--- a/tests/store/tTest-impact.js
+++ b/tests/store/tTest-impact.js
@@ -19,11 +19,13 @@ function resetStore() {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 2,
 
         visitorsPerDay: 40098,
-        lockedField: 'days'
+        lockedField: 'days',
+        comparisonMode: 'all'
     };
 
     store.dispatch('test:reset', resetObj)

--- a/tests/store/tTest-sample.js
+++ b/tests/store/tTest-sample.js
@@ -19,11 +19,13 @@ function resetStore() {
         power: 80,
         falsePosRate: 10,
         sdRate: 10,
+        variants: 1,
 
         runtime: 14,
 
         visitorsPerDay: Math.ceil(561364 / 14),
-        lockedField: 'days'
+        lockedField: 'days',
+        comparisonMode: 'all'
     };
 
     store.dispatch('test:reset', resetObj)


### PR DESCRIPTION
I added multi-variant calculations for even splits in the power calculator. This is using Sidak's correction in the alpha value. This change includes: 
1. In the interface the users can select the number of variants and if they want to compare all variance with base or just one variant.
2. Additional the users now can hide the daily traffic if they don't consider necessary to use it.
3. For non-inferiority tests the absolute and relative impact is now showed at the same time.
4. All the scientific test were updated to test with multiple variants.

**TODO:** Add more tests in the store to consider multiple configurations.